### PR TITLE
lics: import custom properties

### DIFF
--- a/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/CustomPropertiesRepository.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/CustomPropertiesRepository.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2016.
+ * Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.siemens.sw360.datahandler.db;
+
+import com.siemens.sw360.datahandler.couchdb.DatabaseConnector;
+import com.siemens.sw360.datahandler.couchdb.DatabaseRepository;
+import com.siemens.sw360.datahandler.thrift.CustomProperties;
+import org.ektorp.support.View;
+
+import java.util.List;
+
+
+/**
+ * CRUD access for the CustomProperties class
+ *
+ * @author birgit.heydenreich@tngtech.com
+ */
+@View(name = "all", map = "function(doc) { if (doc.type == 'customproperties') emit(null, doc._id) }")
+public class CustomPropertiesRepository extends DatabaseRepository<CustomProperties> {
+
+    private static final String CUSTOM_PROPERTIES_BY_DOCTYPE =
+            "function(doc) {" +
+                    "  if (doc.type == 'customproperties') {" +
+                    "    emit(doc.documentType, doc);" +
+                    "  }" +
+                    "}";
+
+    public CustomPropertiesRepository(DatabaseConnector db) {
+        super(CustomProperties.class, db);
+        initStandardDesignDocument();
+    }
+
+    @View(name = "customPropertiesByDocType", map = CUSTOM_PROPERTIES_BY_DOCTYPE)
+    public List<CustomProperties> getCustomProperties(String documentType) {
+        List<CustomProperties> queryResults = queryByPrefix("customPropertiesByDocType", documentType);
+
+        if (queryResults.size() > 1) {
+            log.error("More than one customProperties object found for document type " + documentType);
+        }
+        return queryResults;
+    }
+}

--- a/backend/src/src-licenses/src/main/java/com/siemens/sw360/licenses/LicenseHandler.java
+++ b/backend/src/src-licenses/src/main/java/com/siemens/sw360/licenses/LicenseHandler.java
@@ -11,8 +11,10 @@ package com.siemens.sw360.licenses;
 
 
 import com.siemens.sw360.datahandler.common.DatabaseSettings;
+import com.siemens.sw360.datahandler.permissions.PermissionUtils;
 import com.siemens.sw360.datahandler.thrift.RequestStatus;
 import com.siemens.sw360.datahandler.thrift.licenses.*;
+import com.siemens.sw360.datahandler.thrift.CustomProperties;
 import com.siemens.sw360.datahandler.thrift.users.User;
 import com.siemens.sw360.licenses.db.LicenseDatabaseHandler;
 import org.apache.thrift.TException;
@@ -279,4 +281,16 @@ public class LicenseHandler implements LicenseService.Iface {
         return handler.deleteLicense(id, user);
     }
 
+    @Override
+    public List<CustomProperties> getCustomProperties(String documentType) {
+        return handler.getCustomProperties(documentType);
+    }
+
+    @Override
+    public RequestStatus updateCustomProperties(CustomProperties customProperties, User user){
+        if(! PermissionUtils.isAdmin(user)){
+            return RequestStatus.FAILURE;
+        }
+        return handler.addOrUpdateCustomProperties(customProperties);
+    }
 }

--- a/backend/src/src-licenses/src/main/java/com/siemens/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/src/src-licenses/src/main/java/com/siemens/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -14,6 +14,7 @@ import com.siemens.sw360.components.summary.SummaryType;
 import com.siemens.sw360.datahandler.common.CommonUtils;
 import com.siemens.sw360.datahandler.common.SW360Utils;
 import com.siemens.sw360.datahandler.couchdb.DatabaseConnector;
+import com.siemens.sw360.datahandler.db.CustomPropertiesRepository;
 import com.siemens.sw360.datahandler.db.ReleaseRepository;
 import com.siemens.sw360.datahandler.db.VendorRepository;
 import com.siemens.sw360.datahandler.entitlement.LicenseModerator;
