### PR TITLE
Excel export extended by releases

### DIFF
--- a/backend/src-common/src/main/java/com/siemens/sw360/components/summary/ComponentSummary.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/components/summary/ComponentSummary.java
@@ -76,17 +76,15 @@ public class ComponentSummary extends DocumentSummary<Component> {
             copyField(document, copy, Component._Fields.DESCRIPTION);
         }
 
-
-
         copyField(document, copy, Component._Fields.ID);
         copyField(document, copy, Component._Fields.NAME);
         copyField(document, copy, Component._Fields.VENDOR_NAMES);
         copyField(document, copy, Component._Fields.COMPONENT_TYPE);
 
-
         if (type == SummaryType.SUMMARY) {
-            copyField(document, copy, Component._Fields.MAIN_LICENSE_IDS);
-            copyField(document, copy, Component._Fields.CATEGORIES);
+            for (Component._Fields field : Component.metaDataMap.keySet()) {
+                copyField(document, copy, field);
+            }
         }
 
         return copy;

--- a/backend/src-common/src/main/java/com/siemens/sw360/components/summary/ProjectSummary.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/components/summary/ProjectSummary.java
@@ -10,7 +10,6 @@ package com.siemens.sw360.components.summary;
 
 import com.siemens.sw360.datahandler.thrift.projects.Project;
 import com.siemens.sw360.datahandler.thrift.projects.Project._Fields;
-import com.siemens.sw360.exporter.ProjectExporter;
 
 import static com.siemens.sw360.datahandler.thrift.ThriftUtils.copyField;
 
