### PR TITLE
avoiding duplicate documents

### DIFF
--- a/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -125,9 +125,13 @@ public class ProjectDatabaseHandler {
     // ADD INDIVIDUAL OBJECTS //
     ////////////////////////////
 
-    public String addProject(Project project, User user) throws SW360Exception {
+    public AddDocumentRequestSummary addProject(Project project, User user) throws SW360Exception {
         // Prepare project for database
         prepareProject(project);
+        if(isDuplicate(project)) {
+            return new AddDocumentRequestSummary()
+                    .setRequestStatus(AddDocumentRequestStatus.DUPLICATE);
+        }
 
         // Save creating user
         project.createdBy = user.getEmail();
@@ -137,9 +141,13 @@ public class ProjectDatabaseHandler {
         // Add project to database and return ID
         repository.add(project);
 
-        return project.getId();
+        return new AddDocumentRequestSummary().setId(project.getId()).setRequestStatus(AddDocumentRequestStatus.SUCCESS);
     }
 
+    private boolean isDuplicate(Project project){
+        List<Project> duplicates = repository.searchByNameAndVersion(project.getName(), project.getVersion());
+        return duplicates.size()>0;
+    }
     ///////////////////////////////
     // UPDATE INDIVIDUAL OBJECTS //
     ///////////////////////////////

--- a/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ProjectRepository.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.siemens.sw360.datahandler.common.SW360Utils.getBUFromOrganisation;
 
 /**
@@ -141,6 +142,14 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
     public List<Project> searchByName(String name, User user, SummaryType summaryType) {
         Set<String> searchIds = queryForIdsByPrefix("byname", name);
         return makeSummaryFromFullDocs(summaryType, filterAccessibleProjectsByIds(user, searchIds));
+    }
+
+    public List<Project> searchByNameAndVersion(String name, String version) {
+        List<Project> projectsMatchingName = queryView("byname", name);
+        List<Project> projectsMatchingNameAndVersion = projectsMatchingName.stream()
+                .filter(p -> isNullOrEmpty(version) ? isNullOrEmpty(p.getVersion()) : version.equals(p.getVersion()))
+                .collect(Collectors.toList());
+        return makeSummaryFromFullDocs(SummaryType.SHORT, projectsMatchingNameAndVersion);
     }
 
 

--- a/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ReleaseRepository.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ReleaseRepository.java
@@ -16,12 +16,14 @@ import com.siemens.sw360.datahandler.couchdb.DatabaseConnector;
 import com.siemens.sw360.datahandler.couchdb.SummaryAwareRepository;
 import com.siemens.sw360.datahandler.thrift.components.Release;
 import com.siemens.sw360.datahandler.thrift.users.User;
-
 import org.ektorp.ViewQuery;
 import org.ektorp.support.View;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
  * CRUD access for the Release class
@@ -97,6 +99,14 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
     @View(name = "byname", map = BY_NAME_VIEW)
     public List<Release> searchByName(String name) {
         return makeSummary(SummaryType.SHORT, queryForIdsByPrefix("byname", name));
+    }
+
+    public List<Release> searchByNameAndVersion(String name, String version){
+        List<Release> releasesMatchingName = searchByName(name);
+        List<Release> releasesMatchingNameAndVersion = releasesMatchingName.stream()
+                .filter(r -> isNullOrEmpty(version) ? isNullOrEmpty(r.getVersion()) : version.equals(r.getVersion()))
+                .collect(Collectors.toList());
+        return releasesMatchingNameAndVersion;
     }
 
     public List<Release> getReleaseSummary() {

--- a/backend/src/src-bdpimport/src/main/java/com/bosch/osmi/sw360/bdp/entitytranslation/BdpComponentToSw360ReleaseTranslator.java
+++ b/backend/src/src-bdpimport/src/main/java/com/bosch/osmi/sw360/bdp/entitytranslation/BdpComponentToSw360ReleaseTranslator.java
@@ -18,6 +18,8 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 public class BdpComponentToSw360ReleaseTranslator implements EntityTranslator<Component, Release> {
 
+    public static final String unknownVersionString = "UNKNOWN";
+
     @Override
     public Release apply(com.bosch.osmi.bdp.access.api.model.Component componentBdp) {
         Release releaseSW360 = new Release();
@@ -31,7 +33,7 @@ public class BdpComponentToSw360ReleaseTranslator implements EntityTranslator<Co
             releaseSW360.setVersion(componentBdp.getComponentVersion());
         } else {
             // this appears for example, if componentBdp.getUsageLevel() == "ORIGINAL_CODE"
-            releaseSW360.setVersion("UNKNOWN");
+            releaseSW360.setVersion(unknownVersionString);
         }
 
         releaseSW360.setReleaseDate(componentBdp.getReleaseDate());

--- a/backend/src/src-components/src/main/java/com/siemens/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/com/siemens/sw360/components/ComponentHandler.java
@@ -11,10 +11,7 @@ package com.siemens.sw360.components;
 import com.siemens.sw360.datahandler.common.DatabaseSettings;
 import com.siemens.sw360.datahandler.db.ComponentDatabaseHandler;
 import com.siemens.sw360.datahandler.db.ComponentSearchHandler;
-import com.siemens.sw360.datahandler.thrift.RequestStatus;
-import com.siemens.sw360.datahandler.thrift.RequestSummary;
-import com.siemens.sw360.datahandler.thrift.ThriftClients;
-import com.siemens.sw360.datahandler.thrift.ThriftUtils;
+import com.siemens.sw360.datahandler.thrift.*;
 import com.siemens.sw360.datahandler.thrift.attachments.Attachment;
 import com.siemens.sw360.datahandler.thrift.components.*;
 import com.siemens.sw360.datahandler.thrift.users.User;
@@ -199,7 +196,7 @@ public class ComponentHandler implements ComponentService.Iface {
     ////////////////////////////
 
     @Override
-    public String addComponent(Component component, User user) throws TException {
+    public AddDocumentRequestSummary addComponent(Component component, User user) throws TException {
         assertNotNull(component);
         assertIdUnset(component.getId());
         assertUser(user);
@@ -208,7 +205,7 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
-    public String addRelease(Release release, User user) throws TException {
+    public AddDocumentRequestSummary addRelease(Release release, User user) throws TException {
         assertNotNull(release);
         assertIdUnset(release.getId());
         assertUser(user);

--- a/backend/src/src-components/src/test/java/com/siemens/sw360/components/ComponentHandlerTest.java
+++ b/backend/src/src-components/src/test/java/com/siemens/sw360/components/ComponentHandlerTest.java
@@ -51,10 +51,10 @@ public class ComponentHandlerTest {
     public void testGetByUploadId() throws Exception {
 
         Component originalComponent = new Component("name").setDescription("a desc");
-        String componentId = componentHandler.addComponent(originalComponent, adminUser);
+        String componentId = componentHandler.addComponent(originalComponent, adminUser).getId();
 
         Release release = new Release("name", "version", componentId).setFossologyId("id");
-        String releaseId = componentHandler.addRelease(release, adminUser);
+        String releaseId = componentHandler.addRelease(release, adminUser).getId();
 
         Component component = componentHandler.getComponentForReportFromFossologyUploadId("id");
 

--- a/backend/src/src-components/src/test/java/com/siemens/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/com/siemens/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -66,6 +66,8 @@ public class ComponentDatabaseHandlerTest {
     private Map<String, Vendor> vendors;
     private ComponentDatabaseHandler handler;
 
+    private int nextReleaseVersion = 0;
+
 
     @Mock
     ComponentModerator moderator;
@@ -590,7 +592,7 @@ public class ComponentDatabaseHandlerTest {
         Release release = new Release().setName("REL").setVersion("VER");
         expected.addToReleases(release);
 
-        String id = handler.addComponent(expected, "new@mail.com");
+        String id = handler.addComponent(expected, "new@mail.com").getId();
         assertNotNull(id);
 
         Component actual = handler.getComponent(id, user1);
@@ -606,7 +608,7 @@ public class ComponentDatabaseHandlerTest {
         Release expected = new Release().setName("REL").setVersion("VER");
         expected.setComponentId("C1");
 
-        String id = handler.addRelease(expected, "new@mail.com");
+        String id = handler.addRelease(expected, "new@mail.com").getId();
         assertNotNull(id);
 
         Release actual = handler.getRelease(id, user1);
@@ -659,11 +661,11 @@ public class ComponentDatabaseHandlerTest {
     private String addRelease(String componentId, Set<String> licenseIds) throws SW360Exception {
         Release release = new Release()
                 .setName("REL")
-                .setVersion("VER")
+                .setVersion(nextReleaseVersion+"")
                 .setMainLicenseIds(licenseIds)
                 .setComponentId(componentId);
-
-        String id = handler.addRelease(release, user1.getEmail());
+        nextReleaseVersion++;
+        String id = handler.addRelease(release, user1.getEmail()).getId();
         assertNotNull(id);
         return id;
     }
@@ -695,7 +697,7 @@ public class ComponentDatabaseHandlerTest {
         Release release = new Release().setName("REL").setVersion("VER").setOperatingSystems(os).setLanguages(lang).setVendorId("V1");
         release.setComponentId(componentId);
 
-        String id = handler.addRelease(release, user1.getEmail());
+        String id = handler.addRelease(release, user1.getEmail()).getId();
         assertNotNull(id);
 
         {
@@ -716,7 +718,7 @@ public class ComponentDatabaseHandlerTest {
         Release release2 = new Release().setName("REL2").setVersion("VER2").setOperatingSystems(os2).setLanguages(lang2).setVendorId("V2");
         release2.setComponentId(componentId);
 
-        String id2 = handler.addRelease(release2, user1.getEmail());
+        String id2 = handler.addRelease(release2, user1.getEmail()).getId();
 
         {
             Component component = handler.getComponent(componentId, user1);
@@ -958,33 +960,30 @@ public class ComponentDatabaseHandlerTest {
 
 
     @Test
-    public void testDuplicateComponentIsFound() throws Exception {
+    public void testDuplicateComponentNotAdded() throws Exception {
         String originalComponentId = "C3";
         final Component tmp = handler.getComponent(originalComponentId, user1);
         tmp.unsetId();
         tmp.unsetRevision();
-        String newComponentId = handler.addComponent(tmp, email1);
+        String newComponentId = handler.addComponent(tmp, email1).getId();
 
         final Map<String, List<String>> duplicateComponents = handler.getDuplicateComponents();
 
-        assertThat(duplicateComponents.size(), is(1));
-        assertThat(duplicateComponents.get(printName(tmp)), containsInAnyOrder(newComponentId, originalComponentId));
-
+        assertThat(duplicateComponents.size(), is(0));
     }
 
 
     @Test
-    public void testDuplicateReleaseIsFound() throws Exception {
+    public void testDuplicateReleaseNotAdded() throws Exception {
 
         String originalReleaseId = "R1A";
         final Release tmp = handler.getRelease(originalReleaseId, user1);
         tmp.unsetId();
         tmp.unsetRevision();
-        String newReleaseId = handler.addRelease(tmp, email1);
+        String newReleaseId = handler.addRelease(tmp, email1).getId();
 
         final Map<String, List<String>> duplicateReleases = handler.getDuplicateReleases();
 
-        assertThat(duplicateReleases.size(), is(1));
-        assertThat(duplicateReleases.get(printName(tmp)), containsInAnyOrder(newReleaseId, originalReleaseId));
+        assertThat(duplicateReleases.size(), is(0));
     }
 }

--- a/backend/src/src-projects/src/main/java/com/siemens/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/com/siemens/sw360/projects/ProjectHandler.java
@@ -10,6 +10,9 @@ package com.siemens.sw360.projects;
 
 import com.siemens.sw360.datahandler.common.CommonUtils;
 import com.siemens.sw360.datahandler.common.DatabaseSettings;
+import com.siemens.sw360.datahandler.db.ProjectDatabaseHandler;
+import com.siemens.sw360.datahandler.db.ProjectSearchHandler;
+import com.siemens.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import com.siemens.sw360.datahandler.thrift.RequestStatus;
 import com.siemens.sw360.datahandler.thrift.attachments.Attachment;
 import com.siemens.sw360.datahandler.thrift.projects.Project;
@@ -17,8 +20,6 @@ import com.siemens.sw360.datahandler.thrift.projects.ProjectLink;
 import com.siemens.sw360.datahandler.thrift.projects.ProjectRelationship;
 import com.siemens.sw360.datahandler.thrift.projects.ProjectService;
 import com.siemens.sw360.datahandler.thrift.users.User;
-import com.siemens.sw360.datahandler.db.ProjectDatabaseHandler;
-import com.siemens.sw360.datahandler.db.ProjectSearchHandler;
 import org.apache.thrift.TException;
 
 import java.io.IOException;
@@ -143,7 +144,7 @@ public class ProjectHandler implements ProjectService.Iface {
     ////////////////////////////
 
     @Override
-    public String addProject(Project project, User user) throws TException {
+    public AddDocumentRequestSummary addProject(Project project, User user) throws TException {
         assertNotNull(project);
         assertIdUnset(project.getId());
         assertUser(user);

--- a/backend/src/src-projects/src/test/java/com/siemens/sw360/projects/ProjectHandlerTest.java
+++ b/backend/src/src-projects/src/test/java/com/siemens/sw360/projects/ProjectHandlerTest.java
@@ -148,7 +148,7 @@ public class ProjectHandlerTest {
         Project project4 = new Project();
         project4.setName("Project4").setBusinessUnit("AB CD FE");
 
-        String id = handler.addProject(project4, user2);
+        String id = handler.addProject(project4, user2).getId();
 
         Project projectActual = handler.getProjectById(id, user2);
         assertEquals("Project4", projectActual.getName());

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/ErrorMessages.java
@@ -16,8 +16,11 @@ import com.google.common.collect.ImmutableList;
 public class ErrorMessages {
 
     public static final String PROJECT_NOT_ADDED = "Project could not be added.";
+    public static final String PROJECT_DUPLICATE ="Project could not be added, since a project with the same name and version already exists.";
     public static final String COMPONENT_NOT_ADDED = "Component could not be added.";
+    public static final String COMPONENT_DUPLICATE ="Component could not be added, since a component with the same name already exists.";
     public static final String RELEASE_NOT_ADDED = "Release could not be added.";
+    public static final String RELEASE_DUPLICATE ="Release could not be added, since a release with the same name and version already exists.";
     public static final String ERROR_GETTING_PROJECT = "Error fetching project from backend.";
     public static final String ERROR_GETTING_COMPONENT = "Error fetching component from backend.";
     public static final String ERROR_GETTING_RELEASE = "Error fetching release from backend.";
@@ -41,8 +44,11 @@ public class ErrorMessages {
     //this map is used in errorKeyToMessage.jspf to generate key-value pairs for the liferay-ui error tag
     public static final ImmutableList<String> allErrorMessages = ImmutableList.<String>builder()
             .add(PROJECT_NOT_ADDED)
+            .add(PROJECT_DUPLICATE)
             .add(COMPONENT_NOT_ADDED)
+            .add(COMPONENT_DUPLICATE)
             .add(RELEASE_NOT_ADDED)
+            .add(RELEASE_DUPLICATE)
             .add(LICENSE_USED_BY_RELEASE)
             .add(DOCUMENT_USED_BY_PROJECT_OR_RELEASE)
             .add(DOCUMENT_NOT_PROCESSED_SUCCESSFULLY)

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/PortletUtils.java
@@ -8,7 +8,6 @@
  */
 package com.siemens.sw360.portal.common;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -37,8 +36,10 @@ import org.apache.thrift.TFieldIdEnum;
 import org.apache.thrift.meta_data.FieldMetaData;
 
 import javax.portlet.PortletRequest;
-import java.util.*;
-
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -244,7 +245,6 @@ public class PortletUtils {
         newProject.setBusinessUnit(department);
 
         //project specifics
-        newProject.unsetName();
         newProject.unsetAttachments();
 
         return newProject;

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/AttachmentAwarePortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/AttachmentAwarePortlet.java
@@ -53,7 +53,8 @@ public abstract class AttachmentAwarePortlet extends Sw360Portlet {
         uploadHistoryPerUserEmailAndDocumentId = new HashMap<>();
     }
 
-    public static void setAttachmentsInRequest(RenderRequest request, Set<Attachment> attachments) {
+
+    public static void setAttachmentsInRequest(PortletRequest request, Set<Attachment> attachments) {
         request.setAttribute(ATTACHMENTS, CommonUtils.nullToEmptySet(attachments));
     }
 

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/Sw360Portlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/Sw360Portlet.java
@@ -310,7 +310,7 @@ abstract public class Sw360Portlet extends MVCPortlet {
         request.setAttribute(RELEASE_LIST, linkedReleaseRelations);
     }
 
-    protected void putDirectlyLinkedReleaseRelationsInRequest(RenderRequest request, Map<String, ReleaseRelationship> releaseIdToRelationship) {
+    protected void putDirectlyLinkedReleaseRelationsInRequest(PortletRequest request, Map<String, ReleaseRelationship> releaseIdToRelationship) {
         List<ReleaseLink> linkedReleaseRelations = SW360Utils.getLinkedReleaseRelations(releaseIdToRelationship, thriftClients, log);
         request.setAttribute(RELEASE_LIST, linkedReleaseRelations);
     }
@@ -320,7 +320,7 @@ abstract public class Sw360Portlet extends MVCPortlet {
         request.setAttribute(RELEASE_LIST, linkedReleases);
     }
 
-    protected void putDirectlyLinkedReleasesInRequest(RenderRequest request, Map<String, String> releaseIdToRelationship) throws TException {
+    protected void putDirectlyLinkedReleasesInRequest(PortletRequest request, Map<String, String> releaseIdToRelationship) throws TException {
         List<ReleaseLink> linkedReleases = SW360Utils.getLinkedReleases(releaseIdToRelationship, thriftClients, log);
         request.setAttribute(RELEASE_LIST, linkedReleases);
     }
@@ -330,7 +330,7 @@ abstract public class Sw360Portlet extends MVCPortlet {
         request.setAttribute(PROJECT_LIST, linkedProjects);
     }
 
-    protected void putDirectlyLinkedProjectsInRequest(RenderRequest request, Map<String, ProjectRelationship> projectIdToRelationship) {
+    protected void putDirectlyLinkedProjectsInRequest(PortletRequest request, Map<String, ProjectRelationship> projectIdToRelationship) {
         final Collection<ProjectLink> linkedProjects = SW360Utils.getLinkedProjects(projectIdToRelationship, thriftClients, log);
         request.setAttribute(PROJECT_LIST, linkedProjects);
     }

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/components/ComponentPortlet.java
@@ -846,12 +846,21 @@ public class ComponentPortlet extends FossologyAwarePortlet {
         }
     }
 
-    private void prepareRequestForReleaseEditAfterDuplicateError(ActionRequest request, Release release) {
+    private void prepareRequestForReleaseEditAfterDuplicateError(ActionRequest request, Release release) throws TException {
+        fillVendor(release);
         request.setAttribute(RELEASE, release);
         setAttachmentsInRequest(request, release.getAttachments());
         putDirectlyLinkedReleaseRelationsInRequest(request, release.getReleaseIdToRelationship());
         request.setAttribute(USING_PROJECTS, Collections.emptySet());
         request.setAttribute(USING_COMPONENTS, Collections.emptySet());
+    }
+
+    private void fillVendor(Release release) throws TException {
+        VendorService.Iface client = thriftClients.makeVendorClient();
+        if(release.isSetVendorId()) {
+            Vendor vendor = client.getByID(release.getVendorId());
+            release.setVendor(vendor);
+        }
     }
 
     @UsedAsLiferayAction

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/portlets/components/ComponentPortlet.java
@@ -381,11 +381,13 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                 setSW360SessionError(request, ErrorMessages.ERROR_GETTING_COMPONENT);
             }
         } else {
-            Component component = new Component();
-            request.setAttribute(COMPONENT, component);
-            setUsingDocs(request, user, null, component.getReleaseIds());
-            setAttachmentsInRequest(request, component.getAttachments());
-            SessionMessages.add(request, "request_processed", "New Component");
+            if(request.getAttribute(COMPONENT) == null) {
+                Component component = new Component();
+                request.setAttribute(COMPONENT, component);
+                setUsingDocs(request, user, null, component.getReleaseIds());
+                setAttachmentsInRequest(request, component.getAttachments());
+                SessionMessages.add(request, "request_processed", "New Component");
+            }
         }
     }
 
@@ -421,14 +423,17 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                 }
 
             } else {
-                release = new Release();
-                release.setComponentId(id);
-                release.setClearingState(ClearingState.NEW_CLEARING);
-                request.setAttribute(RELEASE, release);
-                putDirectlyLinkedReleaseRelationsInRequest(request, release.getReleaseIdToRelationship());
-                setAttachmentsInRequest(request, release.getAttachments());
-                setUsingDocs(request, null, user, client);
-                SessionMessages.add(request, "request_processed", "New Release");
+                release = (Release) request.getAttribute(RELEASE);
+                if(release == null) {
+                    release = new Release();
+                    release.setComponentId(id);
+                    release.setClearingState(ClearingState.NEW_CLEARING);
+                    request.setAttribute(RELEASE, release);
+                    putDirectlyLinkedReleaseRelationsInRequest(request, release.getReleaseIdToRelationship());
+                    setAttachmentsInRequest(request, release.getAttachments());
+                    setUsingDocs(request, null, user, client);
+                    SessionMessages.add(request, "request_processed", "New Release");
+                }
             }
 
             Component component = client.getComponentById(id, user);
@@ -746,27 +751,43 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                 ComponentPortletUtils.updateComponentFromRequest(request, component);
                 RequestStatus requestStatus = client.updateComponent(component, user);
                 setSessionMessage(request, requestStatus, "Component", "update", component.getName());
-                cleanUploadHistory(user.getEmail(),id);                
+                cleanUploadHistory(user.getEmail(),id);
                 response.setRenderParameter(PAGENAME, PAGENAME_DETAIL);
                 response.setRenderParameter(COMPONENT_ID, request.getParameter(COMPONENT_ID));
             } else {
                 Component component = new Component();
                 ComponentPortletUtils.updateComponentFromRequest(request, component);
-                String componentId = client.addComponent(component, user);
+                AddDocumentRequestSummary summary = client.addComponent(component, user);
 
-                if (componentId != null) {
-                    String successMsg = "Component " + component.getName() + " added successfully";
-                    SessionMessages.add(request, "request_processed", successMsg);
-                    response.setRenderParameter(COMPONENT_ID, componentId);
-                } else {
-                    setSW360SessionError(request, ErrorMessages.COMPONENT_NOT_ADDED);
+                AddDocumentRequestStatus status = summary.getRequestStatus();
+                switch(status){
+                    case SUCCESS:
+                        String successMsg = "Component " + component.getName() + " added successfully";
+                        SessionMessages.add(request, "request_processed", successMsg);
+                        response.setRenderParameter(COMPONENT_ID, summary.getId());
+                        response.setRenderParameter(PAGENAME, PAGENAME_EDIT);
+                        break;
+                    case DUPLICATE:
+                        setSW360SessionError(request, ErrorMessages.COMPONENT_DUPLICATE);
+                        response.setRenderParameter(PAGENAME, PAGENAME_EDIT);
+                        prepareRequestForEditAfterDuplicateError(request, component);
+                        break;
+                    default:
+                        setSW360SessionError(request, ErrorMessages.COMPONENT_NOT_ADDED);
+                        response.setRenderParameter(PAGENAME, PAGENAME_VIEW);
                 }
-                response.setRenderParameter(PAGENAME, PAGENAME_EDIT);
             }
 
         } catch (TException e) {
             log.error("Error fetching component from backend!", e);
         }
+    }
+
+    private void prepareRequestForEditAfterDuplicateError(ActionRequest request, Component component) throws TException {
+        request.setAttribute(COMPONENT, component);
+        setAttachmentsInRequest(request, component.getAttachments());
+        request.setAttribute(USING_PROJECTS, Collections.emptySet());
+        request.setAttribute(USING_COMPONENTS, Collections.emptySet());
     }
 
     @UsedAsLiferayAction
@@ -797,23 +818,40 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                     release.setComponentId(component.getId());
                     release.setClearingState(ClearingState.NEW_CLEARING);
                     ComponentPortletUtils.updateReleaseFromRequest(request, release);
-                    releaseId = client.addRelease(release, user);
+                    AddDocumentRequestSummary summary = client.addRelease(release, user);
 
-                    if (releaseId != null) {
-                        response.setRenderParameter(RELEASE_ID, releaseId);
-                        String successMsg = "Release " + printName(release) + " added successfully";
-                        SessionMessages.add(request, "request_processed", successMsg);
-                    } else {
-                        setSW360SessionError(request, ErrorMessages.RELEASE_NOT_ADDED);
+                    AddDocumentRequestStatus status = summary.getRequestStatus();
+                    switch(status){
+                        case SUCCESS:
+                            response.setRenderParameter(RELEASE_ID, summary.getId());
+                            String successMsg = "Release " + printName(release) + " added successfully";
+                            SessionMessages.add(request, "request_processed", successMsg);
+                            response.setRenderParameter(PAGENAME, PAGENAME_EDIT_RELEASE);
+                            break;
+                        case DUPLICATE:
+                            setSW360SessionError(request, ErrorMessages.RELEASE_DUPLICATE);
+                            response.setRenderParameter(PAGENAME, PAGENAME_EDIT_RELEASE);
+                            prepareRequestForReleaseEditAfterDuplicateError(request, release);
+                            break;
+                        default:
+                            setSW360SessionError(request, ErrorMessages.RELEASE_NOT_ADDED);
+                            response.setRenderParameter(PAGENAME, PAGENAME_DETAIL);
                     }
 
-                    response.setRenderParameter(PAGENAME, PAGENAME_EDIT_RELEASE);
                     response.setRenderParameter(COMPONENT_ID, request.getParameter(COMPONENT_ID));
                 }
             } catch (TException e) {
                 log.error("Error fetching release from backend!", e);
             }
         }