@@ -63,6 +64,7 @@ public class LicenseDatabaseHandler {
     private final RiskCategoryRepository riskCategoryRepository;
     private final LicenseTypeRepository licenseTypeRepository;
     private final LicenseModerator moderator;
+    private final CustomPropertiesRepository customPropertiesRepository;
 
     private final Logger log = Logger.getLogger(LicenseDatabaseHandler.class);
 
@@ -77,6 +79,7 @@ public class LicenseDatabaseHandler {
         riskRepository = new RiskRepository(db);
         riskCategoryRepository = new RiskCategoryRepository(db);
         licenseTypeRepository = new LicenseTypeRepository(db);
+        customPropertiesRepository = new CustomPropertiesRepository(db);
 
         moderator = new LicenseModerator();
     }
@@ -746,5 +749,18 @@ public class LicenseDatabaseHandler {
         ReleaseRepository releaseRepository = new ReleaseRepository(db,new VendorRepository(db));
         final List<Release> usingReleases = releaseRepository.searchReleasesByUsingLicenseId(licenseId);
         return !usingReleases.isEmpty();
+    }
+
+    public List<CustomProperties> getCustomProperties(String documentType){
+        return customPropertiesRepository.getCustomProperties(documentType);
+    }
+
+    public RequestStatus addOrUpdateCustomProperties(CustomProperties customProperties){
+        if(customProperties.isSetId()){
+            customPropertiesRepository.update(customProperties);
+        } else {
+            customPropertiesRepository.add(customProperties);
+        }
+        return RequestStatus.SUCCESS;
     }
 }

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/tags/DisplayMap.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/tags/DisplayMap.java
@@ -49,9 +49,13 @@ public class DisplayMap extends SimpleTagSupport {
 
     public static String getMapAsString(Map<String, String> map) {
         StringBuilder sb = new StringBuilder();
-        sb.append("<ul style=\"list-style-type: none; padding:0; margin:0;\">");
+        sb.append("<ul class=\"mapDisplayRootItem\">");
         map.entrySet().stream().forEach(e -> sb.append(
-                "<li><b>" + e.getKey() + "</b> " + e.getValue() + "</li>"
+                "<li><span class=\"mapDisplayChildItemLeft\">"
+                        + e.getKey()
+                        + "</span><span class=\"mapDisplayChildItemRight\"> "
+                        + e.getValue()
+                        + "</span></li>"
         ));
         sb.append("</ul>");
         return sb.toString();

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
@@ -755,6 +755,7 @@
             <rtexprvalue>true</rtexprvalue>
         </attribute>
     </tag>
+
     <tag>
         <name>out</name>
         <tag-class>com.siemens.sw360.portal.tags.OutTag</tag-class>

--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -400,3 +400,13 @@ input[readonly].clickable {
 .clear-float {
     clear:right;
 }
+
+.mapDisplayRootItem {
+    list-style-type: none;
+    padding:0;
+    margin:0;
+}
+
+.mapDisplayChildItemLeft {
+    font-weight:bold;
+}

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailTodos.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailTodos.jspf
@@ -1,5 +1,6 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+  ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
@@ -32,7 +33,8 @@
             <td colspan="3">Todo</td>
             <td>Applies to development</td>
             <td>Applies to distribution</td>
-            <td colspan="2">
+            <td>Further properties</td>
+            <td colspan="1">
                 Obligations
             </td>
             <td class="addToWhiteListCheckboxesPlaceholder"></td>
@@ -43,9 +45,9 @@
                 <td colspan="3"><sw360:out value="${todo.text}"/></td>
                 <td><sw360:DisplayBoolean value="${todo.development}" defined="${todo.setDevelopment}"/></td>
                 <td><sw360:DisplayBoolean value="${todo.distribution}" defined="${todo.setDistribution}"/></td>
-
+                <td><sw360:DisplayMap value="${todo.customPropertyToValue}"/></td>
                 <core_rt:if test="${todo.obligationsSize > 0}">
-                    <td colspan="2">
+                    <td colspan="1">
                         <core_rt:forEach var="ob" varStatus="status" items="${todo.obligations}">
                             <ul>
                                 <li style="color: red"><sw360:out value="${ob.name}"/></li>
@@ -55,7 +57,7 @@
                 </core_rt:if>
 
                 <core_rt:if test="${todo.obligationsSize == 0}">
-                    <td colspan="2"> No obligations</td>
+                    <td colspan="1"> No obligations</td>
                 </core_rt:if>
                 <td class="addToWhiteListCheckboxesPlaceholder"></td>
             </tr>
@@ -85,7 +87,8 @@
             <td colspan="3">Todo</td>
             <td>Applies to development</td>
             <td>Applies to distribution</td>
-            <td colspan="2">
+            <td>Further properties</td>
+            <td colspan="1">
                 Obligations
             </td>
             <td class="addToWhiteListCheckboxes">Add to white list</td>
@@ -95,9 +98,9 @@
                 <td colspan="3"><sw360:out value="${todo.text}"/></td>
                 <td><sw360:DisplayBoolean value="${todo.development}" defined="${todo.setDevelopment}"/></td>
                 <td><sw360:DisplayBoolean value="${todo.distribution}" defined="${todo.setDistribution}"/></td>
-
+                <td><sw360:DisplayMap value="${todo.customPropertyToValue}"/></td>
                 <core_rt:if test="${todo.obligationsSize > 0}">
-                    <td colspan="2">
+                    <td colspan="1">
                         <core_rt:forEach var="ob" varStatus="status" items="${todo.obligations}">
                             <ul>
                                 <li style="color: red"><sw360:out value="${ob.name}"/></li>
@@ -107,7 +110,7 @@
                 </core_rt:if>
 
                 <core_rt:if test="${todo.obligationsSize == 0}">
-                    <td colspan="2"> No obligations</td>
+                    <td colspan="1"> No obligations</td>
                 </core_rt:if>
                 <td class="addToWhiteListCheckboxes">
                     <label><input type="checkbox" name="<portlet:namespace/>whiteList" value="${todo.id}"
@@ -132,7 +135,8 @@
             <td colspan="3">Todo</td>
             <td>Applies to development</td>
             <td>Applies to distribution</td>
-            <td colspan="2">
+            <td>Further properties</td>
+            <td colspan="1">
                 Obligations
             </td>
             <td class="addToWhiteListCheckboxes">Add to white list</td>
@@ -142,9 +146,9 @@
                 <td colspan="3"><sw360:out value="${todo.text}"/></td>
                 <td><sw360:DisplayBoolean value="${todo.development}" defined="${todo.setDevelopment}"/></td>
                 <td><sw360:DisplayBoolean value="${todo.distribution}" defined="${todo.setDistribution}"/></td>
-
+                <td><sw360:DisplayMap value="${todo.customPropertyToValue}"/></td>
                 <core_rt:if test="${todo.obligationsSize > 0}">
-                    <td colspan="2">
+                    <td colspan="1">
                         <core_rt:forEach var="ob" varStatus="status" items="${todo.obligations}">
                             <ul>
                                 <li style="color: red"><sw360:out value="${ob.name}"/></li>
@@ -154,7 +158,7 @@
                 </core_rt:if>
 
                 <core_rt:if test="${todo.obligationsSize == 0}">
-                    <td colspan="2"> No obligations</td>
+                    <td colspan="1"> No obligations</td>
                 </core_rt:if>
                 <td class="addToWhiteListCheckboxes">
                     <label><input type="checkbox" name="<portlet:namespace/>whiteList" value="${todo.id}"

--- a/libraries/commonIO/pom.xml
+++ b/libraries/commonIO/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+  ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
@@ -24,6 +25,14 @@
             <groupId>com.siemens.sw360</groupId>
             <artifactId>datahandler</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/libraries/commonIO/src/main/java/com/siemens/sw360/commonIO/ConvertRecord.java
+++ b/libraries/commonIO/src/main/java/com/siemens/sw360/commonIO/ConvertRecord.java
@@ -21,6 +21,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
+import static com.siemens.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
+
 /**
  * Convert CSV Record to license objects
  *
@@ -112,8 +114,8 @@ public class ConvertRecord {
             if(! isValidPropertyRecord(record)){
                 break;
             }
-            String property = record.get(1);
-            String value = record.get(2);
+            String property = record.get(1).trim();
+            String value = record.get(2).trim();
             addPropertyAndValueToMap(property, value, resultProperties);
         }
         return resultProperties;
@@ -136,8 +138,8 @@ public class ConvertRecord {
                 break;
             }
             Integer id = Integer.parseInt(record.get(0));
-            String property = record.get(1);
-            String value = record.get(2);
+            String property = record.get(1).trim();
+            String value = record.get(2).trim();
             resultPropertiesById.put(id, new PropertyWithValue(property, value));
         }
         return resultPropertiesById;
@@ -145,8 +147,7 @@ public class ConvertRecord {
 
     private static boolean isValidPropertyRecord(CSVRecord record){
         if(record.size() < 3 ||
-                "".equals(record.get(1)) ||
-                "".equals(record.get(2))){
+                isNullEmptyOrWhitespace(record.get(1))){
             return  false;
         }
         try {
@@ -174,13 +175,13 @@ public class ConvertRecord {
         return new Serializer<PropertyWithValueAndId>() {
             @Override
             public Function<PropertyWithValueAndId, List<String>> transformer() {
-                return e -> {
+                return propertyWithValueAndId -> {
 
                     final ArrayList<String> out = new ArrayList<>(3);
 
-                    out.add(e.getId().toString());
-                    out.add(e.getProperty());
-                    out.add(e.getValue());
+                    out.add(propertyWithValueAndId.getId().toString());
+                    out.add(propertyWithValueAndId.getProperty());
+                    out.add(propertyWithValueAndId.getValue());
                     return out;
                 };
             }
@@ -601,8 +602,8 @@ public class ConvertRecord {
     }
 
     public static class PropertyWithValue{
-        public String property;
-        public String value;
+        private String property;
+        private String value;
 
         public PropertyWithValue(String property, String value){
             this.property = property;
@@ -619,8 +620,8 @@ public class ConvertRecord {
     }
 
     public static class PropertyWithValueAndId {
-        public PropertyWithValue propertyWithValue;
-        public Integer id;
+        private PropertyWithValue propertyWithValue;
+        private Integer id;
 
         public PropertyWithValueAndId(Integer id, PropertyWithValue propertyWithValue){
             this.propertyWithValue = propertyWithValue;

--- a/libraries/commonIO/src/test/java/com/siemens/sw360/commonIO/ConvertRecordTest.java
+++ b/libraries/commonIO/src/test/java/com/siemens/sw360/commonIO/ConvertRecordTest.java
@@ -37,7 +37,9 @@ public class ConvertRecordTest {
     private List<CSVRecord> smallestPossibleRecord;
     private List<CSVRecord> fullRecord;
     private List<CSVRecord> emptyPropRecord;
+    private List<CSVRecord> whitePropRecord;
     private List<CSVRecord> emptyValRecord;
+    private List<CSVRecord> whiteValRecord;
     private List<Todo> todos;
     private List<CSVRecord> fullTodoRecord;
 
@@ -51,8 +53,14 @@ public class ConvertRecordTest {
         String emptyProp = "header\n 1,,val";
         emptyPropRecord = readToRecord(emptyProp);
 
+        String whiteProp = "header\n 1,  ,val";
+        whitePropRecord = readToRecord(whiteProp);
+
         String emptyValue = "header\n 1,prop,";
         emptyValRecord = readToRecord(emptyValue);
+
+        String whiteValue = "header\n 1,prop, ";
+        whiteValRecord = readToRecord(whiteValue);
 
         String smallestPossible = "headers\n 1,prop1,val1";
         smallestPossibleRecord = readToRecord(smallestPossible);
@@ -93,10 +101,24 @@ public class ConvertRecordTest {
     }
 
     @Test
-    public void testConvertCustomPropertiesEmptyValue() throws Exception {
-        Map<String, Set<String>> properties = convertCustomProperties(emptyValRecord);
+    public void testConvertCustomPropertiesWhitespaceProp() throws Exception {
+        Map<String, Set<String>> properties = convertCustomProperties(whitePropRecord);
         assertThat(properties.keySet().size(), is(0));
         assertThat(properties.values().size(), is(0));
+    }
+
+    @Test
+    public void testConvertCustomPropertiesEmptyValue() throws Exception {
+        Map<String, Set<String>> properties = convertCustomProperties(emptyValRecord);
+        assertThat(properties.keySet().size(), is(1));
+        assertThat(properties.values().size(), is(1));
+    }
+
+    @Test
+    public void testConvertCustomPropertiesWhiteValue() throws Exception {
+        Map<String, Set<String>> properties = convertCustomProperties(whiteValRecord);
+        assertThat(properties.keySet().size(), is(1));
+        assertThat(properties.values().size(), is(1));
     }
 
     @Test

--- a/libraries/commonIO/src/test/java/com/siemens/sw360/commonIO/ConvertRecordTest.java
+++ b/libraries/commonIO/src/test/java/com/siemens/sw360/commonIO/ConvertRecordTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2016.
+ * Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.siemens.sw360.commonIO;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+import com.siemens.sw360.datahandler.common.ImportCSV;
+import com.siemens.sw360.datahandler.thrift.licenses.Todo;
+import org.apache.commons.csv.CSVRecord;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static com.siemens.sw360.commonIO.ConvertRecord.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * @author: birgit.heydenreich@tngtech.com
+ */
+
+public class ConvertRecordTest {
+
+    private List<CSVRecord> emptyRecord;
+    private List<CSVRecord> tooSmallRecord;
+    private List<CSVRecord> smallestPossibleRecord;
+    private List<CSVRecord> fullRecord;
+    private List<CSVRecord> emptyPropRecord;
+    private List<CSVRecord> emptyValRecord;
+    private List<Todo> todos;
+    private List<CSVRecord> fullTodoRecord;
+
+    @Before
+    public void prepare() {
+        emptyRecord = readToRecord(" ");
+
+        String tooSmall = "header\n 1, prop";
+        tooSmallRecord = readToRecord(tooSmall);
+
+        String emptyProp = "header\n 1,,val";
+        emptyPropRecord = readToRecord(emptyProp);
+
+        String emptyValue = "header\n 1,prop,";
+        emptyValRecord = readToRecord(emptyValue);
+
+        String smallestPossible = "headers\n 1,prop1,val1";
+        smallestPossibleRecord = readToRecord(smallestPossible);
+
+        String full = "headers\n 1,A,A1 \n 2,A,A2 \n 3,A,A3 \n 4,B,B1 \n 5,B,B2";
+        fullRecord = readToRecord(full);
+
+        String fullTodo = "header \n '1','text1','true','true' \n '2','text2','false','false'";
+        fullTodoRecord = readToRecord(fullTodo);
+
+        Map<String, String> todoCustomProperties1 = new HashMap<>();
+        todoCustomProperties1.put("A", "A1");
+        Todo todo1 = new Todo().setTodoId(1).setCustomPropertyToValue(todoCustomProperties1);
+        Map<String, String> todoCustomProperties2 = new HashMap<>();
+        todoCustomProperties2.put("A", "A2");
+        todoCustomProperties2.put("C", "C2");
+        Todo todo2 = new Todo().setTodoId(2).setCustomPropertyToValue(todoCustomProperties2);
+        todos = Arrays.asList(todo1, todo2);
+    }
+
+    public List<CSVRecord> readToRecord(String string) {
+        ByteArrayInputStream stream = new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8));
+        return ImportCSV.readAsCSVRecords(stream);
+    }
+
+    @Test
+    public void testConvertCustomPropertiesEmpty() throws Exception {
+        Map<String, Set<String>> properties = convertCustomProperties(emptyRecord);
+        assertThat(properties.keySet().size(), is(0));
+        assertThat(properties.values().size(), is(0));
+    }
+
+    @Test
+    public void testConvertCustomPropertiesEmptyProp() throws Exception {
+        Map<String, Set<String>> properties = convertCustomProperties(emptyPropRecord);
+        assertThat(properties.keySet().size(), is(0));
+        assertThat(properties.values().size(), is(0));
+    }
+
+    @Test
+    public void testConvertCustomPropertiesEmptyValue() throws Exception {
+        Map<String, Set<String>> properties = convertCustomProperties(emptyValRecord);
+        assertThat(properties.keySet().size(), is(0));
+        assertThat(properties.values().size(), is(0));
+    }
+
+    @Test
+    public void testConvertCustomPropertiesTooSmall() throws Exception {
+        Map<String, Set<String>> properties = convertCustomProperties(tooSmallRecord);
+        assertThat(properties.keySet().size(), is(0));
+        assertThat(properties.values().size(), is(0));
+    }
+
+    @Test
+    public void testConvertCustomPropertiesSmallestPossible() throws Exception {
+        Map<String, Set<String>> properties = convertCustomProperties(smallestPossibleRecord);
+        assertThat(properties.keySet(), Matchers.containsInAnyOrder("prop1"));
+        assertThat(properties.get("prop1"), Matchers.containsInAnyOrder("val1"));
+    }
+
+    @Test
+    public void testConvertCustomPropertiesFull() throws Exception {
+        Map<String, Set<String>> properties = convertCustomProperties(fullRecord);
+        assertThat(properties.keySet(), Matchers.containsInAnyOrder("A", "B"));
+        assertThat(properties.get("A"), Matchers.containsInAnyOrder("A1", "A2", "A3"));
+        assertThat(properties.get("B"), Matchers.containsInAnyOrder("B1", "B2"));
+    }
+
+    @Test
+    public void testConvertCustomPropertiesByEmpty() throws Exception {
+        Map<Integer, ConvertRecord.PropertyWithValue> properties = convertCustomPropertiesById(emptyRecord);
+        assertThat(properties.keySet().size(), is(0));
+        assertThat(properties.values().size(), is(0));
+    }
+
+    @Test
+    public void testConvertCustomPropertiesByIdSmallestPossible() throws Exception {
+        Map<Integer, ConvertRecord.PropertyWithValue> properties = convertCustomPropertiesById(smallestPossibleRecord);
+        assertThat(properties.keySet(), Matchers.containsInAnyOrder(1));
+        assertThat(properties.get(1).getProperty(), is("prop1"));
+        assertThat(properties.get(1).getValue(), is("val1"));
+    }
+
+    @Test
+    public void testConvertCustomPropertiesByIdFull() throws Exception {
+        Map<Integer, ConvertRecord.PropertyWithValue> properties = convertCustomPropertiesById(fullRecord);
+        assertThat(properties.keySet(), Matchers.containsInAnyOrder(1, 2, 3, 4, 5));
+        assertThat(properties.get(1).getProperty(), is("A"));
+        assertThat(properties.get(1).getValue(), is("A1"));
+        assertThat(properties.get(2).getProperty(), is("A"));
+        assertThat(properties.get(2).getValue(), is("A2"));
+        assertThat(properties.get(3).getProperty(), is("A"));
+        assertThat(properties.get(3).getValue(), is("A3"));
+        assertThat(properties.get(4).getProperty(), is("B"));
+        assertThat(properties.get(4).getValue(), is("B1"));
+        assertThat(properties.get(5).getProperty(), is("B"));
+        assertThat(properties.get(5).getValue(), is("B2"));
+    }
+
+    @Test
+    public void testFillTodoCustomPropertyInfoEmpty() throws Exception {
+        List<ConvertRecord.PropertyWithValueAndId> customProperties = new ArrayList<>();
+        SetMultimap<Integer, Integer> todoCustomPropertyMap = HashMultimap.create();
+        fillTodoCustomPropertyInfo(Collections.EMPTY_LIST, customProperties, todoCustomPropertyMap);
+        assertThat(customProperties.size(), is(0));
+        assertThat(todoCustomPropertyMap.size(), is(0));
+    }
+
+    @Test
+    public void testFillTodoCustomPropertyInfoFull() throws Exception {
+        List<ConvertRecord.PropertyWithValueAndId> customProperties = new ArrayList<>();
+        SetMultimap<Integer, Integer> todoCustomPropertyMap = HashMultimap.create();
+        fillTodoCustomPropertyInfo(todos, customProperties, todoCustomPropertyMap);
+        assertThat(customProperties.size(), is(3));
+        assertThat(todoCustomPropertyMap.size(), is(3));
+        int id = todoCustomPropertyMap.get(1).stream().findFirst().get();
+        assertThat(customProperties.get(id).getProperty(), is("A"));
+        assertThat(customProperties.get(id).getValue(), is("A1"));
+    }
+
+    @Test
+    public void testConvertTodosEmpty() throws Exception {
+        List<Todo> todos = convertTodos(emptyRecord);
+        assertThat(todos.size(), is(0));
+    }
+
+    @Test
+    public void testConvertTodosFull() throws Exception {
+        List<Todo> todos = convertTodos(fullTodoRecord);
+        assertThat(todos.size(), is(2));
+        assertThat(todos.get(0).getText(), is("text1"));
+        assertThat(todos.get(0).getTodoId(), is(1));
+        assertThat(todos.get(0).isDevelopment(), is(true));
+        assertThat(todos.get(0).isDistribution(), is(true));
+        assertThat(todos.get(1).getText(), is("text2"));
+        assertThat(todos.get(1).getTodoId(), is(2));
+        assertThat(todos.get(1).isDevelopment(), is(false));
+        assertThat(todos.get(1).isDistribution(), is(false));
+
+    }
+
+
+}

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ZipTools.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ZipTools.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
+ * With modifications by Bosch Software Innovations GmbH, 2016.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -31,19 +32,31 @@ public class ZipTools {
     public static final String LICENSE_TODO_FILE = "dbo.licensetodo.csv";
     public static final String LICENSE_RISK_FILE = "dbo.licenserisk.csv";
     public static final String LICENSE_FILE = "dbo.License.csv";
-    public static final Set<String> licenseFileNames =  ImmutableSet.<String>builder()
+    public static final String CUSTOM_PROPERTIES_FILE = "dbo.customProperties.csv";
+    public static final String TODO_CUSTOM_PROPERTIES_FILE = "dbo.todoCustomProperties.csv";
+    public static final Set<String> requiredLicenseFileNames = ImmutableSet.<String>builder()
                                                                     .add(RISK_CATEGORY_FILE).add(RISK_FILE)
                                                                     .add(OBLIGATION_FILE).add(OBLIGATION_TODO_FILE)
                                                                     .add(TODO_FILE).add(LICENSETYPE_FILE)
                                                                     .add(LICENSE_TODO_FILE).add(LICENSE_RISK_FILE)
                                                                     .add(LICENSE_FILE).build();
+    public static final Set<String> optionalLicenseFileNames = ImmutableSet.<String>builder()
+                                                                    .addAll(requiredLicenseFileNames)
+                                                                    .add(CUSTOM_PROPERTIES_FILE)
+                                                                    .add(TODO_CUSTOM_PROPERTIES_FILE).build();
 
     public static boolean isValidLicenseArchive(HashMap<String, InputStream> inputMap) {
         if(inputMap==null) return false;
-        boolean isValidLicenseArchive = inputMap.size() == licenseFileNames.size();
-        for (String licenseFileName : licenseFileNames) {
+        boolean isValidLicenseArchive = inputMap.size() >= requiredLicenseFileNames.size();
+        for (String licenseFileName : requiredLicenseFileNames) {
             isValidLicenseArchive &= inputMap.containsKey(licenseFileName);
         }
+        for (String licenseFileName : inputMap.keySet()){
+            isValidLicenseArchive &= optionalLicenseFileNames.contains(licenseFileName);
+        }
+        isValidLicenseArchive &=  ! inputMap.keySet().contains(TODO_CUSTOM_PROPERTIES_FILE)
+                                 || inputMap.keySet().contains(CUSTOM_PROPERTIES_FILE);
+
         return isValidLicenseArchive;
     }
 

--- a/libraries/importers/license-importer/src/main/java/com/siemens/sw360/importer/LicenseImporter.java
+++ b/libraries/importers/license-importer/src/main/java/com/siemens/sw360/importer/LicenseImporter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * With modifications by Bosch Software Innovations GmbH, 2016.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -74,7 +75,7 @@ public class LicenseImporter {
         Map<Integer, Set<Integer>> obligationTodoMapping;
         try (final InputStream in = getURL(obligationTodoFilename).openStream()) {
             List<CSVRecord> obligationTodoRecords = ImportCSV.readAsCSVRecords(in);
-            obligationTodoMapping = ConvertRecord.convertObligationTodo(obligationTodoRecords);
+            obligationTodoMapping = ConvertRecord.convertRelationalTableWithIntegerKeys(obligationTodoRecords);
         }
 
         log.debug("Parsing todos ...");
@@ -152,7 +153,7 @@ public class LicenseImporter {
 
         Map<Integer, Todo> todoMap = null;
         try (final InputStream in = getURL(todoFilename).openStream()) {
-            todoMap = TypeMappings.getTodoMap(licenseClient, obligationMap, obligationTodoMapping, in);
+            todoMap = TypeMappings.getTodoMapAndWriteMissingToDatabase(licenseClient, obligationMap, obligationTodoMapping, in);
         } catch (TException e) {
             log.error("Error saving Todos", e);
         }

--- a/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/CommonUtils.java
+++ b/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/CommonUtils.java
@@ -9,12 +9,15 @@
 package com.siemens.sw360.datahandler.common;
 
 import com.google.common.base.*;
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.collect.*;
-import com.siemens.sw360.datahandler.thrift.*;
-import com.siemens.sw360.datahandler.thrift.attachments.*;
-import com.siemens.sw360.datahandler.thrift.components.ClearingState;
+import com.siemens.sw360.datahandler.thrift.DocumentState;
+import com.siemens.sw360.datahandler.thrift.ModerationState;
+import com.siemens.sw360.datahandler.thrift.RequestStatus;
+import com.siemens.sw360.datahandler.thrift.RequestSummary;
+import com.siemens.sw360.datahandler.thrift.attachments.Attachment;
+import com.siemens.sw360.datahandler.thrift.attachments.AttachmentContent;
+import com.siemens.sw360.datahandler.thrift.attachments.AttachmentType;
+import com.siemens.sw360.datahandler.thrift.attachments.CheckStatus;
 import com.siemens.sw360.datahandler.thrift.components.Release;
 import com.siemens.sw360.datahandler.thrift.licenses.Todo;
 import com.siemens.sw360.datahandler.thrift.moderation.ModerationRequest;
@@ -36,7 +39,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
 import java.util.Optional;
-import java.util.function.*;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.apache.log4j.LogManager.getLogger;
@@ -547,5 +549,9 @@ public class CommonUtils {
                 }
         );
         return destination;
+    }
+
+    public static boolean isNullEmptyOrWhitespace(String string){
+        return string==null || string.trim().length() == 0;
     }
 }

--- a/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/CommonUtils.java
+++ b/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/CommonUtils.java
@@ -9,15 +9,12 @@
 package com.siemens.sw360.datahandler.common;
 
 import com.google.common.base.*;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.collect.*;
-import com.siemens.sw360.datahandler.thrift.DocumentState;
-import com.siemens.sw360.datahandler.thrift.ModerationState;
-import com.siemens.sw360.datahandler.thrift.RequestStatus;
-import com.siemens.sw360.datahandler.thrift.RequestSummary;
-import com.siemens.sw360.datahandler.thrift.attachments.Attachment;
-import com.siemens.sw360.datahandler.thrift.attachments.AttachmentContent;
-import com.siemens.sw360.datahandler.thrift.attachments.AttachmentType;
-import com.siemens.sw360.datahandler.thrift.attachments.CheckStatus;
+import com.siemens.sw360.datahandler.thrift.*;
+import com.siemens.sw360.datahandler.thrift.attachments.*;
+import com.siemens.sw360.datahandler.thrift.components.ClearingState;
 import com.siemens.sw360.datahandler.thrift.components.Release;
 import com.siemens.sw360.datahandler.thrift.licenses.Todo;
 import com.siemens.sw360.datahandler.thrift.moderation.ModerationRequest;
@@ -39,6 +36,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
 import java.util.Optional;
+import java.util.function.*;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.apache.log4j.LogManager.getLogger;
@@ -531,5 +529,23 @@ public class CommonUtils {
             getLogger(CommonUtils.class).error("List contained more then one item but was treated as \"Optional\".");
         }
         return Optional.of(thriftOutput.get(0));
+    }
+
+    public static Map<String, Set<String>> mergeMapIntoMap(Map<String, Set<String>> source, Map<String, Set<String>> destination) {
+        if (destination == null) {
+            return source;
+        }
+        if (source == null) {
+            return destination;
+        }
+        source.keySet().stream().forEach(k -> {
+                    if (destination.containsKey(k)) {
+                        destination.get(k).addAll(source.get(k));
+                    } else {
+                        destination.put(k, source.get(k));
+                    }
+                }
+        );
+        return destination;
     }
 }

