### PR TITLE
fix(#151): display hash with `<span>` instead of `<input>`

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -321,3 +321,8 @@ input[readonly].clickable {
 .release-list-entry-element input {
     width: 100%;
 }
+
+.hashvalue {
+    word-break: break-all;
+    font-family: monospace;
+}

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsDetail.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsDetail.jsp
@@ -42,9 +42,7 @@
                 <td colspan="2" rowspan="3" class="lessPadding">
                     Type: <sw360:DisplayEnum value="${attachment.attachmentType}"/> <br/>
                     Status: <sw360:DisplayEnum value="${attachment.checkStatus}"/> <br/>
-                    SHA1-Checksum: <input class="checksumInput" readonly="true"
-                           type="text"
-                           value="${attachment.sha1}">
+                    SHA1-Checksum: <span class="hashvalue">${attachment.sha1}</span>
                 </td>
             </tr>
             <tr id="attachmentRow3${loop.count}" >


### PR DESCRIPTION
closes #151