+    }
+
+    private void prepareRequestForReleaseEditAfterDuplicateError(ActionRequest request, Release release) {
+        request.setAttribute(RELEASE, release);
+        setAttachmentsInRequest(request, release.getAttachments());
+        putDirectlyLinkedReleaseRelationsInRequest(request, release.getReleaseIdToRelationship());
+        request.setAttribute(USING_PROJECTS, Collections.emptySet());
+        request.setAttribute(USING_COMPONENTS, Collections.emptySet());
     }
 
     @UsedAsLiferayAction

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseInformation.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseInformation.jspf
@@ -53,14 +53,14 @@
             <input class="toplabelledInput" name="<portlet:namespace/><%=Component._Fields.LANGUAGES%>"
                    id="programminglanguages" type="text"
                    placeholder="e.g., Java,C++, C#,..."
-                   value="<sw360:DisplayCollection value='${component.languages}' />"/>
+                   value="<sw360:DisplayCollection value='${release.languages}' />"/>
         </td>
         <td width="33%">
             <label class="textlabel stackedLabel" for="op_systems">Operating Systems</label>
             <input class="toplabelledInput" id="op_systems"
                    name="<portlet:namespace/><%=Component._Fields.OPERATING_SYSTEMS%>" type="text" align="middle"
                    placeholder="e.g.,Linux,MAC,Windows,..."