--- a/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/thrift/ThriftUtils.java
+++ b/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/thrift/ThriftUtils.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
+ * With modifications by Bosch Software Innovations GmbH, 2016.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -50,6 +51,7 @@ public class ThriftUtils {
             .add(Component.class).add(Release.class) // Component service
             .add(License.class).add(Todo.class).add(Obligation.class) // License service
             .add(LicenseType.class).add(Risk.class).add(RiskCategory.class) // License service
+            .add(CustomProperties.class) // License service
             .add(Project.class) // Project service
             .add(User.class) // User service
             .add(Vendor.class) // Vendor service

--- a/libraries/lib-datahandler/src/main/thrift/licenses.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenses.thrift
@@ -17,6 +17,7 @@ typedef users.User User
 typedef users.RequestedAction RequestedAction
 typedef sw360.RequestStatus RequestStatus
 typedef sw360.DocumentState DocumentState
+typedef sw360.CustomProperties CustomProperties
 
 struct Obligation {
 	1: optional string id,
@@ -37,6 +38,7 @@ struct Todo {
     8: optional list<Obligation> obligations,
     9: optional set<string> obligationDatabaseIds,
     10: required i32 todoId,
+    11: optional map<string, string> customPropertyToValue,
 
     // These two are a quick fix to receiving booleans in PHP not working at the moment
     15: optional string developmentString,
@@ -143,7 +145,7 @@ service LicenseService {
     /**
      * Update the whitelisted todos for an organisation, generate moderation request if user has no permissions
      **/
-    RequestStatus updateWhitelist(1: string licenceId, 2: set<string> todoDatabaseIds, 3: User user);
+    RequestStatus updateWhitelist(1: string licenseId, 2: set<string> todoDatabaseIds, 3: User user);
 
     /**
      * delete license from database if user has permissions,
@@ -271,4 +273,8 @@ service LicenseService {
      * return filled todo
      **/
     Todo getTodoById( 1: string id);
+
+    list<CustomProperties> getCustomProperties(1: string documentType);
+
+    RequestStatus updateCustomProperties(1: CustomProperties customProperties, 2: User user )
 }

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -1,5 +1,6 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
+ * With contributions by Bosch Software Innovations GmbH, 2016.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -58,4 +59,12 @@ struct RequestSummary {
   2: optional i32 totalAffectedElements;
   3: optional i32 totalElements;
   4: optional string message;
+}
+
+struct CustomProperties {
+    1: optional string id,
+    2: optional string revision,
+    3: optional string type = "customproperties",
+    4: optional string documentType,
+    5: map<string, set<string>> propertyToValues;
 }


### PR DESCRIPTION
This PR allows to import lics archives with licenses that have custom properties. For that a new table is introduced that is contained as csv file hi the archive.