### PR TITLE
fix: SPDX licenseinfo should also use `Document` AttachmentType

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/com/siemens/sw360/licenseinfo/parsers/SPDXParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/com/siemens/sw360/licenseinfo/parsers/SPDXParser.java
@@ -44,12 +44,27 @@ public class SPDXParser extends LicenseInfoParser {
             "rdf",
             "spdx" // usually used for tag:value format
     );
-    protected static final List<AttachmentType> ACCEPTABLE_ATTACHMENT_TYPES = ImmutableList.of(
-            AttachmentType.COMPONENT_LICENSE_INFO_XML,
-            AttachmentType.COMPONENT_LICENSE_INFO_COMBINED,
-            AttachmentType.SCAN_RESULT_REPORT,
-            AttachmentType.SCAN_RESULT_REPORT_XML,
-            AttachmentType.OTHER);
+    protected static final List<AttachmentType> NOT_ACCEPTABLE_ATTACHMENT_TYPES = ImmutableList.of(
+            AttachmentType.SOURCE,
+            AttachmentType.DESIGN,
+            AttachmentType.REQUIREMENT,
+            AttachmentType.CLEARING_REPORT,
+            AttachmentType.SOURCE_SELF,
+            AttachmentType.BINARY,
+            AttachmentType.BINARY_SELF,
+            AttachmentType.DECISION_REPORT,
+            AttachmentType.LEGAL_EVALUATION,
+            AttachmentType.LICENSE_AGREEMENT,
+            AttachmentType.SCREENSHOT
+    );
+    // Thus acceptable attachment types are:
+    //
+    //  - AttachmentType.DOCUMENT
+    //  - AttachmentType.COMPONENT_LICENSE_INFO_XML
+    //  - AttachmentType.COMPONENT_LICENSE_INFO_COMBINED
+    //  - AttachmentType.SCAN_RESULT_REPORT
+    //  - AttachmentType.SCAN_RESULT_REPORT_XML
+    //  - AttachmentType.OTHER
 
     private static final Logger log = Logger.getLogger(CLIParser.class);
 
@@ -66,7 +81,7 @@ public class SPDXParser extends LicenseInfoParser {
         isAcceptable &= ACCEPTABLE_ATTACHMENT_FILE_EXTENSIONS.stream()
                 .map(extension -> lowerFileName.endsWith(extension))
                 .reduce(false, (b1, b2) -> b1 || b2);
-        isAcceptable &= ACCEPTABLE_ATTACHMENT_TYPES.contains(attachment.getAttachmentType());
+        isAcceptable &= ! NOT_ACCEPTABLE_ATTACHMENT_TYPES.contains(attachment.getAttachmentType());
 
         // TODO: test for namespace `spdx` in rdf file (maybe to much overhead? Better try parsing and die?)
 

--- a/backend/src/src-licenseinfo/src/test/java/com/siemens/sw360/licenseinfo/parsers/SPDXParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/com/siemens/sw360/licenseinfo/parsers/SPDXParserTest.java
@@ -12,7 +12,7 @@ package com.siemens.sw360.licenseinfo.parsers;
 import com.siemens.sw360.datahandler.couchdb.AttachmentConnector;
 import com.siemens.sw360.datahandler.thrift.SW360Exception;
 import com.siemens.sw360.datahandler.thrift.attachments.Attachment;
-import com.siemens.sw360.datahandler.thrift.attachments.AttachmentContent;
+import com.siemens.sw360.datahandler.thrift.attachments.AttachmentType;
 import com.siemens.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import com.siemens.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.apache.thrift.TException;
@@ -79,7 +79,8 @@ public class SPDXParserTest {
     @Test
     public void testIsApplicableTo() throws Exception {
         try {
-            SPDXParser.ACCEPTABLE_ATTACHMENT_TYPES.stream()
+            Arrays.stream(AttachmentType.values())
+                    .filter(at -> ! SPDXParser.NOT_ACCEPTABLE_ATTACHMENT_TYPES.contains(at))
                     .forEach(attachmentType -> SPDXParser.ACCEPTABLE_ATTACHMENT_FILE_EXTENSIONS.stream()
                             .forEach(extension -> {
                                 String filename = "filename." + extension;
@@ -118,7 +119,11 @@ public class SPDXParserTest {
     @Test
     public void testGetLicenseInfo() throws Exception {
 
-        Attachment attachment = makeAttachment(spdxExampleFile, SPDXParser.ACCEPTABLE_ATTACHMENT_TYPES.get(0));
+        Attachment attachment = makeAttachment(spdxExampleFile,
+                Arrays.stream(AttachmentType.values())
+                        .filter(at -> ! SPDXParser.NOT_ACCEPTABLE_ATTACHMENT_TYPES.contains(at))
+                        .findAny()
+                        .get());
 
         LicenseInfoParsingResult result = parser.getLicenseInfo(attachment);
 


### PR DESCRIPTION
The `AttachmentType.Document` was previously excluded

In the effort to solve this bug, also some code was refactored.