### PR TITLE
Attachment handling

### DIFF
--- a/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -19,6 +19,7 @@ package com.siemens.sw360.datahandler.db;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Sets;
 import com.siemens.sw360.components.summary.SummaryType;
@@ -46,6 +47,8 @@ import org.jetbrains.annotations.NotNull;
 import java.net.MalformedURLException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/AttachmentPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/AttachmentPortletUtils.java
@@ -42,6 +42,7 @@ import javax.portlet.ResourceResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -55,6 +56,7 @@ import static java.net.URLConnection.guessContentTypeFromStream;
  * @author cedric.bodet@tngtech.com
  * @author Johannes.Najjar@tngtech.com
  * @author daniele.fognini@tngtech.com
+ * @author birgit.heydenreich@tngtech.com
  */
 public class AttachmentPortletUtils {
 
@@ -272,10 +274,19 @@ public class AttachmentPortletUtils {
         try {
             String filename = client.getAttachmentContent(attachmentContentId).getFilename();
             return CommonUtils.getNewAttachment(user, attachmentContentId, filename);
-
         } catch (TException e) {
             log.error("Could not get attachment content", e);
         }
         return null;
+    }
+
+    public void deleteUnneededAttachments(Set<String> attachmentContentIds){
+        try {
+            for(String id: attachmentContentIds) {
+                client.deleteAttachmentContent(id);
+            }
+        } catch (TException e){
+            log.error("Could not delete attachments from database.",e);
+        }
     }
 }

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/PortalConstants.java
@@ -162,6 +162,8 @@ public class PortalConstants {
     public static final String ATTACHMENT_LINK_TO = ATTACHMENT_PREFIX + "LinkTo";
     public static final String ATTACHMENT_DOWNLOAD = ATTACHMENT_PREFIX + "Download";
 
+    public static final String ATTACHMENT_DELETE_ON_CANCEL = "attachmentDeleteOnCancel";
+
     public static final String CLEANUP = "Cleanup";
     public static final String DUPLICATES = "Duplicates";
     public static final String DOWNLOAD = "Download";

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/PortletUtils.java
@@ -49,6 +49,7 @@ import static java.lang.Integer.parseInt;
  *
  * @author cedric.bodet@tngtech.com
  * @author Johannes.Najjar@tngtech.com
+ * @author birgit.heydenreich@tngtech.com
  */
 public class PortletUtils {
 

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/PortletUtils.java
@@ -17,8 +17,7 @@
  */
 package com.siemens.sw360.portal.common;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.siemens.sw360.datahandler.common.CommonUtils;
 import com.siemens.sw360.datahandler.common.SW360Utils;
 import com.siemens.sw360.datahandler.thrift.ModerationState;
@@ -30,6 +29,7 @@ import com.siemens.sw360.datahandler.thrift.components.*;
 import com.siemens.sw360.datahandler.thrift.projects.Project;
 import com.siemens.sw360.datahandler.thrift.projects.ProjectState;
 import com.siemens.sw360.datahandler.thrift.projects.ProjectType;
+import com.siemens.sw360.datahandler.thrift.users.User;
 import com.siemens.sw360.portal.users.UserCacheHolder;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TBase;
@@ -37,8 +37,10 @@ import org.apache.thrift.TFieldIdEnum;
 import org.apache.thrift.meta_data.FieldMetaData;
 
 import javax.portlet.PortletRequest;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.lang.Integer.parseInt;
 
@@ -143,48 +145,61 @@ public class PortletUtils {
     }
 
 
-    public static void updateAttachmentsFromRequest(PortletRequest request, Set<Attachment> attachments) {
-        if (attachments == null || attachments.size() == 0) return;
+    public static Set<Attachment> updateAttachmentsFromRequest(PortletRequest request, Set<Attachment> documentAttachments) {
+        if (documentAttachments == null) {
+            log.error("UpdateAttachments called with null documentAttachments.");
+            return null;
+        }
 
+        User user = UserCacheHolder.getUserFromRequest(request);
+        String[] fileNames = request.getParameterValues(Release._Fields.ATTACHMENTS.toString() + Attachment._Fields.FILENAME);
         String[] ids = request.getParameterValues(Release._Fields.ATTACHMENTS.toString() + Attachment._Fields.ATTACHMENT_CONTENT_ID.toString());
         String[] createdComments = request.getParameterValues(Release._Fields.ATTACHMENTS.toString() + Attachment._Fields.CREATED_COMMENT.toString());
         String[] checkedComments = request.getParameterValues(Release._Fields.ATTACHMENTS.toString() + Attachment._Fields.CHECKED_COMMENT.toString());
         String[] checkStatuses = request.getParameterValues(Release._Fields.ATTACHMENTS.toString() + Attachment._Fields.CHECK_STATUS.toString());
         String[] atypes = request.getParameterValues(Release._Fields.ATTACHMENTS.toString() + Attachment._Fields.ATTACHMENT_TYPE.toString());
 
-        if (CommonUtils.oneIsNull(atypes, createdComments, checkedComments, ids)) {
-            log.error("We have a problem null arrays");
-        } else if (atypes.length != createdComments.length || atypes.length != ids.length || atypes.length != checkedComments.length)
+        if(ids == null || ids.length == 0) {
+            return new HashSet<>();
+        } else if (CommonUtils.oneIsNull(atypes, createdComments, checkedComments, fileNames)) {
+            log.error("We have a problem with null arrays");
+        } else if (
+                atypes.length != createdComments.length ||
+                atypes.length != ids.length ||
+                atypes.length != checkedComments.length ||
+                atypes.length != fileNames.length) {
             log.error("We have a problem length != other.length ");
-        else {
-            Map<String, Attachment> attachmentMap = Maps.uniqueIndex(attachments, new Function<Attachment, String>() {
-                @Override
-                public String apply(Attachment attachment) {
-                    return attachment.getAttachmentContentId();
-                }
-            });
-
+        } else {
+            Map<String, Attachment> documentAttachmentMap = documentAttachments.stream().collect(Collectors.toMap(Attachment::getAttachmentContentId, Function.identity()));
+            Map<String, Attachment> documentAttachmentsInRequestMap = new HashMap<>();
             int length = atypes.length;
 
             for (int i = 0; i < length; ++i) {
 
                 String id = ids[i];
-                if (attachmentMap.containsKey(id)) {
-                    Attachment attachment = attachmentMap.get(id);
-                    attachment.setCreatedComment(createdComments[i]);
-                    attachment.setAttachmentType(getAttachmentTypefromString(atypes[i]));
-                    if(attachment.checkedComment != checkedComments[i]|| attachment.checkStatus != getCheckStatusfromString(checkStatuses[i])){
-                        attachment.setCheckedOn(SW360Utils.getCreatedOn());
-                        attachment.setCheckedBy(UserCacheHolder.getUserFromRequest(request).getEmail());
-                        attachment.setCheckedTeam(UserCacheHolder.getUserFromRequest(request).getDepartment());
-                        attachment.setCheckStatus(getCheckStatusfromString(checkStatuses[i]));
-                        attachment.setCheckedComment(checkedComments[i]);
-                    }
+                Attachment attachment;
+                if (documentAttachmentMap.containsKey(id)) {
+                    attachment = documentAttachmentMap.get(id);
+                    documentAttachmentsInRequestMap.put(id,attachment);
                 } else {
-                    log.error("Unable to find attachment!" + id);
+                    //the sha1 checksum is not computed here, but in the backend, when updating the component in the database
+                    attachment = CommonUtils.getNewAttachment(user, id, fileNames[i]);
+                    documentAttachments.add(attachment);
+                }
+                attachment.setCreatedComment(createdComments[i]);
+                attachment.setAttachmentType(getAttachmentTypefromString(atypes[i]));
+                if(attachment.checkedComment != checkedComments[i]|| attachment.checkStatus != getCheckStatusfromString(checkStatuses[i])){
+                    attachment.setCheckedOn(SW360Utils.getCreatedOn());
+                    attachment.setCheckedBy(UserCacheHolder.getUserFromRequest(request).getEmail());
+                    attachment.setCheckedTeam(UserCacheHolder.getUserFromRequest(request).getDepartment());
+                    attachment.setCheckStatus(getCheckStatusfromString(checkStatuses[i]));
+                    attachment.setCheckedComment(checkedComments[i]);
                 }
             }
+            Set<String> removedAttachmentIds = Sets.difference(documentAttachmentMap.keySet(),documentAttachmentsInRequestMap.keySet());
+            documentAttachments.removeIf(attachment -> removedAttachmentIds.contains(attachment.getAttachmentContentId()));
         }
+        return documentAttachments;
     }
 
 

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/AttachmentAwarePortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/AttachmentAwarePortlet.java
@@ -25,12 +25,14 @@ import com.siemens.sw360.datahandler.thrift.attachments.AttachmentContent;
 import com.siemens.sw360.datahandler.thrift.users.User;
 import com.siemens.sw360.portal.common.AttachmentPortletUtils;
 import com.siemens.sw360.portal.common.PortalConstants;
+import com.siemens.sw360.portal.common.UsedAsLiferayAction;
 import com.siemens.sw360.portal.users.UserCacheHolder;
 
 import javax.portlet.*;
 import java.io.IOException;
-import java.util.Set;
+import java.util.*;
 
+import static com.siemens.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static com.siemens.sw360.datahandler.common.CommonUtils.toSingletonSet;
 import static com.siemens.sw360.portal.common.PortalConstants.ATTACHMENTS;
 
@@ -39,23 +41,25 @@ import static com.siemens.sw360.portal.common.PortalConstants.ATTACHMENTS;
  *
  * @author cedric.bodet@tngtech.com
  * @author Johannes.Najjar@tngtech.com
+ * @author birgit.heydenreich@tngtech.com
  */
 public abstract class AttachmentAwarePortlet extends Sw360Portlet {
 
     protected final AttachmentPortletUtils attachmentPortletUtils;
+    protected Map< String, Map< String, Set<String>>> uploadHistoryPerUserEmailAndDocumentId;
 
     protected AttachmentAwarePortlet() {
-        attachmentPortletUtils = new AttachmentPortletUtils(thriftClients);
+        this(new ThriftClients());
     }
 
     public AttachmentAwarePortlet(ThriftClients thriftClients) {
-        super(thriftClients);
-        attachmentPortletUtils = new AttachmentPortletUtils(thriftClients);
+        this(thriftClients, new AttachmentPortletUtils(thriftClients));
     }
 
     public AttachmentAwarePortlet(ThriftClients thriftClients, AttachmentPortletUtils attachmentPortletUtils) {
         super(thriftClients);
         this.attachmentPortletUtils = attachmentPortletUtils;
+        uploadHistoryPerUserEmailAndDocumentId = new HashMap<>();
     }
 
     public static void setAttachmentsInRequest(RenderRequest request, Set<Attachment> attachments) {
@@ -80,6 +84,7 @@ public abstract class AttachmentAwarePortlet extends Sw360Portlet {
         } else if (PortalConstants.ATTACHMENT_UPLOAD.equals(action)) {
             if ("POST".equals(request.getMethod())) {
                 // POST is for actual upload
+                storeUploadedAttachmentIdInHistory(request);
                 if (!attachmentPortletUtils.uploadAttachmentPart(request, "file")) {
                     response.setProperty(ResourceResponse.HTTP_STATUS_CODE, "404");
                 }
@@ -129,6 +134,39 @@ public abstract class AttachmentAwarePortlet extends Sw360Portlet {
         }
     }
 
+    private void storeUploadedAttachmentIdInHistory(ResourceRequest request){
+        String documentId = request.getParameter(PortalConstants.DOCUMENT_ID);
+        String userEmail = UserCacheHolder.getUserFromRequest(request).getEmail();
+        String attachmentId = request.getParameter("resumableIdentifier");
+
+        if(!uploadHistoryPerUserEmailAndDocumentId.containsKey(userEmail)){
+            Map<String,Set<String>> documentIdsToAttachmentIds = new HashMap<>();
+            documentIdsToAttachmentIds.put(documentId,new HashSet<>());
+            uploadHistoryPerUserEmailAndDocumentId.put(userEmail, documentIdsToAttachmentIds);
+        } else if (!uploadHistoryPerUserEmailAndDocumentId.get(userEmail).containsKey(documentId)){
+            uploadHistoryPerUserEmailAndDocumentId.get(userEmail).put(documentId,new HashSet<>());
+        }
+
+        Set<String> attachmentIdsForDocument = uploadHistoryPerUserEmailAndDocumentId.get(userEmail).get(documentId);
+        attachmentIdsForDocument.add(attachmentId);
+    }
+
+    public void cleanUploadHistory(String userEmail, String documentId){
+        if(uploadHistoryPerUserEmailAndDocumentId.containsKey(userEmail)) {
+            if (uploadHistoryPerUserEmailAndDocumentId.get(userEmail).containsKey(documentId)) {
+                uploadHistoryPerUserEmailAndDocumentId.get(userEmail).remove(documentId);
+            }
+        }
+    }
+
+    public void deleteUnneededAttachments(String userEmail, String documentId){
+        if(uploadHistoryPerUserEmailAndDocumentId.containsKey(userEmail)) {
+            Set<String> uploadedAttachmentIds = nullToEmptySet(uploadHistoryPerUserEmailAndDocumentId.get(userEmail).get(documentId));
+            attachmentPortletUtils.deleteUnneededAttachments(uploadedAttachmentIds);
+            cleanUploadHistory(userEmail,documentId);
+        }
+    }
+
     protected boolean isAttachmentAwareAction(String action) {
         return action.startsWith(PortalConstants.ATTACHMENT_PREFIX);
     }
@@ -144,6 +182,17 @@ public abstract class AttachmentAwarePortlet extends Sw360Portlet {
             super.dealWithGenericAction(request, response, action);
         } else {
             dealWithAttachments(request, response, action);
+        }
+    }
+
+    @UsedAsLiferayAction
+    public void attachmentDeleteOnCancel(ActionRequest request, ActionResponse response){
+        String userEmail = UserCacheHolder.getUserFromRequest(request).getEmail();
+        if(uploadHistoryPerUserEmailAndDocumentId.containsKey(userEmail)) {
+            String documentId = request.getParameter(PortalConstants.DOCUMENT_ID);
+            Set<String> uploadedAttachmentIds = nullToEmptySet(uploadHistoryPerUserEmailAndDocumentId.get(userEmail).get(documentId));
+            attachmentPortletUtils.deleteUnneededAttachments(uploadedAttachmentIds);
+            cleanUploadHistory(userEmail, documentId);
         }
     }
 }

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/components/ComponentPortlet.java
@@ -68,47 +68,6 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
     private static final Logger log = Logger.getLogger(ComponentPortlet.class);
 
-    @Override
-    protected Attachment linkAttachment(String documentId, String documentType, User user, String attachmentContentId) {
-        try {
-            AttachmentService.Iface attachmentClient = thriftClients.makeAttachmentClient();
-            String filename = attachmentClient.getAttachmentContent(attachmentContentId).getFilename();
-            ComponentService.Iface client = thriftClients.makeComponentClient();
-
-            RequestStatus requestStatus;
-            if (typeIsComponent(documentType)) {
-                requestStatus = client.addAttachmentToComponent(documentId, user, attachmentContentId, filename);
-            } else {
-                requestStatus = client.addAttachmentToRelease(documentId, user, attachmentContentId, filename);
-            }
-
-            if (!requestStatus.equals(RequestStatus.FAILURE)) {
-                return CommonUtils.getNewAttachment(user, attachmentContentId, filename, attachmentClient.getSha1FromAttachmentContentId(attachmentContentId));
-            } else {
-                return null;
-            }
-
-        } catch (TException e) {
-            log.error("Could not get component or release", e);
-        }
-        return null;
-    }
-
-    @Override
-    protected RequestStatus deleteAttachment(String documentId, String documentType, User user, String attachmentContentId) {
-        try {
-            ComponentService.Iface client = thriftClients.makeComponentClient();
-            if (typeIsComponent(documentType)) {
-                return client.removeAttachmentFromComponent(documentId, user, attachmentContentId);
-            } else {
-                return client.removeAttachmentFromRelease(documentId, user, attachmentContentId);
-            }
-        } catch (TException e) {
-            log.error("Could not get component or release", e);
-        }
-        return RequestStatus.FAILURE;
-    }
-
     private boolean typeIsComponent(String documentType) {
         return SW360Constants.TYPE_COMPONENT.equals(documentType);
     }
@@ -695,7 +654,6 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
             if (id != null) {
                 Component component = client.getComponentByIdForEdit(id, user);
-
                 ComponentPortletUtils.updateComponentFromRequest(request, component);
                 RequestStatus requestStatus = client.updateComponent(component, user);
                 setSessionMessage(request, requestStatus, "Component", "update", component.getName());

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/components/ComponentPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/components/ComponentPortletUtils.java
@@ -21,6 +21,7 @@ import com.siemens.sw360.datahandler.common.CommonUtils;
 import com.siemens.sw360.datahandler.thrift.RequestStatus;
 import com.siemens.sw360.datahandler.thrift.ThriftClients;
 import com.siemens.sw360.datahandler.thrift.attachments.Attachment;
+import com.siemens.sw360.datahandler.thrift.attachments.AttachmentService;
 import com.siemens.sw360.datahandler.thrift.components.*;
 import com.siemens.sw360.datahandler.thrift.users.RequestedAction;
 import com.siemens.sw360.datahandler.thrift.users.User;
@@ -82,7 +83,7 @@ public abstract class ComponentPortletUtils {
         }
         // ensure ATTACHMENTS are processed after CLEARING_STATE so that automatic asignment of CLEARING_STATE will not get overwritten by the clearing state from request
         if (!release.isSetAttachments()) release.setAttachments(new HashSet<Attachment>());
-        PortletUtils.updateAttachmentsFromRequest(request, release.getAttachments());
+        release.setAttachments(PortletUtils.updateAttachmentsFromRequest(request, release.getAttachments()));
         CommonUtils.setReleaseClearingStateOnUpdate(release);
     }
 
@@ -121,7 +122,7 @@ public abstract class ComponentPortletUtils {
             switch (field) {
                 case ATTACHMENTS:
                     if (!component.isSetAttachments()) component.setAttachments(new HashSet<Attachment>());
-                    PortletUtils.updateAttachmentsFromRequest(request, component.getAttachments());
+                    component.setAttachments(PortletUtils.updateAttachmentsFromRequest(request, component.getAttachments()));
                     break;
 
 

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/moderation/ModerationPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/moderation/ModerationPortlet.java
@@ -526,16 +526,6 @@ public class ModerationPortlet extends FossologyAwarePortlet {
     }
 
     @Override
-    protected Attachment linkAttachment(String documentId, String documentType, User user, String attachmentId) {
-        throw unsupportedActionException();
-    }
-
-    @Override
-    protected RequestStatus deleteAttachment(String documentId, String documentType, User user, String attachmentId) {
-        throw unsupportedActionException();
-    }
-
-    @Override
     protected Set<Attachment> getAttachments(String documentId, String documentType, User user) {
         throw unsupportedActionException();
     }

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -73,37 +73,13 @@ public class ProjectPortlet extends FossologyAwarePortlet {
 
     private static final Logger log = Logger.getLogger(ProjectPortlet.class);
 
-    private static final ImmutableList<Project._Fields> projectFilteredFields = ImmutableList.of(Project._Fields.BUSINESS_UNIT,Project._Fields.PROJECT_TYPE, Project._Fields.PROJECT_RESPONSIBLE,Project._Fields.NAME,Project._Fields.STATE,Project._Fields.TAG);
-    @Override
-    protected Attachment linkAttachment(String documentId, String documentType, User user, String attachmentContentId) {
-        try {
-            AttachmentService.Iface attachmentClient = thriftClients.makeAttachmentClient();
-            String filename = attachmentClient.getAttachmentContent(attachmentContentId).getFilename();
-            ProjectService.Iface client = thriftClients.makeProjectClient();
-            RequestStatus requestStatus = client.addAttachmentToProject(documentId, user, attachmentContentId, filename);
-
-            if (!requestStatus.equals(RequestStatus.FAILURE)) {
-                return CommonUtils.getNewAttachment(user, attachmentContentId, filename, attachmentClient.getSha1FromAttachmentContentId(attachmentContentId));
-            } else {
-                return null;
-            }
-
-        } catch (TException e) {
-            log.error("Could not get project", e);
-        }
-        return null;
-    }
-
-    @Override
-    protected RequestStatus deleteAttachment(String documentId, String documentType, User user, String attachmentContentId) {
-        try {
-            ProjectService.Iface client = thriftClients.makeProjectClient();
-            return client.removeAttachmentFromProject(documentId, user, attachmentContentId);
-        } catch (TException e) {
-            log.error("Could not get project", e);
-        }
-        return RequestStatus.FAILURE;
-    }
+    private static final ImmutableList<Project._Fields> projectFilteredFields = ImmutableList.of(
+            Project._Fields.BUSINESS_UNIT,
+            Project._Fields.PROJECT_TYPE,
+            Project._Fields.PROJECT_RESPONSIBLE,
+            Project._Fields.NAME,
+            Project._Fields.STATE,
+            Project._Fields.TAG);
 
     @Override
     protected Set<Attachment> getAttachments(String documentId, String documentType, User user) {

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -30,7 +30,6 @@ import com.siemens.sw360.datahandler.common.ThriftEnumUtils;
 import com.siemens.sw360.datahandler.thrift.DocumentState;
 import com.siemens.sw360.datahandler.thrift.RequestStatus;
 import com.siemens.sw360.datahandler.thrift.attachments.Attachment;
-import com.siemens.sw360.datahandler.thrift.attachments.AttachmentService;
 import com.siemens.sw360.datahandler.thrift.components.ComponentService;
 import com.siemens.sw360.datahandler.thrift.components.Release;
 import com.siemens.sw360.datahandler.thrift.components.ReleaseClearingStateSummary;
@@ -192,6 +191,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         final User user = UserCacheHolder.getUserFromRequest(request);
 
         try {
+            deleteUnneededAttachments(user.getEmail(),projectId);
             ProjectService.Iface client = thriftClients.makeProjectClient();
             return client.deleteProject(projectId, user);
         } catch (TException e) {
@@ -621,6 +621,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 ProjectPortletUtils.updateProjectFromRequest(request, project);
                 requestStatus = client.updateProject(project, user);
                 setSessionMessage(request, requestStatus, "Project", "update", printName(project));
+                cleanUploadHistory(user.getEmail(),id);
             } else {
                 // Add project
                 Project project = new Project();

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortletUtils.java
@@ -55,7 +55,7 @@ public class ProjectPortletUtils {
 
                 case ATTACHMENTS:
                     if (!project.isSetAttachments()) project.setAttachments(new HashSet<Attachment>());
-                    PortletUtils.updateAttachmentsFromRequest(request, project.getAttachments());
+                    project.setAttachments(PortletUtils.updateAttachmentsFromRequest(request, project.getAttachments()));
                     break;
                 default:
                     setFieldValue(request, project, field);

--- a/frontend/sw360-portlet/src/main/webapp/html/components/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/edit.jsp
@@ -58,6 +58,9 @@
     <portlet:param name="<%=PortalConstants.COMPONENT_ID%>" value="${component.id}"/>
 </portlet:actionURL>
 
+<portlet:actionURL var="deleteAttachmentsOnCancelURL" name='<%=PortalConstants.ATTACHMENT_DELETE_ON_CANCEL%>'>
+</portlet:actionURL>
+
 <link rel="stylesheet" href="<%=request.getContextPath()%>/css/sw360.css">
 <link rel="stylesheet" href="<%=request.getContextPath()%>/css/external/jquery-ui.css">
 <!--include jQuery -->
@@ -119,11 +122,23 @@
     baseUrl = '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>';
 
     function cancel() {
+        deleteAttachmentsOnCancel();
         var baseUrl = '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>';
         var portletURL = Liferay.PortletURL.createURL(baseUrl)
                 .setParameter('<%=PortalConstants.PAGENAME%>', '<%=PortalConstants.PAGENAME_DETAIL%>')
                 .setParameter('<%=PortalConstants.COMPONENT_ID%>', '${component.id}');
         window.location = portletURL.toString();
+    }
+
+    function deleteAttachmentsOnCancel() {
+        jQuery.ajax({
+            type: 'POST',
+            url: '<%=deleteAttachmentsOnCancelURL%>',
+            cache: false,
+            data: {
+                "<portlet:namespace/><%=PortalConstants.DOCUMENT_ID%>": "${component.id}"
+            },
+        });
     }
 
     var contextpath;

--- a/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
@@ -55,6 +55,9 @@
     <portlet:param name="<%=PortalConstants.RELEASE_ID%>" value="${release.id}"/>
 </portlet:actionURL>
 
+<portlet:actionURL var="deleteAttachmentsOnCancelURL" name='<%=PortalConstants.ATTACHMENT_DELETE_ON_CANCEL%>'>
+</portlet:actionURL>
+
 <portlet:resourceURL var="viewVendorURL">
     <portlet:param name="<%=PortalConstants.ACTION%>" value="<%=PortalConstants.VIEW_VENDOR%>"/>
 </portlet:resourceURL>
@@ -155,11 +158,23 @@
     );
 
     function cancel() {
+        deleteAttachmentsOnCancel();
         var baseUrl = '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>';
         var portletURL = Liferay.PortletURL.createURL(baseUrl)
                 .setParameter('<%=PortalConstants.PAGENAME%>', '<%=PortalConstants.PAGENAME_DETAIL%>')
                 .setParameter('<%=PortalConstants.COMPONENT_ID%>', '${component.id}');
         window.location = portletURL.toString();
+    }
+
+    function deleteAttachmentsOnCancel() {
+        jQuery.ajax({
+            type: 'POST',
+            url: '<%=deleteAttachmentsOnCancelURL%>',
+            cache: false,
+            data: {
+                "<portlet:namespace/><%=PortalConstants.DOCUMENT_ID%>": "${release.id}"
+            },
+        });
     }
 
     function validate(){

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
@@ -36,6 +36,9 @@
     <portlet:param name="<%=PortalConstants.PROJECT_ID%>" value="${project.id}" />
 </portlet:actionURL>
 
+<portlet:actionURL var="deleteAttachmentsOnCancelURL" name='<%=PortalConstants.ATTACHMENT_DELETE_ON_CANCEL%>'>
+</portlet:actionURL>
+
 <portlet:actionURL var="deleteURL" name="delete">
     <portlet:param name="<%=PortalConstants.PROJECT_ID%>" value="${project.id}"/>
 </portlet:actionURL>
@@ -91,6 +94,7 @@
 
 <script>
     function cancel() {
+        deleteAttachmentsOnCancel();
         var baseUrl = '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>';
         var portletURL = Liferay.PortletURL.createURL( baseUrl )
 <core_rt:if test="${not addMode}" >
@@ -102,6 +106,17 @@
 
                 .setParameter('<%=PortalConstants.PROJECT_ID%>','${project.id}');
         window.location = portletURL.toString();
+    }
+
+    function deleteAttachmentsOnCancel() {
+        jQuery.ajax({
+            type: 'POST',
+            url: '<%=deleteAttachmentsOnCancelURL%>',
+            cache: false,
+            data: {
+                "<portlet:namespace/><%=PortalConstants.DOCUMENT_ID%>": "${project.id}"
+            },
+        });
     }
 
     var contextpath;

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsDelete.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsDelete.jsp
@@ -33,29 +33,7 @@
 
     function deleteAttachment(rowId, attachmentId) {
         if (confirm("Do you really want to delete this attachment?")) {
-
-            jQuery.ajax({
-                type: 'POST',
-                url: '<%=deleteAjaxURL%>',
-                cache: false,
-                data: {
-                    <portlet:namespace/>attachmentId: attachmentId
-                },
-                success: function (data) {
-                    if(data.result == 'SUCCESS') {
-                        $('#' + rowId).remove();
-                    }
-                    else if(data.result == 'SENT_TO_MODERATOR') {
-                        alert("A moderation request was sent to remove the attachment.");
-                    }
-                    else {
-                        alert("I could not remove the attachment!");
-                    }
-                },
-                error: function () {
-                    alert("I could not remove the attachment!");
-                }
-            });
+            $('#' + rowId).remove();
         }
     }
 

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsUpload.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsUpload.jsp
@@ -31,11 +31,13 @@
 <portlet:resourceURL var="newAttachmentAjaxURL">
     <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.ATTACHMENT_RESERVE_ID%>'/>
     <portlet:param name="<%=PortalConstants.DOCUMENT_TYPE%>" value="${documentType}"/>
+    <portlet:param name="<%=PortalConstants.DOCUMENT_ID%>" value="${documentID}"/>
 </portlet:resourceURL>
 
 <portlet:resourceURL var="uploadPartAjaxURL">
     <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.ATTACHMENT_UPLOAD%>'/>
     <portlet:param name="<%=PortalConstants.DOCUMENT_TYPE%>" value="${documentType}"/>
+    <portlet:param name="<%=PortalConstants.DOCUMENT_ID%>" value="${documentID}"/>
 </portlet:resourceURL>
 
 <portlet:resourceURL var="cancelAttachmentAjaxURL">

--- a/frontend/sw360-portlet/src/test/java/com/siemens/sw360/portal/portlets/FossologyAwarePortletTest.java
+++ b/frontend/sw360-portlet/src/test/java/com/siemens/sw360/portal/portlets/FossologyAwarePortletTest.java
@@ -193,16 +193,6 @@ public class FossologyAwarePortletTest extends TestCase {
 
         fossologyAwarePortlet = new FossologyAwarePortlet(thriftClients) {
             @Override
-            protected Attachment linkAttachment(String documentId, String documentType, User user, String attachmentId) {
-                return null;
-            }
-
-            @Override
-            protected RequestStatus deleteAttachment(String documentId, String documentType, User user, String attachmentId) {
-                return null;
-            }
-
-            @Override
             protected Set<Attachment> getAttachments(String documentId, String documentType, User user) {
                 return null;
             }

--- a/frontend/sw360-portlet/src/test/java/com/siemens/sw360/portal/portlets/FossologyAwarePortletTest.java
+++ b/frontend/sw360-portlet/src/test/java/com/siemens/sw360/portal/portlets/FossologyAwarePortletTest.java
@@ -192,6 +192,7 @@ public class FossologyAwarePortletTest extends TestCase {
         }).when(projectClient).getProjectById(anyString(), any(User.class));
 
         fossologyAwarePortlet = new FossologyAwarePortlet(thriftClients) {
+
             @Override
             protected Set<Attachment> getAttachments(String documentId, String documentType, User user) {
                 return null;

--- a/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/CommonUtils.java
+++ b/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/CommonUtils.java
@@ -231,6 +231,13 @@ public class CommonUtils {
 
     @NotNull
     public static Attachment getNewAttachment(User user, String attachmentContentId, String fileName, String sha1) {
+        Attachment attachment = getNewAttachment(user,attachmentContentId, fileName);
+        attachment.setSha1(sha1);
+        return attachment;
+    }
+
+    @NotNull
+    public static Attachment getNewAttachment(User user, String attachmentContentId, String fileName) {
         Attachment attachment = new Attachment();
         attachment.setCreatedBy(user.getEmail());
         attachment.setCreatedOn(SW360Utils.getCreatedOn());
@@ -241,7 +248,7 @@ public class CommonUtils {
         attachment.setAttachmentType(AttachmentType.DOCUMENT);
         attachment.setCheckStatus(CheckStatus.NOTCHECKED);
         attachment.setCheckedComment("");
-        attachment.setSha1(sha1);
+        attachment.setSha1("");
         return attachment;
     }
 

--- a/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/couchdb/AttachmentConnector.java
+++ b/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/couchdb/AttachmentConnector.java
@@ -17,6 +17,7 @@
  */
 package com.siemens.sw360.datahandler.couchdb;
 
+import com.google.common.collect.Sets;
 import com.siemens.sw360.datahandler.common.Duration;
 import com.siemens.sw360.datahandler.thrift.SW360Exception;
 import com.siemens.sw360.datahandler.thrift.attachments.Attachment;
@@ -28,6 +29,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 import static com.siemens.sw360.datahandler.common.CommonUtils.nullToEmptyCollection;
 import static com.siemens.sw360.datahandler.common.SW360Assert.assertNotEmpty;
@@ -85,6 +87,13 @@ public class AttachmentConnector extends AttachmentStreamConnector {
         connector.deleteIds(attachmentContentIds, AttachmentContent.class);
     }
 
+    public void deleteAttachmentDifference(Set<Attachment> before, Set<Attachment> after){
+        if (before == null || before.size() == 0) {
+            return;
+        }
+        deleteAttachments(Sets.difference(before,after));
+    }
+
     public String getSha1FromAttachmentContentId(String attachmentContentId) {
         try {
             AttachmentContent attachmentContent = getAttachmentContent(attachmentContentId);
@@ -96,6 +105,15 @@ public class AttachmentConnector extends AttachmentStreamConnector {
         } catch (IOException e) {
             log.error("Problem computing the sha1 checksum", e);
             return "";
+        }
+    }
+
+    public void setSha1ForAttachments(Set<Attachment> attachments){
+        for(Attachment attachment : attachments){
+            if(! attachment.isSetSha1() || attachment.getSha1().equals("")){
+                String sha1 = getSha1FromAttachmentContentId(attachment.getAttachmentContentId());
+                attachment.setSha1(sha1);
+            }
         }
     }
 }


### PR DESCRIPTION
Improved attachment handling:

 - component,project,release: uploading/deleting attachments without linking them instantaneously to the document
 - change on document attachments is only made when pressing "update document"
 - moderation request is only created when pressing "update document"
 - delete attachments from database when attachments are unlinked from document

- store uploaded attachment ids in a history per user and per documentId
- delete attachments from db on cancel and on delete document (also attachments that are
uploaded but not yet linked to document)
- properly handeled: user leaves edit mode by cancel, update or delete document
- not properly handled: user leaves edit mode by going to a different portal: in this case, uploaded attachments cannot be linked to document any more, but stay in db (use database sanitation to delete them later)
- closes #116