@@ -32,8 +31,6 @@ public class ProjectSummary extends DocumentSummary<Project> {
         copyField(document, copy, _Fields.CLEARING_TEAM);
 
         switch (type) {
-            case EXPORT_SUMMARY:
-                setExportSummaryFields(document, copy);
             case SUMMARY:
                 setSummaryFields(document, copy);
             default:
@@ -45,7 +42,7 @@ public class ProjectSummary extends DocumentSummary<Project> {
 
     protected static void setSummaryFields(Project document, Project copy) {
 
-        for (_Fields renderedField : ProjectExporter.RENDERED_FIELDS) {
+        for (_Fields renderedField : Project.metaDataMap.keySet()) {
             switch (renderedField) {
                 case RELEASE_IDS:
                     if (document.isSetReleaseIdToUsage()) {
@@ -57,12 +54,4 @@ public class ProjectSummary extends DocumentSummary<Project> {
             }
         }
     }
-
-    protected static void setExportSummaryFields(Project document, Project copy) {
-        copyField(document, copy, _Fields.CREATED_ON);
-        copyField(document, copy, _Fields.CREATED_BY);
-        copyField(document, copy, _Fields.LEAD_ARCHITECT);
-        copyField(document, copy, _Fields.BUSINESS_UNIT);
-    }
-
 }

--- a/backend/src-common/src/main/java/com/siemens/sw360/components/summary/ProjectSummary.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/components/summary/ProjectSummary.java
@@ -42,15 +42,15 @@ public class ProjectSummary extends DocumentSummary<Project> {
 
     protected static void setSummaryFields(Project document, Project copy) {
 
-        for (_Fields renderedField : Project.metaDataMap.keySet()) {
-            switch (renderedField) {
+        for (_Fields field : Project.metaDataMap.keySet()) {
+            switch (field) {
                 case RELEASE_IDS:
                     if (document.isSetReleaseIdToUsage()) {
                         copy.setReleaseIds(document.releaseIdToUsage.keySet());
                     }
                     break;
                 default:
-                    copyField(document, copy, renderedField);
+                    copyField(document, copy, field);
             }
         }
     }

--- a/backend/src-common/src/main/java/com/siemens/sw360/components/summary/ReleaseSummary.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/components/summary/ReleaseSummary.java
@@ -12,6 +12,7 @@ import com.google.common.base.Strings;
 import com.siemens.sw360.datahandler.db.VendorRepository;
 import com.siemens.sw360.datahandler.thrift.components.Release;
 import com.siemens.sw360.datahandler.thrift.components.Release._Fields;
+import com.siemens.sw360.exporter.ReleaseExporter;
 
 import static com.siemens.sw360.datahandler.thrift.ThriftUtils.copyField;
 
@@ -36,33 +37,41 @@ public class ReleaseSummary extends DocumentSummary<Release> {
     @Override
     protected Release summary(SummaryType type, Release document) {
         Release copy = new Release();
-        copyField(document, copy, _Fields.ID);
-        copyField(document, copy, _Fields.NAME);
-        copyField(document, copy, _Fields.VERSION);
-        copyField(document, copy, _Fields.COMPONENT_ID);
-        copyField(document, copy, _Fields.CLEARING_TEAM_TO_FOSSOLOGY_STATUS);
-        copyField(document, copy, _Fields.FOSSOLOGY_ID);
+        if(type == SummaryType.DETAILED_EXPORT_SUMMARY){
+           setDetailedExportSummaryFields(document, copy);
+        } else {
+            copyField(document, copy, _Fields.ID);
+            copyField(document, copy, _Fields.NAME);
+            copyField(document, copy, _Fields.VERSION);
+            copyField(document, copy, _Fields.COMPONENT_ID);
+            copyField(document, copy, _Fields.CLEARING_TEAM_TO_FOSSOLOGY_STATUS);
+            copyField(document, copy, _Fields.FOSSOLOGY_ID);
 
-        if(document.isSetVendorId() ) {
+            if (type != SummaryType.SHORT) {
+                copyField(document, copy, _Fields.CPEID);
+                copyField(document, copy, _Fields.CREATED_BY);
+                copyField(document, copy, _Fields.MAINLINE_STATE);
+                copyField(document, copy, _Fields.CLEARING_STATE);
+                copyField(document, copy, _Fields.RELEASE_DATE);
+                copyField(document, copy, _Fields.LANGUAGES);
+                copyField(document, copy, _Fields.OPERATING_SYSTEMS);
+                copyField(document, copy, _Fields.ATTACHMENTS);
+                copyField(document, copy, _Fields.MAIN_LICENSE_IDS);
+            }
+        }
+        if (document.isSetVendorId()) {
             final String vendorId = document.getVendorId();
             if (!Strings.isNullOrEmpty(vendorId)) {
                 copy.setVendor(vendorRepository.get(vendorId));
             }
         }
-
-        if (type != SummaryType.SHORT) {
-            copyField(document, copy, _Fields.CPEID);
-            copyField(document, copy, _Fields.CREATED_BY);
-            copyField(document, copy, _Fields.MAINLINE_STATE);
-            copyField(document, copy, _Fields.CLEARING_STATE);
-            copyField(document, copy, _Fields.RELEASE_DATE);
-            copyField(document, copy, _Fields.LANGUAGES);
-            copyField(document, copy, _Fields.OPERATING_SYSTEMS);
-            copyField(document, copy, _Fields.ATTACHMENTS);
-            copyField(document, copy, _Fields.MAIN_LICENSE_IDS);
-        }
-
         return copy;
+    }
+
+    private void setDetailedExportSummaryFields(Release document, Release copy) {
+        for (_Fields renderedField : ReleaseExporter.RENDERED_FIELDS) {
+            copyField(document, copy, renderedField);
+        }
     }
 
 }

--- a/backend/src-common/src/main/java/com/siemens/sw360/components/summary/ReleaseSummary.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/components/summary/ReleaseSummary.java
@@ -55,7 +55,7 @@ public class ReleaseSummary extends DocumentSummary<Release> {
     }
 
     private void setDetailedExportSummaryFields(Release document, Release copy) {
-        for (_Fields renderedField : ReleaseExporter.RENDERED_FIELDS) {
+        for (_Fields renderedField : ReleaseExporter.RELEASE_RENDERED_FIELDS) {
             copyField(document, copy, renderedField);
         }
     }

--- a/backend/src-common/src/main/java/com/siemens/sw360/components/summary/ReleaseSummary.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/components/summary/ReleaseSummary.java
@@ -40,23 +40,9 @@ public class ReleaseSummary extends DocumentSummary<Release> {
         if(type == SummaryType.DETAILED_EXPORT_SUMMARY){
            setDetailedExportSummaryFields(document, copy);
         } else {
-            copyField(document, copy, _Fields.ID);
-            copyField(document, copy, _Fields.NAME);
-            copyField(document, copy, _Fields.VERSION);
-            copyField(document, copy, _Fields.COMPONENT_ID);
-            copyField(document, copy, _Fields.CLEARING_TEAM_TO_FOSSOLOGY_STATUS);
-            copyField(document, copy, _Fields.FOSSOLOGY_ID);
-
+            setShortSummaryFields(document,copy);
             if (type != SummaryType.SHORT) {
-                copyField(document, copy, _Fields.CPEID);
-                copyField(document, copy, _Fields.CREATED_BY);
-                copyField(document, copy, _Fields.MAINLINE_STATE);
-                copyField(document, copy, _Fields.CLEARING_STATE);
-                copyField(document, copy, _Fields.RELEASE_DATE);
-                copyField(document, copy, _Fields.LANGUAGES);
-                copyField(document, copy, _Fields.OPERATING_SYSTEMS);
-                copyField(document, copy, _Fields.ATTACHMENTS);
-                copyField(document, copy, _Fields.MAIN_LICENSE_IDS);
+               setAdditionalFieldsForSummariesOtherThanShortAndDetailedExport(document, copy);
             }
         }
         if (document.isSetVendorId()) {
@@ -72,6 +58,27 @@ public class ReleaseSummary extends DocumentSummary<Release> {
         for (_Fields renderedField : ReleaseExporter.RENDERED_FIELDS) {
             copyField(document, copy, renderedField);
         }
+    }
+
+    private void setShortSummaryFields(Release document, Release copy) {
+        copyField(document, copy, _Fields.ID);
+        copyField(document, copy, _Fields.NAME);
+        copyField(document, copy, _Fields.VERSION);
+        copyField(document, copy, _Fields.COMPONENT_ID);
+        copyField(document, copy, _Fields.CLEARING_TEAM_TO_FOSSOLOGY_STATUS);
+        copyField(document, copy, _Fields.FOSSOLOGY_ID);
+    }
+
+    private void setAdditionalFieldsForSummariesOtherThanShortAndDetailedExport(Release document, Release copy){
+        copyField(document, copy, _Fields.CPEID);
+        copyField(document, copy, _Fields.CREATED_BY);
+        copyField(document, copy, _Fields.MAINLINE_STATE);
+        copyField(document, copy, _Fields.CLEARING_STATE);
+        copyField(document, copy, _Fields.RELEASE_DATE);
+        copyField(document, copy, _Fields.LANGUAGES);
+        copyField(document, copy, _Fields.OPERATING_SYSTEMS);
+        copyField(document, copy, _Fields.ATTACHMENTS);
+        copyField(document, copy, _Fields.MAIN_LICENSE_IDS);
     }
 
 }

--- a/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -696,7 +696,7 @@ public class ComponentDatabaseHandler {
         return releaseRepository.makeSummary(SummaryType.SHORT, ids);
     }
 
-    public List<Release> getDetailedReleases(Set<String> ids, User user) {
+    public List<Release> getDetailedReleasesForExport(Set<String> ids) {
         return releaseRepository.makeSummary(SummaryType.DETAILED_EXPORT_SUMMARY, ids);
     }
 

--- a/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -696,6 +696,10 @@ public class ComponentDatabaseHandler {
         return releaseRepository.makeSummary(SummaryType.SHORT, ids);
     }
 
+    public List<Release> getDetailedReleases(Set<String> ids, User user) {
+        return releaseRepository.makeSummary(SummaryType.DETAILED_EXPORT_SUMMARY, ids);
+    }
+
     public List<Release> getFullReleases(Set<String> ids, User user) {
         return releaseRepository.makeSummary(SummaryType.SUMMARY, ids);
     }

--- a/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -11,7 +11,6 @@ package com.siemens.sw360.datahandler.db;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Maps;
 import com.siemens.sw360.datahandler.common.CommonUtils;
 import com.siemens.sw360.datahandler.common.Duration;
 import com.siemens.sw360.datahandler.common.SW360Constants;
@@ -20,7 +19,6 @@ import com.siemens.sw360.datahandler.couchdb.AttachmentConnector;
 import com.siemens.sw360.datahandler.couchdb.DatabaseConnector;
 import com.siemens.sw360.datahandler.entitlement.ProjectModerator;
 import com.siemens.sw360.datahandler.thrift.*;
-import com.siemens.sw360.datahandler.thrift.components.Release;
 import com.siemens.sw360.datahandler.thrift.components.ReleaseLink;
 import com.siemens.sw360.datahandler.thrift.moderation.ModerationRequest;
 import com.siemens.sw360.datahandler.thrift.projects.Project;
@@ -34,10 +32,9 @@ import org.apache.log4j.Logger;
 import java.net.MalformedURLException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
-import static com.siemens.sw360.datahandler.common.CommonUtils.*;
+import static com.siemens.sw360.datahandler.common.CommonUtils.isInProgressOrPending;
+import static com.siemens.sw360.datahandler.common.CommonUtils.nullToEmptyList;
 import static com.siemens.sw360.datahandler.common.SW360Assert.assertNotNull;
 import static com.siemens.sw360.datahandler.common.SW360Assert.fail;
 import static com.siemens.sw360.datahandler.common.SW360Utils.*;
@@ -99,10 +96,6 @@ public class ProjectDatabaseHandler {
 
     public List<Project> searchByName(String name, User user) {
         return repository.searchByName(name, user);
-    }
-
-    public List<Project> searchByNameFortExport(String name, User user) {
-        return repository.searchByNameForExport(name, user);
     }
 
     ////////////////////////////

--- a/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ProjectRepository.java
@@ -232,10 +232,6 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
         return searchByName(name, user, SummaryType.SHORT);
     }
 
-    public List<Project> searchByNameForExport(String name, User user) {
-        return searchByName(name, user, SummaryType.EXPORT_SUMMARY);
-    }
-
     @NotNull
     private Set<Project> filterAccessibleProjectsByIds(User user, Set<String> searchIds) {
         final Set<Project> accessibleProjects = getAccessibleProjects(user);

--- a/backend/src/src-components/src/main/java/com/siemens/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/com/siemens/sw360/components/ComponentHandler.java
@@ -160,7 +160,7 @@ public class ComponentHandler implements ComponentService.Iface {
     @Override
     public List<Release> getReleasesByIdsForExport(Set<String> ids) throws TException {
         assertNotNull(ids);
-        return handler.getDetailedReleases(ids, null);
+        return handler.getDetailedReleasesForExport(ids);
     }
 
     @Override

--- a/backend/src/src-components/src/main/java/com/siemens/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/com/siemens/sw360/components/ComponentHandler.java
@@ -9,7 +9,6 @@
 package com.siemens.sw360.components;
 
 import com.siemens.sw360.attachments.AttachmentHandler;
-import com.siemens.sw360.datahandler.common.CommonUtils;
 import com.siemens.sw360.datahandler.common.DatabaseSettings;
 import com.siemens.sw360.datahandler.db.ComponentDatabaseHandler;
 import com.siemens.sw360.datahandler.db.ComponentSearchHandler;
@@ -18,13 +17,14 @@ import com.siemens.sw360.datahandler.thrift.RequestSummary;
 import com.siemens.sw360.datahandler.thrift.ThriftClients;
 import com.siemens.sw360.datahandler.thrift.ThriftUtils;
 import com.siemens.sw360.datahandler.thrift.attachments.Attachment;
-import com.siemens.sw360.datahandler.thrift.attachments.AttachmentType;
 import com.siemens.sw360.datahandler.thrift.components.*;
 import com.siemens.sw360.datahandler.thrift.users.User;
 import org.apache.thrift.TException;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.siemens.sw360.datahandler.common.SW360Assert.*;
 
@@ -160,7 +160,7 @@ public class ComponentHandler implements ComponentService.Iface {
     @Override
     public List<Release> getReleasesByIdsForExport(Set<String> ids) throws TException {
         assertNotNull(ids);
-        return handler.getReleases(ids, null);
+        return handler.getDetailedReleases(ids, null);
     }
 
     @Override

--- a/backend/src/src-components/src/test/java/com/siemens/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/com/siemens/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -218,7 +218,6 @@ public class ComponentDatabaseHandlerTest {
                     break;
                 // Fields that are not defined
                 default:
-                    assertFalse(field.getFieldName(), isSet);
                     break;
             }
         }

--- a/backend/src/src-projects/src/main/java/com/siemens/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/com/siemens/sw360/projects/ProjectHandler.java
@@ -53,8 +53,11 @@ public class ProjectHandler implements ProjectService.Iface {
 
     @Override
     public List<Project> refineSearch(String text, Map<String, Set<String>> subQueryRestrictions,User user) throws TException {
-        List<Project> foundProjects = searchHandler.search(text, subQueryRestrictions,user);
-        foundProjects.stream().forEach(p -> p.releaseIds = p.isSetReleaseIdToUsage()? p.releaseIdToUsage.keySet() : Collections.EMPTY_SET);
+        List<Project> foundProjects = searchHandler.search(text, subQueryRestrictions, user);
+        foundProjects.stream()
+                .forEach(p -> p.releaseIds = p.isSetReleaseIdToUsage()
+                                ? p.releaseIdToUsage.keySet()
+                                : Collections.EMPTY_SET);
         return foundProjects;
     }
 

--- a/backend/src/src-projects/src/main/java/com/siemens/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/com/siemens/sw360/projects/ProjectHandler.java
@@ -53,7 +53,9 @@ public class ProjectHandler implements ProjectService.Iface {
 
     @Override
     public List<Project> refineSearch(String text, Map<String, Set<String>> subQueryRestrictions,User user) throws TException {
-        return searchHandler.search(text, subQueryRestrictions,user);
+        List<Project> foundProjects = searchHandler.search(text, subQueryRestrictions,user);
+        foundProjects.stream().forEach(p -> p.releaseIds = p.isSetReleaseIdToUsage()? p.releaseIdToUsage.keySet() : Collections.EMPTY_SET);
+        return foundProjects;
     }
 
     @Override
@@ -83,14 +85,6 @@ public class ProjectHandler implements ProjectService.Iface {
         assertUser(user);
 
         return handler.searchByName(name, user);
-    }
-
-    @Override
-    public List<Project> searchByNameForExport(String name, User user) throws TException {
-        assertNotEmpty(name);
-        assertUser(user);
-
-        return handler.searchByNameFortExport(name, user);
     }
 
     @Override

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/PortalConstants.java
@@ -119,6 +119,7 @@ public class PortalConstants {
     public static final String RELEASE_LIST_FROM_LINKED_PROJECTS = "releaseListFromLinkedProjects";
     public static final String STATE;
     public static final String PROJECT_TYPE;
+    public static final String EXTENDED_EXCEL_EXPORT = "extendedExcelExport";
 
     public static final String FOSSOLOGY_FINGER_PRINTS = "fingerPrints";
     public static final String USER_LIST = "userList";

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/components/ComponentPortlet.java
@@ -25,6 +25,7 @@ import com.siemens.sw360.datahandler.thrift.VerificationState;
 import com.siemens.sw360.datahandler.thrift.VerificationStateInfo;
 import com.siemens.sw360.datahandler.thrift.attachments.Attachment;
 import com.siemens.sw360.datahandler.thrift.components.*;
+import com.siemens.sw360.datahandler.thrift.licenses.License;
 import com.siemens.sw360.datahandler.thrift.cvesearch.CveSearchService;
 import com.siemens.sw360.datahandler.thrift.cvesearch.VulnerabilityUpdateStatus;
 import com.siemens.sw360.datahandler.thrift.projects.Project;

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -208,13 +208,13 @@ public class ProjectPortlet extends FossologyAwarePortlet {
     private void exportExcel(ResourceRequest request, ResourceResponse response) {
         try {
             User user = UserCacheHolder.getUserFromRequest(request);
-            boolean isExtendedExcelExport = Boolean.valueOf(request.getParameter(PortalConstants.EXTENDED_EXCEL_EXPORT));
+            boolean extendedByReleases = Boolean.valueOf(request.getParameter(PortalConstants.EXTENDED_EXCEL_EXPORT));
             List<Project> projects = getFilteredProjectList(request);
             ProjectExporter exporter = new ProjectExporter(
                     thriftClients.makeComponentClient(),
                     thriftClients.makeProjectClient(),
                     user,
-                    isExtendedExcelExport);
+                    extendedByReleases);
             PortletResponseUtil.sendFile(request, response, "Projects.xlsx", exporter.makeExcelExport(projects), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         } catch (IOException | SW360Exception e) {
             log.error("An error occurred while generating the Excel export", e);
@@ -433,13 +433,9 @@ public class ProjectPortlet extends FossologyAwarePortlet {
     }
 
     private void prepareStandardView(RenderRequest request) throws IOException {
-        String searchtext = request.getParameter(KEY_SEARCH_TEXT);
-        String searchfilter = request.getParameter(KEY_SEARCH_FILTER_TEXT);
         List<Project> projectList = getFilteredProjectList(request);
 
         request.setAttribute(PROJECT_LIST, projectList);
-        request.setAttribute(KEY_SEARCH_TEXT, searchtext);
-        request.setAttribute(KEY_SEARCH_FILTER_TEXT, searchfilter);
         List<Organization> organizations = UserUtils.getOrganizations(request);
         request.setAttribute(PortalConstants.ORGANIZATIONS, organizations);
     }
@@ -474,7 +470,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             } else {
                 projectList = projectClient.refineSearch(searchtext, filterMap, user);
             }
-            for (Project project : projectList) {
+            for(Project project:projectList){
                 setClearingStateSummary(project);
             }
         } catch (TException e) {

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -459,7 +459,6 @@ public class ProjectPortlet extends FossologyAwarePortlet {
 
         List<Project> projectList;
 
-
         final User user = UserCacheHolder.getUserFromRequest(request);
         ProjectService.Iface projectClient = thriftClients.makeProjectClient();
 

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/projects/ProjectPortletUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -145,13 +145,13 @@ public class ProjectPortletUtils {
         return vulnerabilityCheckStatus;
     }
 
-    private static com.liferay.portal.model.User getLiferayUser(RenderRequest request, User user) throws PortalException, SystemException {
+    private static com.liferay.portal.model.User getLiferayUser(PortletRequest request, User user) throws PortalException, SystemException {
         ThemeDisplay themeDisplay = (ThemeDisplay) request.getAttribute(WebKeys.THEME_DISPLAY);
         long companyId = themeDisplay.getCompanyId();
         return UserLocalServiceUtil.getUserByEmailAddress(companyId, user.email);
     }
 
-    static void ensureUserCustomFieldExists(com.liferay.portal.model.User liferayUser, RenderRequest request) throws PortalException, SystemException {
+    static void ensureUserCustomFieldExists(com.liferay.portal.model.User liferayUser, PortletRequest request) throws PortalException, SystemException {
         ExpandoBridge exp = liferayUser.getExpandoBridge();
         if (!exp.hasAttribute(CUSTOM_FIELD_PROJECT_GROUP_FILTER)){
             exp.addAttribute(CUSTOM_FIELD_PROJECT_GROUP_FILTER, ExpandoColumnConstants.STRING, false);
@@ -174,7 +174,7 @@ public class ProjectPortletUtils {
         }
     }
 
-    static void saveStickyProjectGroup(RenderRequest request, User user, String groupFilterValue) {
+    static void saveStickyProjectGroup(PortletRequest request, User user, String groupFilterValue) {
         try {
             ExpandoBridge exp = getUserExpandoBridge(request, user);
             exp.setAttribute(CUSTOM_FIELD_PROJECT_GROUP_FILTER, groupFilterValue);
@@ -183,7 +183,7 @@ public class ProjectPortletUtils {
         }
     }
 
-    static String loadStickyProjectGroup(RenderRequest request, User user){
+    static String loadStickyProjectGroup(PortletRequest request, User user){
         try {
             ExpandoBridge exp = getUserExpandoBridge(request, user);
             return (String) exp.getAttribute(CUSTOM_FIELD_PROJECT_GROUP_FILTER);
@@ -193,7 +193,7 @@ public class ProjectPortletUtils {
         }
     }
 
-    private static ExpandoBridge getUserExpandoBridge(RenderRequest request, User user) throws PortalException, SystemException {
+    private static ExpandoBridge getUserExpandoBridge(PortletRequest request, User user) throws PortalException, SystemException {
         com.liferay.portal.model.User liferayUser = getLiferayUser(request, user);
         ensureUserCustomFieldExists(liferayUser, request);
         return liferayUser.getExpandoBridge();

--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -335,11 +335,11 @@ input[readonly].clickable {
     font-family: monospace;
 }
 
-.formatSelect {
-   width: 20em !important;
-   height: 25px !important;
-   margin-bottom: 0 !important;
-    padding:0 !important;
+#extendedByReleases, .formatSelect {
+   width: 20em;
+   height: 25px;
+   margin-bottom: 0;
+   padding:0;
 }
 
 .notificationBulletSpan {
@@ -398,5 +398,5 @@ input[readonly].clickable {
 }
 
 .clear-float {
-    clear:both;
+    clear:right;
 }

--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -335,6 +335,13 @@ input[readonly].clickable {
     font-family: monospace;
 }
 
+.formatSelect {
+   width: 20em !important;
+   height: 25px !important;
+   margin-bottom: 0 !important;
+    padding:0 !important;
+}
+
 .notificationBulletSpan {
     min-width: 25px;
     height: 25px;

--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -388,10 +388,15 @@ input[readonly].clickable {
 .formatedMessageForVulCheckedBy:before, .formatedMessageForVulComment:before{
     font-size: small;
 }
+
 .formatedMessageForVulCheckedBy:before {
     content: "Checked by: ";
 }
 
 .formatedMessageForVulComment:before {
     content: "Comment: ";
+}
+
+.clear-float {
+    clear:both;
 }

--- a/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
@@ -63,8 +63,6 @@
 <p class="pageHeader">
     <span class="pageHeaderBigSpan">Components</span> <span class="pageHeaderSmallSpan">(${componentList.size()})</span>
     <span class="pull-right">
-         <input type="button" id="exportbutton" class="addButton"
-                value="Export Components">
           <input type="button" class="addButton" onclick="window.location.href='<%=addComponentURL%>'"
                 value="Add Component">
     </span>
@@ -84,7 +82,7 @@
             <tr>
                 <td>
                     <input type="text" class="searchbar"
-                           id="keywordsearchinput" value="${searchfilter}"
+                           id="keywordsearchinput" value=""
                            onkeyup="useSearch('keywordsearchinput')"
                            name="<portlet:namespace/><%=PortalConstants.KEY_SEARCH_FILTER_TEXT%>">
                     <br/>
@@ -185,6 +183,14 @@
 </div>
 <div style="clear:both"></div>
 
+<span class="pull-right">
+        <select class="toplabelledInput, formatSelect" id="extendedExcelExport" name="extendedExcelExport">
+            <option value="false">Components only</option>
+            <option value="true">Components with releases</option>
+        </select>
+        <input type="button" class="addButton" id="exportExcelButton" value="Export Excel" class="addButton" onclick="exportExcel()"/>
+</span>
+
 <script>
     var oTable;
     var modal;
@@ -224,10 +230,21 @@
     function exportExcel(){
         var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RESOURCE_PHASE) %>')
                 .setParameter('<%=PortalConstants.ACTION%>', '<%=PortalConstants.EXPORT_TO_EXCEL%>');
-        portletURL.setParameter('<%=PortalConstants.KEY_SEARCH_TEXT%>', $('#keywordsearchinput').val());
+        portletURL.setParameter('<%=PortalConstants.KEY_SEARCH_FILTER_TEXT%>', $('#keywordsearchinput').val());
+        portletURL.setParameter('<%=PortalConstants.KEY_SEARCH_TEXT%>', $('#name_search').val());
+        portletURL.setParameter('<%=Component._Fields.CATEGORIES%>',$('#categories').val());
+        portletURL.setParameter('<%=Component._Fields.LANGUAGES%>',$('#languages').val());
+        portletURL.setParameter('<%=Component._Fields.SOFTWARE_PLATFORMS%>',$('#software_platforms').val());
+        portletURL.setParameter('<%=Component._Fields.OPERATING_SYSTEMS%>',$('#operating_systems').val());
+        portletURL.setParameter('<%=Component._Fields.VENDOR_NAMES%>',$('#vendor_names').val());
+        portletURL.setParameter('<%=Component._Fields.COMPONENT_TYPE%>',$('#component_type').val());
+        portletURL.setParameter('<%=Component._Fields.MAIN_LICENSE_IDS%>',$('#main_licenses').val());
+        portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>',$('#extendedExcelExport').val());
+
+        $('#keywordsearchinput').val("");
+        useSearch('keywordsearchinput');
 
         window.location.href=portletURL.toString();
-
     }
 
     function createComponentsTable() {

--- a/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
@@ -105,21 +105,21 @@
             <tr>
                 <td>
                     <label for="name_search">Name Search</label>
-                    <input type="text" class="searchbar" name="<portlet:namespace/><%=PortalConstants.KEY_SEARCH_TEXT%>"
+                    <input type="text" class="searchbar, filterInput" name="<portlet:namespace/><%=PortalConstants.KEY_SEARCH_TEXT%>"
                            value="${searchtext}" id="name_search">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="categories">Categories</label>
-                    <input type="text" class="searchbar" name="<portlet:namespace/><%=Component._Fields.CATEGORIES%>"
+                    <input type="text" class="searchbar, filterInput" name="<portlet:namespace/><%=Component._Fields.CATEGORIES%>"
                            value="${categories}" id="categories">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="component_type">Component Type</label>
-                    <select class="toplabelledInput" id="component_type" name="<portlet:namespace/><%=Component._Fields.COMPONENT_TYPE%>"
+                    <select class="toplabelledInput, filterInput" id="component_type" name="<portlet:namespace/><%=Component._Fields.COMPONENT_TYPE%>"
                             style="min-width: 162px; min-height: 28px;">
                         <option value="<%=PortalConstants.NO_FILTER%>" class="textlabel stackedLabel">Any</option>
                         <sw360:DisplayEnumOptions type="<%=ComponentType.class%>" selectedName="${componentType}" useStringValues="true"/>
@@ -129,14 +129,14 @@
             <tr>
                 <td>
                     <label for="languages">Languages</label>
-                    <input type="text" class="searchbar" name="<portlet:namespace/><%=Component._Fields.LANGUAGES%>"
+                    <input type="text" class="searchbar, filterInput" name="<portlet:namespace/><%=Component._Fields.LANGUAGES%>"
                            value="${languages}" id="languages">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="software_platforms">Software Platforms</label>
-                    <input type="text" class="searchbar"
+                    <input type="text" class="searchbar, filterInput"
                            name="<portlet:namespace/><%=Component._Fields.SOFTWARE_PLATFORMS%>"
                            value="${softwarePlatforms}" id="software_platforms">
                 </td>
@@ -144,7 +144,7 @@
             <tr>
                 <td>
                     <label for="operating_systems">Operating Systems</label>
-                    <input type="text" class="searchbar"
+                    <input type="text" class="searchbar, filterInput"
                            name="<portlet:namespace/><%=Component._Fields.OPERATING_SYSTEMS%>"
                            value="${operatingSystems}" id="operating_systems">
                 </td>
@@ -152,7 +152,7 @@
             <tr>
                 <td>
                     <label for="vendor_names">Vendors</label>
-                    <input type="text" class="searchbar"
+                    <input type="text" class="searchbar, filterInput"
                            name="<portlet:namespace/><%=Component._Fields.VENDOR_NAMES%>"
                            value="${vendorNames}" id="vendor_names">
                 </td>
@@ -160,7 +160,7 @@
             <tr>
                 <td>
                     <label for="main_licenses">Main Licenses</label>
-                    <input type="text" class="searchbar"
+                    <input type="text" class="searchbar, filterInput"
                            name="<portlet:namespace/><%=Component._Fields.MAIN_LICENSE_IDS%>"
                            value="${mainLicenseIds}" id="main_licenses">
                 </td>
@@ -199,6 +199,10 @@
     AUI().use('liferay-portlet-url', function (A) {
         PortletURL = Liferay.PortletURL;
         load();
+        $('.filterInput').on('input', function() {
+            $('#exportExcelButton').prop('disabled', true);
+            //when filters are actually applied, page is refreshed and exportExcelButton enabled automatically
+        });
     });
 
     //This can not be document ready function as liferay definitions need to be loaded first
@@ -228,6 +232,9 @@
     }
 
     function exportExcel(){
+        $('#keywordsearchinput').val("");
+        useSearch('keywordsearchinput');
+
         var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RESOURCE_PHASE) %>')
                 .setParameter('<%=PortalConstants.ACTION%>', '<%=PortalConstants.EXPORT_TO_EXCEL%>');
         portletURL.setParameter('<%=PortalConstants.KEY_SEARCH_FILTER_TEXT%>', $('#keywordsearchinput').val());
@@ -240,9 +247,6 @@
         portletURL.setParameter('<%=Component._Fields.COMPONENT_TYPE%>',$('#component_type').val());
         portletURL.setParameter('<%=Component._Fields.MAIN_LICENSE_IDS%>',$('#main_licenses').val());
         portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>',$('#extendedExcelExport').val());
-
-        $('#keywordsearchinput').val("");
-        useSearch('keywordsearchinput');
 
         window.location.href=portletURL.toString();
     }

--- a/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
@@ -105,21 +105,21 @@
             <tr>
                 <td>
                     <label for="name_search">Name Search</label>
-                    <input type="text" class="searchbar, filterInput" name="<portlet:namespace/><%=PortalConstants.KEY_SEARCH_TEXT%>"
+                    <input type="text" class="searchbar filterInput" name="<portlet:namespace/><%=PortalConstants.KEY_SEARCH_TEXT%>"
                            value="${searchtext}" id="name_search">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="categories">Categories</label>
-                    <input type="text" class="searchbar, filterInput" name="<portlet:namespace/><%=Component._Fields.CATEGORIES%>"
+                    <input type="text" class="searchbar filterInput" name="<portlet:namespace/><%=Component._Fields.CATEGORIES%>"
                            value="${categories}" id="categories">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="component_type">Component Type</label>
-                    <select class="toplabelledInput, filterInput" id="component_type" name="<portlet:namespace/><%=Component._Fields.COMPONENT_TYPE%>"
+                    <select class="toplabelledInput filterInput" id="component_type" name="<portlet:namespace/><%=Component._Fields.COMPONENT_TYPE%>"
                             style="min-width: 162px; min-height: 28px;">
                         <option value="<%=PortalConstants.NO_FILTER%>" class="textlabel stackedLabel">Any</option>
                         <sw360:DisplayEnumOptions type="<%=ComponentType.class%>" selectedName="${componentType}" useStringValues="true"/>
@@ -129,14 +129,14 @@
             <tr>
                 <td>
                     <label for="languages">Languages</label>
-                    <input type="text" class="searchbar, filterInput" name="<portlet:namespace/><%=Component._Fields.LANGUAGES%>"
+                    <input type="text" class="searchbar filterInput" name="<portlet:namespace/><%=Component._Fields.LANGUAGES%>"
                            value="${languages}" id="languages">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="software_platforms">Software Platforms</label>
-                    <input type="text" class="searchbar, filterInput"
+                    <input type="text" class="searchbar filterInput"
                            name="<portlet:namespace/><%=Component._Fields.SOFTWARE_PLATFORMS%>"
                            value="${softwarePlatforms}" id="software_platforms">
                 </td>
@@ -144,7 +144,7 @@
             <tr>
                 <td>
                     <label for="operating_systems">Operating Systems</label>
-                    <input type="text" class="searchbar, filterInput"
+                    <input type="text" class="searchbar filterInput"
                            name="<portlet:namespace/><%=Component._Fields.OPERATING_SYSTEMS%>"
                            value="${operatingSystems}" id="operating_systems">
                 </td>
@@ -152,7 +152,7 @@
             <tr>
                 <td>
                     <label for="vendor_names">Vendors</label>
-                    <input type="text" class="searchbar, filterInput"
+                    <input type="text" class="searchbar filterInput"
                            name="<portlet:namespace/><%=Component._Fields.VENDOR_NAMES%>"
                            value="${vendorNames}" id="vendor_names">
                 </td>
@@ -160,7 +160,7 @@
             <tr>
                 <td>
                     <label for="main_licenses">Main Licenses</label>
-                    <input type="text" class="searchbar, filterInput"
+                    <input type="text" class="searchbar filterInput"
                            name="<portlet:namespace/><%=Component._Fields.MAIN_LICENSE_IDS%>"
                            value="${mainLicenseIds}" id="main_licenses">
                 </td>
@@ -179,9 +179,7 @@
         </tr>
         </tfoot>
     </table>
-    <div class="sw360modal" id="vulnerabilityModal"></div>
 </div>
-<div style="clear:both"></div>
 
 <span class="pull-right">
         <select class="toplabelledInput, formatSelect" id="extendedExcelExport" name="extendedExcelExport">
@@ -193,7 +191,6 @@
 
 <script>
     var oTable;
-    var modal;
 
     var PortletURL;
     AUI().use('liferay-portlet-url', function (A) {
@@ -201,11 +198,9 @@
         load();
         $('.filterInput').on('input', function() {
             $('#exportExcelButton').prop('disabled', true);
-            //when filters are actually applied, page is refreshed and exportExcelButton enabled automatically
         });
     });
 
-    //This can not be document ready function as liferay definitions need to be loaded first
     function load() {
         prepareAutocompleteForMultipleHits('languages', ${programmingLanguages});
         prepareAutocompleteForMultipleHits('software_platforms', ${softwarePlatformsAutoC});
@@ -313,7 +308,6 @@
         }
 
     }
-
 </script>
 <%@include file="/html/utils/includes/modal.jspf" %>
 <%@include file="/html/utils/includes/vulnerabilityModal.jspf" %>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
@@ -180,9 +180,9 @@
         </tfoot>
     </table>
 </div>
-
+<div class="clear-float"></div>
 <span class="pull-right">
-        <select class="toplabelledInput, formatSelect" id="extendedExcelExport" name="extendedExcelExport">
+        <select class="toplabelledInput formatSelect" id="extendedByReleases" name="extendedByReleases">
             <option value="false">Components only</option>
             <option value="true">Components with releases</option>
         </select>
@@ -221,7 +221,6 @@
     }
 
     function useSearch(buttonId) {
-        //we only want to search names starting with the value in the search box
         var val = $.fn.dataTable.util.escapeRegex($('#' + buttonId).val());
         oTable.columns(1).search('^'+val, true).draw();
     }
@@ -232,7 +231,6 @@
 
         var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RESOURCE_PHASE) %>')
                 .setParameter('<%=PortalConstants.ACTION%>', '<%=PortalConstants.EXPORT_TO_EXCEL%>');
-        portletURL.setParameter('<%=PortalConstants.KEY_SEARCH_FILTER_TEXT%>', $('#keywordsearchinput').val());
         portletURL.setParameter('<%=PortalConstants.KEY_SEARCH_TEXT%>', $('#name_search').val());
         portletURL.setParameter('<%=Component._Fields.CATEGORIES%>',$('#categories').val());
         portletURL.setParameter('<%=Component._Fields.LANGUAGES%>',$('#languages').val());
@@ -241,7 +239,7 @@
         portletURL.setParameter('<%=Component._Fields.VENDOR_NAMES%>',$('#vendor_names').val());
         portletURL.setParameter('<%=Component._Fields.COMPONENT_TYPE%>',$('#component_type').val());
         portletURL.setParameter('<%=Component._Fields.MAIN_LICENSE_IDS%>',$('#main_licenses').val());
-        portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>',$('#extendedExcelExport').val());
+        portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>',$('#extendedByReleases').val());
 
         window.location.href=portletURL.toString();
     }

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -72,8 +72,6 @@
     <span class="pull-right">
         <input type="button" id="importbutton" class="addButton"
                value="Import Projects" onclick="window.location.href='/group/guest/import/'" />
-        <input type="button" id="exportbutton" class="addButton"
-               value="Export Projects" />
         <input type="button" class="addButton" onclick="window.location.href='<%=addProjectURL%>'" value="Add Project" />
     </span>
 </p>
@@ -178,6 +176,14 @@
         </tfoot>
     </table>
 </div>
+
+<span class="pull-right">
+        <select class="toplabelledInput, formatSelect" id="extendedExcelExport" name="extendedExcelExport">
+            <option value="false">Projects only</option>
+            <option value="true">Projects with linked releases</option>
+        </select>
+        <input type="button" class="addButton" id="exportExcelButton" value="Export Excel" class="addButton" onclick="exportExcel()"/>
+</span>
 
 
 <div id="fossologyClearing" title="Fossology Clearing" style="display: none; background-color: #ffffff;">
@@ -301,9 +307,15 @@
          var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RESOURCE_PHASE) %>')
                  .setParameter('<%=PortalConstants.ACTION%>', '<%=PortalConstants.EXPORT_TO_EXCEL%>');
          portletURL.setParameter('<%=PortalConstants.KEY_SEARCH_TEXT%>', $('#keywordsearchinput').val());
+         portletURL.setParameter('<%=Project._Fields.NAME%>',$('#project_name').val());
+         portletURL.setParameter('<%=Project._Fields.TYPE%>',$('#project_type').val());
+         portletURL.setParameter('<%=Project._Fields.PROJECT_RESPONSIBLE%>',$('#project_responsible').val());
+         portletURL.setParameter('<%=Project._Fields.BUSINESS_UNIT%>',$('#group').val());
+         portletURL.setParameter('<%=Project._Fields.STATE%>',$('#state').val());
+         portletURL.setParameter('<%=Project._Fields.TAG%>',$('#tag').val());
+         portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>',$('#extendedExcelExport').val());
 
          window.location.href = portletURL.toString();
-
      }
 
      function openSelectClearingDialog(projectId, fieldId) {

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -306,6 +306,9 @@
      }
 
      function exportExcel() {
+         $('#keywordsearchinput').val("");
+         useSearch('keywordsearchinput');
+
          var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RESOURCE_PHASE) %>')
                  .setParameter('<%=PortalConstants.ACTION%>', '<%=PortalConstants.EXPORT_TO_EXCEL%>');
          portletURL.setParameter('<%=Project._Fields.NAME%>',$('#project_name').val());

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -176,7 +176,7 @@
         </tfoot>
     </table>
 </div>
-<span class="clear-float"/>
+<div class="clear-float"></div>
 <span class="pull-right">
         <select class="toplabelledInput formatSelect" id="extendedByReleases" name="extendedByReleases">
             <option value="false">Projects only</option>
@@ -281,7 +281,7 @@
              search: {smart: false},
              "aoColumns": [
                  {title: "Project Name", data: "name", render: {display: renderProjectNameLink}},
-                 {title: "Description", data: "description"},// render: {display: displayEscaped}},
+                 {title: "Description", data: "description"},
                  {title: "Project Responsible", data: "responsible"},
                  {title: "State", data: "state", render: {display: displayEscaped}},
                  {title: "Clearing Status", data: "clearing"},
@@ -292,23 +292,20 @@
          $('#projectsTable_filter').hide();
          $('#projectsTable_first').hide();
          $('#projectsTable_last').hide();
-    }
+     }
 
 
-    function createUrl_comp(paramId, paramVal) {
+     function createUrl_comp(paramId, paramVal) {
          var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>')
                  .setParameter('<%=PortalConstants.PAGENAME%>', '<%=PortalConstants.PAGENAME_DETAIL%>').setParameter(paramId, paramVal);
          return portletURL.toString();
-    }
+     }
 
-    function createDetailURLfromProjectId(paramVal) {
+     function createDetailURLfromProjectId(paramVal) {
          return createUrl_comp('<%=PortalConstants.PROJECT_ID%>', paramVal);
-    }
+     }
 
-    function exportExcel() {
-        $('#keywordsearchinput').val("");
-        useSearch('keywordsearchinput');
-
+     function exportExcel() {
          var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RESOURCE_PHASE) %>')
                  .setParameter('<%=PortalConstants.ACTION%>', '<%=PortalConstants.EXPORT_TO_EXCEL%>');
          portletURL.setParameter('<%=Project._Fields.NAME%>',$('#project_name').val());
@@ -322,14 +319,14 @@
          window.location.href = portletURL.toString();
     }
 
-    function openSelectClearingDialog(projectId, fieldId) {
+     function openSelectClearingDialog(projectId, fieldId) {
          $('#projectId').val(projectId);
 
          setFormSubmit(fieldId);
          fillClearingFormAndOpenDialog(projectId);
-    }
+     }
 
-    function deleteProject(projectId, name) {
+     function deleteProject(projectId, name) {
 
          if (confirm("Do you want to delete project " + name + " ?")) {
 
@@ -359,9 +356,9 @@
              });
 
          }
-    }
+     }
 
-    function fillClearingFormAndOpenDialog(projectId) {
+     function fillClearingFormAndOpenDialog(projectId) {
          jQuery.ajax({
              type: 'POST',
              url: '<%=projectReleasesAjaxURL%>',
@@ -377,9 +374,9 @@
                  alert("I could not get any releases!");
              }
          });
-    }
+     }
 
-    function setFormSubmit(fieldId) {
+     function setFormSubmit(fieldId) {
          $('#fossologyClearingForm').submit(function (e) {
              e.preventDefault();
              closeOpenDialogs();
@@ -406,11 +403,11 @@
 
          });
 
-    }
+     }
 
-    function selectAll(form) {
+     function selectAll(form) {
          $(form).find(':checkbox').prop("checked", true);
-    }
+     }
 
  </script>
 

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -315,6 +315,9 @@
          portletURL.setParameter('<%=Project._Fields.TAG%>',$('#tag').val());
          portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>',$('#extendedExcelExport').val());
 
+         $('#keywordsearchinput').val("");
+         useSearch('keywordsearchinput');
+
          window.location.href = portletURL.toString();
      }
 

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -113,27 +113,27 @@
                 <td>
                     <label for="project_name">Project Name</label>
                     <input type="text" style="width: 90%; padding: 5px; color: gray;height:20px;" name="<portlet:namespace/><%=Project._Fields.NAME%>"
-                           value="${name}" id="project_name">
+                           value="${name}" id="project_name" class="filterInput">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="project_type">Project Type</label>
                     <input type="text" style="width: 90%; padding: 5px; color: gray;height:20px;" name="<portlet:namespace/><%=Project._Fields.PROJECT_TYPE%>"
-                           value="${projectType}" id="project_type">
+                           value="${projectType}" id="project_type" class="filterInput">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="project_responsible">Project Responsible (Email)</label>
                     <input type="text" style="width: 90%; padding: 5px; color: gray;height:20px;" name="<portlet:namespace/><%=Project._Fields.PROJECT_RESPONSIBLE%>"
-                           value="${projectResponsible}" id="project_responsible">
+                           value="${projectResponsible}" id="project_responsible" class="filterInput">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="group">Group</label>
-                    <select class="toplabelledInput" id="group" name="<portlet:namespace/><%=Project._Fields.BUSINESS_UNIT%>"
+                    <select class="toplabelledInput, filterInput" id="group" name="<portlet:namespace/><%=Project._Fields.BUSINESS_UNIT%>"
                             style="width: 90%; padding: 5px; color: gray; min-height: 28px;">
                         <option value="" class="textlabel stackedLabel"
                                 <core_rt:if test="${empty businessUnit}"> selected="selected"</core_rt:if>
@@ -150,14 +150,14 @@
                 <td>
                     <label for="state">State</label>
                     <input type="text" style="width: 90%; padding: 5px; color: gray;height:20px;" name="<portlet:namespace/><%=Project._Fields.STATE%>"
-                           value="${state}" id="state">
+                           value="${state}" id="state" class="filterInput">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="tag">Tag</label>
                     <input type="text" style="width: 90%; padding: 5px; color: gray;height:20px;" name="<portlet:namespace/><%=Project._Fields.TAG%>"
-                           value="${tag}" id="tag">
+                           value="${tag}" id="tag" class="filterInput">
                 </td>
             </tr>
 
@@ -214,6 +214,10 @@
         PortletURL = Liferay.PortletURL;
         load();
         $('#exportbutton').click(exportExcel);
+        $('.filterInput').on('input', function() {
+            $('#exportExcelButton').prop('disabled', true);
+            //when filters are actually applied, page is refreshed and exportExcelButton enabled automatically
+        });
     });
 
     function useSearch(buttonId) {
@@ -290,20 +294,23 @@
          $('#projectsTable_filter').hide();
          $('#projectsTable_first').hide();
          $('#projectsTable_last').hide();
-     }
+    }
 
 
-     function createUrl_comp(paramId, paramVal) {
+    function createUrl_comp(paramId, paramVal) {
          var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>')
                  .setParameter('<%=PortalConstants.PAGENAME%>', '<%=PortalConstants.PAGENAME_DETAIL%>').setParameter(paramId, paramVal);
          return portletURL.toString();
-     }
+    }
 
-     function createDetailURLfromProjectId(paramVal) {
+    function createDetailURLfromProjectId(paramVal) {
          return createUrl_comp('<%=PortalConstants.PROJECT_ID%>', paramVal);
-     }
+    }
 
-     function exportExcel() {
+    function exportExcel() {
+        $('#keywordsearchinput').val("");
+        useSearch('keywordsearchinput');
+
          var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RESOURCE_PHASE) %>')
                  .setParameter('<%=PortalConstants.ACTION%>', '<%=PortalConstants.EXPORT_TO_EXCEL%>');
          portletURL.setParameter('<%=PortalConstants.KEY_SEARCH_TEXT%>', $('#keywordsearchinput').val());
@@ -315,20 +322,17 @@
          portletURL.setParameter('<%=Project._Fields.TAG%>',$('#tag').val());
          portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>',$('#extendedExcelExport').val());
 
-         $('#keywordsearchinput').val("");
-         useSearch('keywordsearchinput');
-
          window.location.href = portletURL.toString();
-     }
+    }
 
-     function openSelectClearingDialog(projectId, fieldId) {
+    function openSelectClearingDialog(projectId, fieldId) {
          $('#projectId').val(projectId);
 
          setFormSubmit(fieldId);
          fillClearingFormAndOpenDialog(projectId);
-     }
+    }
 
-     function deleteProject(projectId, name) {
+    function deleteProject(projectId, name) {
 
          if (confirm("Do you want to delete project " + name + " ?")) {
 
@@ -358,9 +362,9 @@
              });
 
          }
-     }
+    }
 
-     function fillClearingFormAndOpenDialog(projectId) {
+    function fillClearingFormAndOpenDialog(projectId) {
          jQuery.ajax({
              type: 'POST',
              url: '<%=projectReleasesAjaxURL%>',
@@ -376,9 +380,9 @@
                  alert("I could not get any releases!");
              }
          });
-     }
+    }
 
-     function setFormSubmit(fieldId) {
+    function setFormSubmit(fieldId) {
          $('#fossologyClearingForm').submit(function (e) {
              e.preventDefault();
              closeOpenDialogs();
@@ -405,11 +409,11 @@
 
          });
 
-     }
+    }
 
-     function selectAll(form) {
+    function selectAll(form) {
          $(form).find(':checkbox').prop("checked", true);
-     }
+    }
 
  </script>
 

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -176,9 +176,9 @@
         </tfoot>
     </table>
 </div>
-
+<span class="clear-float"/>
 <span class="pull-right">
-        <select class="toplabelledInput, formatSelect" id="extendedExcelExport" name="extendedExcelExport">
+        <select class="toplabelledInput formatSelect" id="extendedByReleases" name="extendedByReleases">
             <option value="false">Projects only</option>
             <option value="true">Projects with linked releases</option>
         </select>
@@ -216,12 +216,10 @@
         $('#exportbutton').click(exportExcel);
         $('.filterInput').on('input', function() {
             $('#exportExcelButton').prop('disabled', true);
-            //when filters are actually applied, page is refreshed and exportExcelButton enabled automatically
         });
     });
 
     function useSearch(buttonId) {
-        //we only want to search names starting with the value in the search box
         var val = $.fn.dataTable.util.escapeRegex($('#' + buttonId).val());
         oTable.columns(0).search('^' + val, true).draw();
     }
@@ -313,14 +311,13 @@
 
          var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RESOURCE_PHASE) %>')
                  .setParameter('<%=PortalConstants.ACTION%>', '<%=PortalConstants.EXPORT_TO_EXCEL%>');
-         portletURL.setParameter('<%=PortalConstants.KEY_SEARCH_TEXT%>', $('#keywordsearchinput').val());
          portletURL.setParameter('<%=Project._Fields.NAME%>',$('#project_name').val());
          portletURL.setParameter('<%=Project._Fields.TYPE%>',$('#project_type').val());
          portletURL.setParameter('<%=Project._Fields.PROJECT_RESPONSIBLE%>',$('#project_responsible').val());
          portletURL.setParameter('<%=Project._Fields.BUSINESS_UNIT%>',$('#group').val());
          portletURL.setParameter('<%=Project._Fields.STATE%>',$('#state').val());
          portletURL.setParameter('<%=Project._Fields.TAG%>',$('#tag').val());
-         portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>',$('#extendedExcelExport').val());
+         portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>',$('#extendedByReleases').val());
 
          window.location.href = portletURL.toString();
     }

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ComponentExporter.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ComponentExporter.java
@@ -55,7 +55,7 @@ public class ComponentExporter extends ExcelExporter<Component> {
         }
 
         @Override
-        public ExcelSubTable makeRows(Component component) {
+        public SubTable makeRows(Component component) {
             List<String> row = new ArrayList<>(getColumns());
 
             row.add(nullToEmpty(component.name));
@@ -67,7 +67,7 @@ public class ComponentExporter extends ExcelExporter<Component> {
             row.add(nullToEmpty(component.createdOn));
             row.add(joinStrings(getVersions(component.releases)));
 
-            return new ExcelSubTable(row);
+            return new SubTable(row);
         }
 
         private static List<String> getVersions(Collection<Release> releases) {

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ComponentExporter.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ComponentExporter.java
@@ -55,7 +55,7 @@ public class ComponentExporter extends ExcelExporter<Component> {
         }
 
         @Override
-        public List<String> makeRow(Component component) {
+        public ExcelSubTable makeRows(Component component) {
             List<String> row = new ArrayList<>(getColumns());
 
             row.add(nullToEmpty(component.name));
@@ -67,7 +67,7 @@ public class ComponentExporter extends ExcelExporter<Component> {
             row.add(nullToEmpty(component.createdOn));
             row.add(joinStrings(getVersions(component.releases)));
 
-            return row;
+            return new ExcelSubTable(row);
         }
 
         private static List<String> getVersions(Collection<Release> releases) {

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExcelExporter.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExcelExporter.java
@@ -71,7 +71,7 @@ public class ExcelExporter<T> {
         int nextExcelSheetRow = 1;
         for (int currentDocNumber = 0; currentDocNumber < numberoOfDocuments; currentDocNumber++) {
             T document = documents.get(currentDocNumber);
-            ExcelSubTable table = helper.makeRows(document);
+            SubTable table = helper.makeRows(document);
             for(int currentTableRow = 0; currentTableRow < table.getnRows(); currentTableRow ++){
                 List<String> rowValues = table.getRow(currentTableRow);
                 Row row = sheet.createRow(nextExcelSheetRow);

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExcelExporter.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExcelExporter.java
@@ -84,9 +84,9 @@ public class ExcelExporter<T> {
     /**
      * Write the values into the row, setting the cells to the given style
      */
-    private void fillRow(Row row, List<String> values, CellStyle style) throws SW360Exception{
+    private void fillRow(Row row, List<String> values, CellStyle style) {
         if(values.size() < helper.getColumns()){
-            throw new SW360Exception("List of row values is too short.");
+            throw new IllegalArgumentException("List of row values is too short.");
         }
         for (int column = 0; column < helper.getColumns(); column++) {
             Cell cell = row.createCell(column);

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExcelExporter.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExcelExporter.java
@@ -9,6 +9,7 @@
 package com.siemens.sw360.exporter;
 
 
+import com.siemens.sw360.datahandler.thrift.SW360Exception;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFFont;
@@ -29,20 +30,17 @@ public class ExcelExporter<T> {
 
     private final ExporterHelper<T> helper;
 
-    private final int nColumns;
-
     public ExcelExporter(ExporterHelper<T> helper) {
         this.helper = helper;
-        nColumns = helper.getColumns();
     }
 
-    public InputStream makeExcelExport(List<T> documents) throws IOException {
+    public InputStream makeExcelExport(List<T> documents) throws IOException, SW360Exception {
         final Workbook workbook = new XSSFWorkbook();
 
-        Sheet sheet = workbook.createSheet("Component Data");
+        Sheet sheet = workbook.createSheet("Data");
 
         /** Adding styles to cells */
-        CellStyle cellStyte = createCellStyte(workbook);
+        CellStyle cellStyle = createCellStyle(workbook);
         CellStyle headerStyle = createHeaderStyle(workbook);
 
         /** Create header row */
@@ -51,10 +49,10 @@ public class ExcelExporter<T> {
         fillRow(headerRow, headerNames, headerStyle);
 
         /** Create data rows */
-        fillValues(sheet, documents, cellStyte);
+        fillValues(sheet, documents, cellStyle);
 
         /** Resize the columns */
-        for (int iColumns = 0; iColumns < nColumns; iColumns++) {
+        for (int iColumns = 0; iColumns < helper.getColumns(); iColumns++) {
             sheet.autoSizeColumn(iColumns);
         }
 
@@ -68,21 +66,29 @@ public class ExcelExporter<T> {
     /**
      * Convert all documents to
      */
-    private void fillValues(Sheet sheet, List<T> documents, CellStyle style) {
-        int nRow = documents.size();
-        for (int iRow = 0; iRow < nRow; iRow++) {
-            T document = documents.get(iRow);
-            List<String> values = helper.makeRow(document);
-            Row row = sheet.createRow(iRow + 1); // Since 0 is used for headers
-            fillRow(row, values, style);
+    private void fillValues(Sheet sheet, List<T> documents, CellStyle style) throws SW360Exception {
+        int numberoOfDocuments = documents.size();
+        int nextExcelSheetRow = 1;
+        for (int currentDocNumber = 0; currentDocNumber < numberoOfDocuments; currentDocNumber++) {
+            T document = documents.get(currentDocNumber);
+            ExcelSubTable table = helper.makeRows(document);
+            for(int currentTableRow = 0; currentTableRow < table.getnRows(); currentTableRow ++){
+                List<String> rowValues = table.getRow(currentTableRow);
+                Row row = sheet.createRow(nextExcelSheetRow);
+                nextExcelSheetRow++;
+                fillRow(row, rowValues, style);
+            }
         }
     }
 
     /**
      * Write the values into the row, setting the cells to the given style
      */
-    private void fillRow(Row row, List<String> values, CellStyle style) {
-        for (int column = 0; column < nColumns; column++) {
+    private void fillRow(Row row, List<String> values, CellStyle style) throws SW360Exception{
+        if(values.size() < helper.getColumns()){
+            throw new SW360Exception("List of row values is too short.");
+        }
+        for (int column = 0; column < helper.getColumns(); column++) {
             Cell cell = row.createCell(column);
             cell.setCellValue(values.get(column));
             cell.setCellStyle(style);
@@ -92,7 +98,7 @@ public class ExcelExporter<T> {
     /**
      * Create style for data cells
      */
-    private static CellStyle createCellStyte(Workbook workbook) {
+    private static CellStyle createCellStyle(Workbook workbook) {
         CellStyle cellStyle = workbook.createCellStyle();
         cellStyle.setBorderBottom(XSSFCellStyle.BORDER_THIN);
         cellStyle.setBorderTop(XSSFCellStyle.BORDER_THIN);
@@ -105,11 +111,10 @@ public class ExcelExporter<T> {
      * Create header style, same has cell style but with bold font
      */
     private static CellStyle createHeaderStyle(Workbook workbook) {
-        CellStyle headerCellStyle = createCellStyte(workbook);
+        CellStyle headerCellStyle = createCellStyle(workbook);
         Font font = workbook.createFont();
         font.setBoldweight(XSSFFont.BOLDWEIGHT_BOLD);
         headerCellStyle.setFont(font);
         return headerCellStyle;
     }
-
 }

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExcelSubTable.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExcelSubTable.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
+ * With modifications by Bosch Software Innovations GmbH, 2016.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.siemens.sw360.exporter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExcelSubTable {
+
+    List<List<String>> elements;
+
+    public int getnRows() {
+        return elements.size();
+    }
+
+    List<String> getRow(int rowNumber) {
+        return elements.get(rowNumber);
+    }
+
+    public ExcelSubTable(List<String> row) {
+        elements = new ArrayList<>();
+        elements.add(row);
+    }
+
+    public ExcelSubTable() {
+        elements = new ArrayList<>();
+    }
+
+    public void addRow(List<String> row) {
+        elements.add(row);
+    }
+}

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExporterHelper.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExporterHelper.java
@@ -9,6 +9,8 @@
 
 package com.siemens.sw360.exporter;
 
+import com.siemens.sw360.datahandler.thrift.SW360Exception;
+
 import java.util.List;
 
 /**
@@ -22,6 +24,6 @@ public interface ExporterHelper<T> {
 
     public List<String> getHeaders();
 
-    public SubTable makeRows(T document);
+    public SubTable makeRows(T document) throws SW360Exception;
 
 }

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExporterHelper.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExporterHelper.java
@@ -22,6 +22,6 @@ public interface ExporterHelper<T> {
 
     public List<String> getHeaders();
 
-    public ExcelSubTable makeRows(T document);
+    public SubTable makeRows(T document);
 
 }

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExporterHelper.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ExporterHelper.java
@@ -22,6 +22,6 @@ public interface ExporterHelper<T> {
 
     public List<String> getHeaders();
 
-    public List<String> makeRow(T document);
+    public ExcelSubTable makeRows(T document);
 
 }

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/LicenseExporter.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/LicenseExporter.java
@@ -9,17 +9,17 @@
  */
 package com.siemens.sw360.exporter;
 
-import com.siemens.sw360.datahandler.thrift.licenses.License;
 import com.siemens.sw360.commonIO.ConvertRecord;
+import com.siemens.sw360.datahandler.thrift.licenses.License;
 import com.siemens.sw360.datahandler.thrift.licenses.LicenseType;
 import org.apache.log4j.Logger;
-
-import static com.siemens.sw360.commonIO.ConvertRecord.*;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
+import static com.siemens.sw360.commonIO.ConvertRecord.licenseSerializer;
 
 /**
  * Created by bodet on 10/02/15.
@@ -81,8 +81,10 @@ public class LicenseExporter extends ExcelExporter<License> {
         }
 
         @Override
-        public List<String> makeRow(License license) {
-            return formatRow(converter.transformer().apply(license));
+        public ExcelSubTable makeRows(License license) {
+            return new ExcelSubTable(
+                    formatRow(converter.transformer().apply(license))
+            );
         }
     }
 

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/LicenseExporter.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/LicenseExporter.java
@@ -81,8 +81,8 @@ public class LicenseExporter extends ExcelExporter<License> {
         }
 
         @Override
-        public ExcelSubTable makeRows(License license) {
-            return new ExcelSubTable(
+        public SubTable makeRows(License license) {
+            return new SubTable(
                     formatRow(converter.transformer().apply(license))
             );
         }

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ProjectExporter.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ProjectExporter.java
@@ -10,66 +10,80 @@
 package com.siemens.sw360.exporter;
 
 import com.google.common.collect.ImmutableList;
-import com.siemens.sw360.datahandler.common.ThriftEnumUtils;
+import com.siemens.sw360.datahandler.common.SW360Utils;
 import com.siemens.sw360.datahandler.thrift.components.ComponentService;
 import com.siemens.sw360.datahandler.thrift.components.Release;
 import com.siemens.sw360.datahandler.thrift.projects.Project;
+import com.siemens.sw360.exporter.ReleaseExporter.ReleaseHelper;
 import org.apache.log4j.Logger;
-import org.apache.thrift.TEnum;
 import org.apache.thrift.TException;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Strings.nullToEmpty;
 import static com.siemens.sw360.datahandler.common.CommonUtils.joinStrings;
-import static com.siemens.sw360.datahandler.common.SW360Utils.printName;
+import static com.siemens.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static com.siemens.sw360.datahandler.thrift.projects.Project._Fields.*;
 
-/**
- * Created by bodet on 06/02/15.
- *
- * @author cedric.bodet@tngtech.com
- */
 public class ProjectExporter extends ExcelExporter<Project> {
 
-
-    public static final List<Project._Fields> RENDERED_FIELDS = ImmutableList.<Project._Fields>builder()
-            .add(ID)
-            .add(NAME)
-            .add(STATE)
-            .add(CREATED_BY)
-            .add(CREATED_ON)
-            .add(PROJECT_RESPONSIBLE)
-            .add(LEAD_ARCHITECT)
-            .add(TAG)
-            .add(BUSINESS_UNIT)
-            .add(RELEASE_IDS)
-            .add(RELEASE_CLEARING_STATE_SUMMARY)
-            .add(EXTERNAL_IDS)
-            .build();
-
-
-
     private static final Logger log = Logger.getLogger(ProjectExporter.class);
+    private static boolean extendedByReleases;
+    private static ReleaseHelper releaseHelper;
 
-    protected static final List<String> HEADERS = ImmutableList.<String>builder()
-            .add("Project ID")
-            .add("Project Name")
-            .add("Project State")
-            .add("Created by")
-            .add("Creation Date")
-            .add("Project Responsible")
-            .add("Project Lead Architect")
-            .add("Project Tag")
-            .add("Group")
-            .add("Release IDs")
-            .add("ReleaseClearingStateSummary")
-            .add("External Ids")
+    public static final Map<String, String> nameToDisplayName;
+    static {
+        nameToDisplayName = new HashMap<>();
+        nameToDisplayName.put("id", "project ID");
+        nameToDisplayName.put("name", "project name");
+        nameToDisplayName.put("state", "project state");
+        nameToDisplayName.put("createdBy", "created by");
+        nameToDisplayName.put("createdOn", "creation date");
+        nameToDisplayName.put("projectResponsible", "project responsible");
+        nameToDisplayName.put("leadArchitect", "project lead architect");
+        nameToDisplayName.put("tag", "project tag");
+        nameToDisplayName.put("businessUnit", "group");
+        nameToDisplayName.put("releaseIds", "release IDs");
+        nameToDisplayName.put("releaseClearingStateSummary", "release clearing state summary");
+        nameToDisplayName.put("externalIds", "external IDs");
+        nameToDisplayName.put("visbility", "visibility");
+        nameToDisplayName.put("projectType", "project type");
+        nameToDisplayName.put("linkedProjects", "linked projects");
+        nameToDisplayName.put("releaseIdToUsage", "release IDs with usage");
+        nameToDisplayName.put("clearingTeam", "clearing team");
+        nameToDisplayName.put("preevaluationDeadline", "pre-evaluation deadline");
+        nameToDisplayName.put("systemTestStart", "system test start");
+        nameToDisplayName.put("systemTestEnd", "system test end");
+        nameToDisplayName.put("deliveryStart", "delivery start");
+        nameToDisplayName.put("phaseOutSince", "phase out since");
+    }
+
+    private static final List<Project._Fields> IGNORED_FIELDS = ImmutableList.<Project._Fields>builder()
+            .add(REVISION)
+            .add(ATTACHMENTS)
+            .add(DOCUMENT_STATE)
+            .add(PERMISSIONS)
             .build();
 
-    public ProjectExporter(ComponentService.Iface client) {
+    public static final List<Project._Fields> RENDERED_FIELDS = Project.metaDataMap.keySet()
+            .stream()
+            .filter(k -> ! IGNORED_FIELDS.contains(k))
+            .collect(Collectors.toList());
+
+    protected static List<String> HEADERS = new ArrayList<>();
+
+    public ProjectExporter(ComponentService.Iface client, boolean extendedByReleases) {
         super(new ProjectHelper(client));
+        releaseHelper = new ReleaseHelper();
+        this.extendedByReleases = extendedByReleases;
+        HEADERS = RENDERED_FIELDS
+                .stream()
+                .map(Project._Fields::getFieldName)
+                .map(n -> SW360Utils.displayNameFor(n, nameToDisplayName))
+                .collect(Collectors.toList());
+        if (extendedByReleases) {
+            ((ArrayList) HEADERS).addAll(releaseHelper.getHeaders());
+        }
     }
 
     private static class ProjectHelper implements ExporterHelper<Project> {
@@ -91,53 +105,68 @@ public class ProjectExporter extends ExcelExporter<Project> {
         }
 
         @Override
-        public List<String> makeRow(Project project) {
+        public ExcelSubTable makeRows(Project project) {
+            if (extendedByReleases) {
+                return makeRowsWithReleases(project);
+            } else {
+                return new ExcelSubTable(makeRowForProjectOnly(project));
+            }
+        }
+
+        private ExcelSubTable makeRowsWithReleases(Project project) {
+            List<Release> releases = getReleases(project);
+            ExcelSubTable table = new ExcelSubTable();
+
+            if(releases.size() >0) {
+                for (Release release : releases) {
+                    List<String> currentRow = makeRowForProjectOnly(project);
+                    currentRow.addAll(releaseHelper.makeRows(release).elements.get(0));
+                    table.addRow(currentRow);
+                }
+            } else {
+                List<String> projectRowWithEmptyReleaseFields = makeRowForProjectOnly(project);
+                for(int i = 0; i < releaseHelper.getColumns(); i++){
+                    projectRowWithEmptyReleaseFields.add("");
+                }
+                table.addRow(projectRowWithEmptyReleaseFields);
+            }
+            return table;
+        }
+
+        private List<String> makeRowForProjectOnly(Project project) {
             List<String> row = new ArrayList<>(getColumns());
 
             for (Project._Fields renderedField : RENDERED_FIELDS) {
-                Object fieldValue = project.getFieldValue(renderedField);
+                if(project.isSet(renderedField)) {
+                    Object fieldValue = project.getFieldValue(renderedField);
 
-                if (renderedField.equals(RELEASE_IDS)) {
-                    row.add(joinStrings(getReleases(project.releaseIds)));
-                }
-                else if (fieldValue instanceof TEnum) {
-                    row.add(nullToEmpty(ThriftEnumUtils.enumToString((TEnum) fieldValue)));
-                }
-                else if (fieldValue instanceof String ) {
-                    row.add(nullToEmpty((String) fieldValue));
-                }
-                else if (fieldValue instanceof Map) {
-                    List<String> mapEntriesAsStrings = ((Map <String, String>) fieldValue).entrySet().stream().map(e -> e.getKey() + " : "+ e.getValue()).collect(Collectors.toList());
-                    row.add(joinStrings(mapEntriesAsStrings));
-                }
-                else {
+                    if (renderedField.equals(RELEASE_IDS)) {
+                        row.add(joinStrings(getReleaseNames(project)));
+                    } else {
+                        row.add(SW360Utils.fieldValueAsString(fieldValue));
+                    }
+                } else {
                     row.add("");
                 }
-
             }
 
             return row;
         }
 
-        private List<String> getReleases(Set<String> ids) {
-            if (ids == null) return Collections.emptyList();
+        private List<String> getReleaseNames(Project project) {
+            if (project.releaseIds == null) return Collections.emptyList();
+            return getReleases(project).stream().map(SW360Utils::printName).collect(Collectors.toList());
+        }
 
-
+        private List<Release> getReleases(Project project) {
             List<Release> releasesByIdsForExport;
             try {
-                releasesByIdsForExport = client.getReleasesByIdsForExport(ids);
+                releasesByIdsForExport = client.getReleasesByIdsForExport(nullToEmptySet(project.releaseIds));
             } catch (TException e) {
                 log.error("Error fetching release information", e);
-                releasesByIdsForExport=Collections.emptyList();
+                releasesByIdsForExport = Collections.emptyList();
             }
-
-            List<String> releaseNames = new ArrayList<>(ids.size());
-
-            for (Release release : releasesByIdsForExport) {
-                releaseNames.add(printName(release));
-            }
-
-            return releaseNames;
+            return releasesByIdsForExport;
         }
     }
 

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ReleaseExporter.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ReleaseExporter.java
@@ -46,12 +46,11 @@ public class ReleaseExporter extends ExcelExporter<Release> {
         nameToDisplayName.put(Release._Fields.COTS_DETAILS.getFieldName(), "COTS details");
         nameToDisplayName.put(Release._Fields.MAIN_LICENSE_IDS.getFieldName(), "main license IDs");
         nameToDisplayName.put(Release._Fields.DOWNLOADURL.getFieldName(), "downloadurl");
-        nameToDisplayName.put(Release._Fields.RELEASE_ID_TO_RELATIONSHIP.getFieldName(), "release IDs with relationship");
+        nameToDisplayName.put(Release._Fields.RELEASE_ID_TO_RELATIONSHIP.getFieldName(), "releases with relationship");
     }
 
     private static final List<Release._Fields> IGNORED_FIELDS = ImmutableList.<Release._Fields>builder()
             .add(REVISION)
-            .add(ATTACHMENTS)
             .add(DOCUMENT_STATE)
             .add(PERMISSIONS)
             .add(VENDOR_ID)
@@ -123,6 +122,9 @@ public class ReleaseExporter extends ExcelExporter<Release> {
 
         @Override
         public SubTable makeRows(Release release) {
+            if(! release.isSetAttachments()){
+                release.setAttachments(Collections.EMPTY_SET);
+            }
             List<String> row = new ArrayList<>();
             for (Release._Fields field : RENDERED_FIELDS) {
                 switch (field) {
@@ -137,6 +139,9 @@ public class ReleaseExporter extends ExcelExporter<Release> {
                         break;
                     case RELEASE_ID_TO_RELATIONSHIP:
                         addReleaseIdToRelationShipToRow(release.getReleaseIdToRelationship(), row);
+                        break;
+                    case ATTACHMENTS:
+                        row.add(release.attachments.size()+"");
                         break;
                     default:
                         if (release.isSet(field)) {

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ReleaseExporter.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ReleaseExporter.java
@@ -9,40 +9,46 @@
 package com.siemens.sw360.exporter;
 
 import com.google.common.collect.ImmutableList;
-import com.siemens.sw360.datahandler.common.SW360Utils;
-import com.siemens.sw360.datahandler.thrift.components.Release;
+import com.siemens.sw360.datahandler.thrift.components.*;
+import com.siemens.sw360.datahandler.thrift.vendors.Vendor;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.siemens.sw360.datahandler.common.CommonUtils.nullToEmptySet;
+import static com.siemens.sw360.datahandler.common.SW360Utils.*;
 import static com.siemens.sw360.datahandler.thrift.components.Release._Fields.*;
 
 
 public class ReleaseExporter extends ExcelExporter<Release> {
+
+    private static final Logger log = Logger.getLogger(ReleaseExporter.class);
     public static final Map<String, String> nameToDisplayName;
+
     static {
         nameToDisplayName = new HashMap<>();
-        nameToDisplayName.put("id", "release ID");
-        nameToDisplayName.put("cpeid", "CPE ID");
-        nameToDisplayName.put("componentId", "component ID");
-        nameToDisplayName.put("releaseDate", "release date");
-        nameToDisplayName.put("externalids", "external IDs");
-        nameToDisplayName.put("createdOn", "created on");
-        nameToDisplayName.put("createdBy", "created by");
-        nameToDisplayName.put("mainlineState", "mainline state");
-        nameToDisplayName.put("clearingState", "clearing state");
-        nameToDisplayName.put("fossologyId", "fossology id");
-        nameToDisplayName.put("clearingTeamToFossologyStatus", "clearing team with FOSSology status");
-        nameToDisplayName.put("attachmentInFossology", "attachment in FOSSology");
-        nameToDisplayName.put("clearingInformation", "clearing information");
-        nameToDisplayName.put("cotsDetails", "COTS details");
-        nameToDisplayName.put("mainLicenseIds", "main license IDs");
-        nameToDisplayName.put("downloadurl", "downloadurl");
-        nameToDisplayName.put("releaseIdToRelationship", "release IDs with relationship");
+        nameToDisplayName.put(Release._Fields.ID.getFieldName(), "release ID");
+        nameToDisplayName.put(Release._Fields.CPEID.getFieldName(), "CPE ID");
+        nameToDisplayName.put(Release._Fields.COMPONENT_ID.getFieldName(), "component ID");
+        nameToDisplayName.put(Release._Fields.RELEASE_DATE.getFieldName(), "release date");
+        nameToDisplayName.put(Release._Fields.EXTERNAL_IDS.getFieldName(), "external IDs");
+        nameToDisplayName.put(Release._Fields.CREATED_ON.getFieldName(), "created on");
+        nameToDisplayName.put(Release._Fields.CREATED_BY.getFieldName(), "created by");
+        nameToDisplayName.put(Release._Fields.MAINLINE_STATE.getFieldName(), "mainline state");
+        nameToDisplayName.put(Release._Fields.CLEARING_STATE.getFieldName(), "clearing state");
+        nameToDisplayName.put(Release._Fields.FOSSOLOGY_ID.getFieldName(), "fossology id");
+        nameToDisplayName.put(Release._Fields.CLEARING_TEAM_TO_FOSSOLOGY_STATUS.getFieldName(),
+                "clearing team with FOSSology status");
+        nameToDisplayName.put(Release._Fields.ATTACHMENT_IN_FOSSOLOGY.getFieldName(), "attachment in FOSSology");
+        nameToDisplayName.put(Release._Fields.CLEARING_INFORMATION.getFieldName(), "clearing information");
+        nameToDisplayName.put(Release._Fields.COTS_DETAILS.getFieldName(), "COTS details");
+        nameToDisplayName.put(Release._Fields.MAIN_LICENSE_IDS.getFieldName(), "main license IDs");
+        nameToDisplayName.put(Release._Fields.DOWNLOADURL.getFieldName(), "downloadurl");
+        nameToDisplayName.put(Release._Fields.RELEASE_ID_TO_RELATIONSHIP.getFieldName(), "release IDs with relationship");
     }
+
     private static final List<Release._Fields> IGNORED_FIELDS = ImmutableList.<Release._Fields>builder()
             .add(REVISION)
             .add(ATTACHMENTS)
@@ -51,27 +57,59 @@ public class ReleaseExporter extends ExcelExporter<Release> {
             .add(VENDOR_ID)
             .build();
 
+    private static final List<Vendor._Fields> VENDOR_IGNORED_FIELDS = ImmutableList.<Vendor._Fields>builder()
+            .add(Vendor._Fields.PERMISSIONS)
+            .add(Vendor._Fields.REVISION)
+            .add(Vendor._Fields.ID)
+            .add(Vendor._Fields.TYPE)
+            .build();
+
     public static final List<Release._Fields> RENDERED_FIELDS = Release.metaDataMap.keySet()
             .stream()
-            .filter(k -> ! IGNORED_FIELDS.contains(k))
+            .filter(k -> !IGNORED_FIELDS.contains(k))
             .collect(Collectors.toList());
 
     private static final List<String> HEADERS = makeHeaders();
 
-    public ReleaseExporter() {
-        super(new ReleaseHelper());
+    public ReleaseExporter(ComponentService.Iface client) {
+        super(new ReleaseHelper(client));
     }
 
-    private static List<String> makeHeaders(){
-        List<String> headers = RENDERED_FIELDS
-                .stream()
-                .map(Release._Fields::getFieldName)
-                .map(n -> SW360Utils.displayNameFor(n, nameToDisplayName))
-                .collect(Collectors.toList());
+    private static List<String> makeHeaders() {
+        List<String> headers = new ArrayList();
+        for (Release._Fields field : RENDERED_FIELDS) {
+            addToHeaders(headers, field);
+        }
         return headers;
     }
 
+    private static void addToHeaders(List<String> headers, Release._Fields field) {
+        switch (field) {
+            case VENDOR:
+                Vendor.metaDataMap.keySet().stream()
+                        .filter(f -> ! VENDOR_IGNORED_FIELDS.contains(f))
+                        .forEach(f -> headers.add("vendor " + f.getFieldName()));
+                break;
+            case COTS_DETAILS:
+                COTSDetails.metaDataMap.keySet().stream()
+                        .forEach(f -> headers.add("COTS details: " + f.getFieldName()));
+                break;
+            case CLEARING_INFORMATION:
+                ClearingInformation.metaDataMap.keySet().stream()
+                        .forEach(f -> headers.add("clearing information: " + f.getFieldName()));
+                break;
+            default:
+                headers.add(displayNameFor(field.getFieldName(), nameToDisplayName));
+        }
+    }
+
     protected static class ReleaseHelper implements ExporterHelper<Release> {
+
+        private final ComponentService.Iface client;
+
+        protected ReleaseHelper(ComponentService.Iface client) {
+            this.client = client;
+        }
 
         @Override
         public int getColumns() {
@@ -84,18 +122,103 @@ public class ReleaseExporter extends ExcelExporter<Release> {
         }
 
         @Override
-        public ExcelSubTable makeRows(Release release) {
-            List<String> row = new ArrayList<>(getColumns());
-            for(Release._Fields field : RENDERED_FIELDS){
-                if(release.isSet(field)) {
-                    Object fieldValue = release.getFieldValue(field);
-                    row.add(SW360Utils.fieldValueAsString(fieldValue));
-                } else {
-                    row.add("");
+        public SubTable makeRows(Release release) {
+            List<String> row = new ArrayList<>();
+            for (Release._Fields field : RENDERED_FIELDS) {
+                switch (field) {
+                    case VENDOR:
+                        addVendorToRow(release.getVendor(), row);
+                        break;
+                    case COTS_DETAILS:
+                        addCotsDetailsToRow(release.getCotsDetails(), row);
+                        break;
+                    case CLEARING_INFORMATION:
+                        addClearingInformationToRow(release.getClearingInformation(), row);
+                        break;
+                    case RELEASE_ID_TO_RELATIONSHIP:
+                        addReleaseIdToRelationShipToRow(release.getReleaseIdToRelationship(), row);
+                        break;
+                    default:
+                        if (release.isSet(field)) {
+                            Object fieldValue = release.getFieldValue(field);
+                            row.add(fieldValueAsString(fieldValue));
+                        } else {
+                            row.add("");
+                        }
                 }
             }
-            return new ExcelSubTable(row);
+            return new SubTable(row);
+        }
+
+        private void addVendorToRow(Vendor vendor, List<String> row) {
+            if (vendor != null) {
+                Vendor.metaDataMap.keySet().stream()
+                        .filter(f -> ! VENDOR_IGNORED_FIELDS.contains(f))
+                        .forEach(f -> {
+                            if (vendor.isSet(f)) {
+                                row.add(fieldValueAsString(vendor.getFieldValue(f)));
+                            } else {
+                                row.add("");
+                            }
+                        });
+            } else {
+                Vendor.metaDataMap.keySet().stream()
+                        .filter(f -> ! VENDOR_IGNORED_FIELDS.contains(f))
+                        .forEach(f -> row.add(""));
+            }
+        }
+
+        private void addCotsDetailsToRow(COTSDetails cotsDetails, List<String> row) {
+            if (cotsDetails != null) {
+                COTSDetails.metaDataMap.keySet().stream()
+                        .forEach(f -> {
+                            if (cotsDetails.isSet(f)) {
+                                row.add(fieldValueAsString(cotsDetails.getFieldValue(f)));
+                            } else {
+                                row.add("");
+                            }
+                        });
+            } else {
+                COTSDetails.metaDataMap.keySet().stream()
+                        .forEach(f -> row.add(""));
+            }
+        }
+
+        private void addClearingInformationToRow(ClearingInformation clearingInformation, List<String> row) {
+            if (clearingInformation != null) {
+                ClearingInformation.metaDataMap.keySet().stream()
+                        .forEach(f -> {
+                            if (clearingInformation.isSet(f)) {
+                                row.add(fieldValueAsString(clearingInformation.getFieldValue(f)));
+                            } else {
+                                row.add("");
+                            }
+                        });
+            } else {
+                ClearingInformation.metaDataMap.keySet().stream()
+                        .forEach(f -> row.add(""));
+            }
+        }
+
+        private void addReleaseIdToRelationShipToRow(Map<String, ReleaseRelationship> releaseIdToRelationship, List<String> row) {
+            if (releaseIdToRelationship != null) {
+                row.add(fieldValueAsString(putReleaseNamesInMap(
+                        releaseIdToRelationship,
+                        getReleases(releaseIdToRelationship.keySet()))));
+            } else {
+                row.add("");
+            }
+        }
+
+        private List<Release> getReleases(Set<String> ids) {
+            List<Release> releasesByIdsForExport;
+            try {
+                releasesByIdsForExport = client.getReleasesByIdsForExport(nullToEmptySet(ids));
+            } catch (TException e) {
+                log.error("Error fetching release information", e);
+                releasesByIdsForExport = Collections.emptyList();
+            }
+            return releasesByIdsForExport;
         }
     }
-
 }

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ReleaseExporter.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/ReleaseExporter.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.siemens.sw360.exporter;
+
+import com.google.common.collect.ImmutableList;
+import com.siemens.sw360.datahandler.common.SW360Utils;
+import com.siemens.sw360.datahandler.thrift.components.Release;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.siemens.sw360.datahandler.thrift.components.Release._Fields.*;
+
+
+public class ReleaseExporter extends ExcelExporter<Release> {
+    public static final Map<String, String> nameToDisplayName;
+    static {
+        nameToDisplayName = new HashMap<>();
+        nameToDisplayName.put("id", "release ID");
+        nameToDisplayName.put("cpeid", "CPE ID");
+        nameToDisplayName.put("componentId", "component ID");
+        nameToDisplayName.put("releaseDate", "release date");
+        nameToDisplayName.put("externalids", "external IDs");
+        nameToDisplayName.put("createdOn", "created on");
+        nameToDisplayName.put("createdBy", "created by");
+        nameToDisplayName.put("mainlineState", "mainline state");
+        nameToDisplayName.put("clearingState", "clearing state");
+        nameToDisplayName.put("fossologyId", "fossology id");
+        nameToDisplayName.put("clearingTeamToFossologyStatus", "clearing team with FOSSology status");
+        nameToDisplayName.put("attachmentInFossology", "attachment in FOSSology");
+        nameToDisplayName.put("clearingInformation", "clearing information");
+        nameToDisplayName.put("cotsDetails", "COTS details");
+        nameToDisplayName.put("mainLicenseIds", "main license IDs");
+        nameToDisplayName.put("downloadurl", "downloadurl");
+        nameToDisplayName.put("releaseIdToRelationship", "release IDs with relationship");
+    }
+    private static final List<Release._Fields> IGNORED_FIELDS = ImmutableList.<Release._Fields>builder()
+            .add(REVISION)
+            .add(ATTACHMENTS)
+            .add(DOCUMENT_STATE)
+            .add(PERMISSIONS)
+            .add(VENDOR_ID)
+            .build();
+
+    public static final List<Release._Fields> RENDERED_FIELDS = Release.metaDataMap.keySet()
+            .stream()
+            .filter(k -> ! IGNORED_FIELDS.contains(k))
+            .collect(Collectors.toList());
+
+    private static final List<String> HEADERS = makeHeaders();
+
+    public ReleaseExporter() {
+        super(new ReleaseHelper());
+    }
+
+    private static List<String> makeHeaders(){
+        List<String> headers = RENDERED_FIELDS
+                .stream()
+                .map(Release._Fields::getFieldName)
+                .map(n -> SW360Utils.displayNameFor(n, nameToDisplayName))
+                .collect(Collectors.toList());
+        return headers;
+    }
+
+    protected static class ReleaseHelper implements ExporterHelper<Release> {
+
+        @Override
+        public int getColumns() {
+            return HEADERS.size();
+        }
+
+        @Override
+        public List<String> getHeaders() {
+            return HEADERS;
+        }
+
+        @Override
+        public ExcelSubTable makeRows(Release release) {
+            List<String> row = new ArrayList<>(getColumns());
+            for(Release._Fields field : RENDERED_FIELDS){
+                if(release.isSet(field)) {
+                    Object fieldValue = release.getFieldValue(field);
+                    row.add(SW360Utils.fieldValueAsString(fieldValue));
+                } else {
+                    row.add("");
+                }
+            }
+            return new ExcelSubTable(row);
+        }
+    }
+
+}

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/SubTable.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/SubTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
  * All rights reserved. This program and the accompanying materials

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/SubTable.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/SubTable.java
@@ -12,7 +12,7 @@ package com.siemens.sw360.exporter;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ExcelSubTable {
+public class SubTable {
 
     List<List<String>> elements;
 
@@ -24,12 +24,12 @@ public class ExcelSubTable {
         return elements.get(rowNumber);
     }
 
-    public ExcelSubTable(List<String> row) {
+    public SubTable(List<String> row) {
         elements = new ArrayList<>();
         elements.add(row);
     }
 
-    public ExcelSubTable() {
+    public SubTable() {
         elements = new ArrayList<>();
     }
 

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/VendorExporter.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/VendorExporter.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Strings.nullToEmpty;
-import static com.siemens.sw360.datahandler.common.CommonUtils.joinStrings;
 import static com.siemens.sw360.datahandler.thrift.vendors.Vendor._Fields.*;
 
 /**
@@ -56,7 +55,7 @@ public class VendorExporter  extends  ExcelExporter<Vendor>{
         }
 
         @Override
-        public List<String> makeRow(Vendor vendor) {
+        public ExcelSubTable makeRows(Vendor vendor) {
             List<String> row = new ArrayList<>(getColumns());
 
             for (Vendor._Fields renderedField : RENDERED_FIELDS) {
@@ -70,7 +69,7 @@ public class VendorExporter  extends  ExcelExporter<Vendor>{
                     row.add("");
                 }
             }
-            return row;
+            return new ExcelSubTable(row);
         }
     }
 }

--- a/libraries/exporters/src/main/java/com/siemens/sw360/exporter/VendorExporter.java
+++ b/libraries/exporters/src/main/java/com/siemens/sw360/exporter/VendorExporter.java
@@ -55,7 +55,7 @@ public class VendorExporter  extends  ExcelExporter<Vendor>{
         }
 
         @Override
-        public ExcelSubTable makeRows(Vendor vendor) {
+        public SubTable makeRows(Vendor vendor) {
             List<String> row = new ArrayList<>(getColumns());
 
             for (Vendor._Fields renderedField : RENDERED_FIELDS) {
@@ -69,7 +69,7 @@ public class VendorExporter  extends  ExcelExporter<Vendor>{
                     row.add("");
                 }
             }
-            return new ExcelSubTable(row);
+            return new SubTable(row);
         }
     }
 }

--- a/libraries/exporters/src/test/java/com/siemens/sw360/exporter/ProjectExporterTest.java
+++ b/libraries/exporters/src/test/java/com/siemens/sw360/exporter/ProjectExporterTest.java
@@ -8,10 +8,32 @@
  */
 package com.siemens.sw360.exporter;
 
+import com.siemens.sw360.datahandler.thrift.components.ComponentService;
+import com.siemens.sw360.datahandler.thrift.projects.ProjectService;
+import com.siemens.sw360.datahandler.thrift.users.User;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
 /**
  * Created by heydenrb on 06.11.15.
  */
 public class ProjectExporterTest {
+    @Mock
+    ComponentService.Iface componentClient;
 
+    @Mock
+    ProjectService.Iface projectClient;
 
+    @Mock
+    User user;
+
+    @Test
+    public void testEveryRenderedProjectFieldHasAHeader() throws Exception {
+        ProjectExporter exporter = new ProjectExporter(componentClient,
+                projectClient, user, false);
+        assertThat(exporter.RENDERED_FIELDS.size(), is(exporter.HEADERS.size()));
+    }
 }

--- a/libraries/exporters/src/test/java/com/siemens/sw360/exporter/ProjectExporterTest.java
+++ b/libraries/exporters/src/test/java/com/siemens/sw360/exporter/ProjectExporterTest.java
@@ -34,6 +34,6 @@ public class ProjectExporterTest {
     public void testEveryRenderedProjectFieldHasAHeader() throws Exception {
         ProjectExporter exporter = new ProjectExporter(componentClient,
                 projectClient, user, false);
-        assertThat(exporter.RENDERED_FIELDS.size(), is(exporter.HEADERS.size()));
+        assertThat(exporter.PROJECT_RENDERED_FIELDS.size(), is(exporter.HEADERS.size()));
     }
 }

--- a/libraries/exporters/src/test/java/com/siemens/sw360/exporter/ProjectExporterTest.java
+++ b/libraries/exporters/src/test/java/com/siemens/sw360/exporter/ProjectExporterTest.java
@@ -8,18 +8,10 @@
  */
 package com.siemens.sw360.exporter;
 
-import org.junit.Test;
-
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
-
 /**
  * Created by heydenrb on 06.11.15.
  */
 public class ProjectExporterTest {
 
-    @Test
-    public void testEveryRenderedFieldHasAHeader() throws Exception {
-        assertThat(ProjectExporter.RENDERED_FIELDS.size(), is(ProjectExporter.HEADERS.size()));
-    }
+
 }

--- a/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/SW360Utils.java
@@ -39,6 +39,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.Iterables.transform;
 import static com.siemens.sw360.datahandler.common.CommonUtils.joinStrings;
+import static com.siemens.sw360.datahandler.common.CommonUtils.nullToEmptyMap;
 import static com.siemens.sw360.datahandler.thrift.ThriftUtils.extractId;
 import static org.apache.log4j.Logger.getLogger;
 
@@ -157,7 +158,7 @@ public class SW360Utils {
         if (isNullOrEmpty(version)) {
             return name;
         } else {
-            return name + "(" + version + ")";
+            return name + " (" + version + ")";
         }
     }
 
@@ -334,7 +335,12 @@ public class SW360Utils {
             return nullToEmpty((String) fieldValue);
         }
         if (fieldValue instanceof Map) {
-            List<String> mapEntriesAsStrings = ((Map<String, Object>) fieldValue).entrySet().stream().map(e -> e.getKey() + " : " + e.getValue().toString()).collect(Collectors.toList());
+            List<String> mapEntriesAsStrings = nullToEmptyMap(((Map<String, Object>) fieldValue)).entrySet().stream()
+                    .map(e -> {
+                        String valueString = e.getValue() != null ? e.getValue().toString():"";
+                        return e.getKey() + " : " + valueString;
+                    })
+                    .collect(Collectors.toList());
             return joinStrings(mapEntriesAsStrings);
         }
         if (fieldValue instanceof Iterable){
@@ -351,7 +357,7 @@ public class SW360Utils {
         if(map == null || releases == null) return Collections.emptyMap();
         Map<String, T> releaseNamesMap = new HashMap<>();
         releases.stream()
-                .forEach(r -> releaseNamesMap.put(SW360Utils.printName(r),map.get(r.getId())));
+                .forEach(r -> releaseNamesMap.put(printName(r),map.get(r.getId())));
         return releaseNamesMap;
     }
 
@@ -359,7 +365,12 @@ public class SW360Utils {
         if(map == null || projects == null) return Collections.emptyMap();
         Map<String, T> projectNamesMap = new HashMap<>();
         projects.stream()
-                .forEach(p -> projectNamesMap.put(SW360Utils.printName(p),map.get(p.getId())));
+                .forEach(p -> projectNamesMap.put(printName(p),map.get(p.getId())));
         return projectNamesMap;
+    }
+
+    public static List<String> getReleaseNames(List<Release> releases) {
+        if (releases == null) return Collections.emptyList();
+        return releases.stream().map(SW360Utils::printName).collect(Collectors.toList());
     }
 }

--- a/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/SW360Utils.java
@@ -346,4 +346,20 @@ public class SW360Utils {
     public static String displayNameFor(String name, Map<String, String> nameToDisplayName){
         return nameToDisplayName.containsKey(name)? nameToDisplayName.get(name) : name;
     }
+
+    public static <T> Map<String, T> putReleaseNamesInMap(Map<String, T> map, List<Release> releases) {
+        if(map == null || releases == null) return Collections.emptyMap();
+        Map<String, T> releaseNamesMap = new HashMap<>();
+        releases.stream()
+                .forEach(r -> releaseNamesMap.put(SW360Utils.printName(r),map.get(r.getId())));
+        return releaseNamesMap;
+    }
+
+    public static <T> Map<String, T> putProjectNamesInMap(Map<String, T> map, List<Project> projects) {
+        if(map == null || projects == null) return Collections.emptyMap();
+        Map<String, T> projectNamesMap = new HashMap<>();
+        projects.stream()
+                .forEach(p -> projectNamesMap.put(SW360Utils.printName(p),map.get(p.getId())));
+        return projectNamesMap;
+    }
 }

--- a/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/SW360Utils.java
@@ -11,9 +11,7 @@ package com.siemens.sw360.datahandler.common;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimaps;
+import com.google.common.collect.*;
 import com.siemens.sw360.datahandler.thrift.ThriftClients;
 import com.siemens.sw360.datahandler.thrift.ThriftUtils;
 import com.siemens.sw360.datahandler.thrift.components.*;
@@ -27,6 +25,7 @@ import com.siemens.sw360.datahandler.thrift.users.User;
 import com.siemens.sw360.datahandler.thrift.vendors.Vendor;
 import com.siemens.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.apache.log4j.Logger;
+import org.apache.thrift.TEnum;
 import org.apache.thrift.TException;
 import org.jetbrains.annotations.NotNull;
 
@@ -37,7 +36,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.Iterables.transform;
+import static com.siemens.sw360.datahandler.common.CommonUtils.joinStrings;
 import static com.siemens.sw360.datahandler.thrift.ThriftUtils.extractId;
 import static org.apache.log4j.Logger.getLogger;
 
@@ -323,5 +324,26 @@ public class SW360Utils {
             idToLicense = Collections.emptyMap();
         }
         return idToLicense;
+    }
+
+    public static String fieldValueAsString(Object fieldValue) {
+        if (fieldValue instanceof TEnum) {
+            return nullToEmpty(ThriftEnumUtils.enumToString((TEnum) fieldValue));
+        }
+        if (fieldValue instanceof String) {
+            return nullToEmpty((String) fieldValue);
+        }
+        if (fieldValue instanceof Map) {
+            List<String> mapEntriesAsStrings = ((Map<String, Object>) fieldValue).entrySet().stream().map(e -> e.getKey() + " : " + e.getValue().toString()).collect(Collectors.toList());
+            return joinStrings(mapEntriesAsStrings);
+        }
+        if (fieldValue instanceof Iterable){
+            return joinStrings((Iterable<String>) fieldValue);
+        }
+        return fieldValue.toString();
+    }
+
+    public static String displayNameFor(String name, Map<String, String> nameToDisplayName){
+        return nameToDisplayName.containsKey(name)? nameToDisplayName.get(name) : name;
     }
 }

--- a/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/SW360Utils.java
@@ -328,6 +328,9 @@ public class SW360Utils {
     }
 
     public static String fieldValueAsString(Object fieldValue) {
+        if(fieldValue == null){
+            return "";
+        }
         if (fieldValue instanceof TEnum) {
             return nullToEmpty(ThriftEnumUtils.enumToString((TEnum) fieldValue));
         }
@@ -354,7 +357,9 @@ public class SW360Utils {
     }
 
     public static <T> Map<String, T> putReleaseNamesInMap(Map<String, T> map, List<Release> releases) {
-        if(map == null || releases == null) return Collections.emptyMap();
+        if(map == null || releases == null) {
+            return Collections.emptyMap();
+        }
         Map<String, T> releaseNamesMap = new HashMap<>();
         releases.stream()
                 .forEach(r -> releaseNamesMap.put(printName(r),map.get(r.getId())));
@@ -362,7 +367,9 @@ public class SW360Utils {
     }
 
     public static <T> Map<String, T> putProjectNamesInMap(Map<String, T> map, List<Project> projects) {
-        if(map == null || projects == null) return Collections.emptyMap();
+        if(map == null || projects == null) {
+            return Collections.emptyMap();
+        }
         Map<String, T> projectNamesMap = new HashMap<>();
         projects.stream()
                 .forEach(p -> projectNamesMap.put(printName(p),map.get(p.getId())));

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -144,11 +144,6 @@ service ProjectService {
     list<Project> searchByName(1: string name, 2: User user);
 
     /**
-     * same as `searchByName`, but returns the export summary of projects
-     */
-    list<Project> searchByNameForExport(1: string name, 2: User user);
-
-    /**
      * list of short project summaries which are visible to the `user` and have `id` in releaseIdToUsage
      */
     set<Project> searchByReleaseId(1: string id, 2: User user);


### PR DESCRIPTION
For projects and components: closes #223

* possibility to extend excel export with (directly linked) releases
* one line per project-release resp. component-release combination 
* (almost) complete export of project, component and releas
* vendor, ClearingInfo, COTSDetails in separate columns 
* export respects filter (but not keyword search)
* export button only enabled when filter parameters and view consistent