-                   value="<sw360:DisplayCollection value="${component.operatingSystems}" />"/>
+                   value="<sw360:DisplayCollection value="${release.operatingSystems}" />"/>
         </td>
         <td width="33%">
             <label class="textlabel stackedLabel mandatory" for="comp_id">CPE ID</label>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
@@ -81,7 +81,6 @@
     </div>
 
     <div id="editField" class="content2">
-
         <form  id="projectEditForm" name="projectEditForm" action="<%=updateURL%>" method="post" >
             <%@include file="/html/projects/includes/projects/basicInfo.jspf" %>
             <%@include file="/html/projects/includes/linkedProjectsEdit.jspf" %>

--- a/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/thrift/ThriftValidate.java
+++ b/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/thrift/ThriftValidate.java
@@ -227,7 +227,6 @@ public class ThriftValidate {
 
     public static void prepareProject(Project project) throws SW360Exception {
         assertNotEmpty(project.getName());
-
         project.setType(TYPE_PROJECT);
 
         // Unset temporary fields

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -18,6 +18,7 @@ namespace php sw360.thrift.components
 
 typedef sw360.RequestStatus RequestStatus
 typedef sw360.RequestSummary RequestSummary
+typedef sw360.AddDocumentRequestSummary AddDocumentRequestSummary
 typedef sw360.DocumentState DocumentState
 typedef attachments.Attachment Attachment
 typedef attachments.FilledAttachment FilledAttachment
@@ -333,7 +334,7 @@ service ComponentService {
      * add component to database with user as creator,
      * return id
      **/
-    string addComponent(1: Component component, 2: User user);
+    AddDocumentRequestSummary addComponent(1: Component component, 2: User user);
 
     /**
      * get component from database filled with releases and permissions for user
@@ -374,7 +375,7 @@ service ComponentService {
       * add release to database with user as creator,
       * return id
       **/
-    string addRelease(1: Release release, 2: User user);
+    AddDocumentRequestSummary addRelease(1: Release release, 2: User user);
 
     /**
       * get release from database filled with vendor and permissions for user

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -25,6 +25,7 @@ typedef users.User User
 typedef users.RequestedAction RequestedAction
 typedef attachments.Attachment Attachment
 typedef components.ReleaseLink ReleaseLink
+typedef sw360.AddDocumentRequestSummary AddDocumentRequestSummary
 
 enum ProjectState {
     ACTIVE = 0,
@@ -165,7 +166,7 @@ service ProjectService {
      * add a project as a user to the db and get the id back
      * (part of project CRUD support)
      */
-    string addProject(1: Project project, 2: User user);
+    AddDocumentRequestSummary addProject(1: Project project, 2: User user);
 
     /**
      * get a project by id, if it is visible for the user

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -24,6 +24,12 @@ enum RemoveModeratorRequestStatus {
     FAILURE = 2,
 }
 
+enum AddDocumentRequestStatus {
+    SUCCESS = 0,
+    DUPLICATE = 1,
+    FAILURE = 2
+}
+
 exception SW360Exception {
     1: required string why,
 }
@@ -65,6 +71,11 @@ struct RequestSummary {
   2: optional i32 totalAffectedElements;
   3: optional i32 totalElements;
   4: optional string message;
+}
+
+struct AddDocumentRequestSummary {
+    1: optional AddDocumentRequestStatus requestStatus;
+    2: optional string id;
 }
 
 struct CustomProperties {


### PR DESCRIPTION
check in backend and display error in frontend in the cases when a user tries to:
* add a project with name and version equal to an existing project
* add a component with name equal to an existing component
* add a release with name and version equal to an existing release
* closes #203