### PR TITLE
Fixed deletion of attachment content on update

### DIFF
--- a/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -255,7 +255,7 @@ public class ComponentDatabaseHandler {
     public String addRelease(Release release, String user) throws SW360Exception {
 
         // Prepare the release and get underlying component ID
-        ThriftValidate.prepareRelease(release);
+        prepareRelease(release);
         String componentId = release.getComponentId();
 
         // Ensure that component exists
@@ -341,11 +341,6 @@ public class ComponentDatabaseHandler {
         // Prepare component for database
         prepareComponent(component);
 
-        //add sha1 to attachments if necessary
-        if(component.isSetAttachments()) {
-            attachmentConnector.setSha1ForAttachments(component.getAttachments());
-        }
-
         // Get actual document for members that should no change
         Component actual = componentRepository.get(component.getId());
         assertNotNull(actual, "Could not find component to doBulk!");
@@ -367,6 +362,16 @@ public class ComponentDatabaseHandler {
             return moderator.updateComponent(component, user);
         }
         return RequestStatus.SUCCESS;
+    }
+
+    private void prepareComponent(Component component) throws SW360Exception {
+        // Prepare component for database
+        ThriftValidate.prepareComponent(component);
+
+        //add sha1 to attachments if necessary
+        if(component.isSetAttachments()) {
+            attachmentConnector.setSha1ForAttachments(component.getAttachments());
+        }
     }
 
     public RequestSummary updateComponents(Set<Component> components, User user) throws SW360Exception {
@@ -391,10 +396,6 @@ public class ComponentDatabaseHandler {
         // Prepare release for database
         prepareRelease(release);
 
-        //add sha1 to attachments if necessary
-        if(release.isSetAttachments()) {
-            attachmentConnector.setSha1ForAttachments(release.getAttachments());
-        }
         // Get actual document for members that should no change
         Release actual = releaseRepository.get(release.getId());
         assertNotNull(actual, "Could not find release to update");
@@ -414,6 +415,16 @@ public class ComponentDatabaseHandler {
         }
 
         return RequestStatus.SUCCESS;
+    }
+
+    private void prepareRelease(Release release) throws SW360Exception {
+        // Prepare release for database
+        ThriftValidate.prepareRelease(release);
+
+        //add sha1 to attachments if necessary
+        if(release.isSetAttachments()) {
+            attachmentConnector.setSha1ForAttachments(release.getAttachments());
+        }
     }
 
     public RequestSummary updateReleases(Collection<Release> releases, User user) throws SW360Exception {

--- a/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -44,7 +44,6 @@ import static com.siemens.sw360.datahandler.common.SW360Assert.assertNotNull;
 import static com.siemens.sw360.datahandler.common.SW360Assert.fail;
 import static com.siemens.sw360.datahandler.common.SW360Utils.*;
 import static com.siemens.sw360.datahandler.permissions.PermissionUtils.makePermission;
-import static com.siemens.sw360.datahandler.thrift.ThriftValidate.prepareProject;
 
 /**
  * Class for accessing the CouchDB database
@@ -150,10 +149,6 @@ public class ProjectDatabaseHandler {
         // Prepare project for database
         prepareProject(project);
 
-        //add sha1 to attachments if necessary
-        if(project.isSetAttachments()) {
-            attachmentConnector.setSha1ForAttachments(project.getAttachments());
-        }
         Project actual = repository.get(project.getId());
 
         if (makePermission(actual, user).isActionAllowed(RequestedAction.WRITE)) {
@@ -165,6 +160,16 @@ public class ProjectDatabaseHandler {
             return RequestStatus.SUCCESS;
         } else {
             return moderator.updateProject(project, user);
+        }
+    }
+
+    private void prepareProject(Project project) throws SW360Exception {
+        // Prepare project for database
+        ThriftValidate.prepareProject(project);
+
+        //add sha1 to attachments if necessary
+        if(project.isSetAttachments()) {
+            attachmentConnector.setSha1ForAttachments(project.getAttachments());
         }
     }
 

--- a/libraries/lib-datahandler/src/test/java/com/siemens/sw360/datahandler/couchdb/AttachmentConnectorTest.java
+++ b/libraries/lib-datahandler/src/test/java/com/siemens/sw360/datahandler/couchdb/AttachmentConnectorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License Version 2.0 as published by the
+ * Free Software Foundation with classpath exception.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License version 2.0 for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program (please see the COPYING file); if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+package com.siemens.sw360.datahandler.couchdb;
+
+import com.siemens.sw360.datahandler.thrift.attachments.Attachment;
+import com.siemens.sw360.datahandler.thrift.attachments.AttachmentContent;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.siemens.sw360.datahandler.common.Duration.durationOf;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AttachmentConnectorTest {
+
+    @Mock
+    DatabaseConnector connector;
+
+    AttachmentConnector attachmentConnector;
+
+    @Before
+    public void setUp() throws Exception {
+        attachmentConnector = new AttachmentConnector(connector, durationOf(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testDeleteAttachmentsDifference() throws Exception {
+        Attachment a1 = mock(Attachment.class);
+        when(a1.getAttachmentContentId()).thenReturn("a1cid");
+        when(a1.getSha1()).thenReturn(null);
+        when(a1.isSetSha1()).thenReturn(false);
+        Attachment a2 = mock(Attachment.class);
+        when(a2.getAttachmentContentId()).thenReturn("a2cid");
+        when(a2.getSha1()).thenReturn(null);
+        when(a2.isSetSha1()).thenReturn(false);
+
+        Set<Attachment> before = new HashSet<>();
+        before.add(a1);
+        before.add(a2);
+
+        Attachment a3 = mock(Attachment.class);
+        when(a3.getAttachmentContentId()).thenReturn("a1cid");
+        when(a3.getSha1()).thenReturn("sha1");
+        when(a3.isSetSha1()).thenReturn(true);
+
+        Set<Attachment> after = new HashSet<>();
+        after.add(a3);
+
+        Set<String> deletedIds = new HashSet<>();
+        deletedIds.add("a2cid");
+
+        attachmentConnector.deleteAttachmentDifference(before, after);
+        verify(connector).deleteIds(deletedIds, AttachmentContent.class);
+    }
+
+
+}


### PR DESCRIPTION
- fixed: attachment content is deleted from sw360attachments db when some attachment property gets updated.
- fixed: sha1 is not computed when a new component, release, or project is created with attachments 
closes #154 