### PR TITLE
scheduleAdminPortlet display improved

### DIFF
--- a/backend/src/src-schedule/src/main/java/com/bosch/osmi/sw360/schedule/service/ScheduleServlet.java
+++ b/backend/src/src-schedule/src/main/java/com/bosch/osmi/sw360/schedule/service/ScheduleServlet.java
@@ -9,16 +9,45 @@
  */
 package com.bosch.osmi.sw360.schedule.service;
 
+import com.bosch.osmi.sw360.schedule.timer.ScheduleConstants;
 import com.siemens.sw360.datahandler.thrift.schedule.ScheduleService;
 import com.siemens.sw360.projects.Sw360ThriftServlet;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 
+import javax.servlet.ServletException;
 import java.io.FileNotFoundException;
 import java.net.MalformedURLException;
 
 public class ScheduleServlet extends Sw360ThriftServlet {
-    public ScheduleServlet() throws MalformedURLException, FileNotFoundException {
+
+    Logger log = Logger.getLogger(ScheduleServlet.class);
+    static ScheduleHandler handler = new ScheduleHandler();
+
+    public ScheduleServlet() throws MalformedURLException, FileNotFoundException, TException {
         // Create a service processor using the provided handler
-        super(new ScheduleService.Processor<>(new ScheduleHandler()), new TCompactProtocol.Factory());
+        super(new ScheduleService.Processor<>(handler), new TCompactProtocol.Factory());
+    }
+
+    public void init() throws ServletException {
+        super.init();
+        try {
+            autoStart();
+        } catch (TException te) {
+            throw new ServletException(te.getMessage());
+        }
+    }
+
+    private void autoStart() throws TException {
+        log.info("Auto-starting scheduling tasks in schedule service...");
+        String[] servicesToSchedule = ScheduleConstants.autostartServices;
+        for (String serviceName : servicesToSchedule) {
+            String cleanServiceName = serviceName.trim();
+            if(! "".equals(cleanServiceName)){
+                handler.scheduleService(cleanServiceName);
+            }
+        }
+        log.info("Auto-start completed.");
     }
 }

--- a/backend/src/src-schedule/src/main/java/com/bosch/osmi/sw360/schedule/timer/ScheduleConstants.java
+++ b/backend/src/src-schedule/src/main/java/com/bosch/osmi/sw360/schedule/timer/ScheduleConstants.java
@@ -12,9 +12,13 @@ package com.bosch.osmi.sw360.schedule.timer;
 
 
 import com.siemens.sw360.datahandler.common.CommonUtils;
+import com.siemens.sw360.datahandler.thrift.ThriftClients;
 import org.apache.log4j.Logger;
 
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.log4j.Logger.getLogger;
 
@@ -27,16 +31,46 @@ public class ScheduleConstants {
     private ScheduleConstants(){}
 
     public static final String PROPERTIES_FILE_PATH = "/sw360.properties";
+    public static final String CVESEARCH_OFFSET_PROPERTY_NAME = "schedule.cvesearch.firstOffset.seconds";
+    public static final String CVESEARCH_INTERVAL_PROPERTY_NAME = "schedule.cvesearch.interval.seconds";
+    public static final String AUTOSTART_PROPERTY_NAME = "autostart";
+    public static final String CVESEARCH_OFFSET_DEFAULT  = 0 + "" ; // default 00:00 am, in seconds
+    public static final String CVESEARCH_INTERVAL_DEFAULT  = (24*60*60)+"" ; // default 24h, in seconds
+
 
     // scheduler properties
-    public static final String SYNC_FIRST_RUN_OFFSET_SEC;
-    public static final String SYNC_INTERVAL_SEC;
+    public static final ConcurrentHashMap<String, Integer> SYNC_FIRST_RUN_OFFSET_SEC = new ConcurrentHashMap<>();
+    public static final ConcurrentHashMap<String, Integer> SYNC_INTERVAL_SEC = new ConcurrentHashMap<>();
+    public static final String[] autostartServices;
+    public static Set<String> invalidConfiguredServices = new HashSet<>();
 
     static {
         Properties props = CommonUtils.loadProperties(ScheduleConstants.class, PROPERTIES_FILE_PATH);
 
-        SYNC_FIRST_RUN_OFFSET_SEC  = props.getProperty("schedule.firstOffset.seconds", (0*60*60)+""); // default 00:00 am
-        SYNC_INTERVAL_SEC  = props.getProperty("schedule.interval.seconds", (24*60*60)+""); // default 24h
+        if(! props.containsKey(CVESEARCH_OFFSET_PROPERTY_NAME)){
+            log.info("Property "+ CVESEARCH_OFFSET_PROPERTY_NAME + " not set. Using default value.");
+        }
+        String cveSearchOffset  = props.getProperty(CVESEARCH_OFFSET_PROPERTY_NAME, CVESEARCH_OFFSET_DEFAULT);
+        try {
+            SYNC_FIRST_RUN_OFFSET_SEC.put(ThriftClients.CVESEARCH_SERVICE, Integer.parseInt(cveSearchOffset));
+        } catch (NumberFormatException nfe){
+            log.error("Property " + CVESEARCH_OFFSET_PROPERTY_NAME + " is not an integer.");
+            invalidConfiguredServices.add(ThriftClients.CVESEARCH_SERVICE);
+        }
+
+        if(! props.containsKey(CVESEARCH_INTERVAL_PROPERTY_NAME)){
+            log.info("Property "+ CVESEARCH_INTERVAL_PROPERTY_NAME + " not set. Using default value.");
+        }
+        String cveSearchInterval  = props.getProperty(CVESEARCH_INTERVAL_PROPERTY_NAME, CVESEARCH_INTERVAL_DEFAULT);
+        try {
+            SYNC_INTERVAL_SEC.put(ThriftClients.CVESEARCH_SERVICE, Integer.parseInt(cveSearchInterval));
+        } catch (NumberFormatException nfe){
+            log.error("Property " + CVESEARCH_INTERVAL_PROPERTY_NAME + " is not an integer.");
+            invalidConfiguredServices.add(ThriftClients.CVESEARCH_SERVICE);
+        }
+
+        String autostartServicesString = props.getProperty(AUTOSTART_PROPERTY_NAME, "");
+        autostartServices = autostartServicesString.split(",");
     }
 
 }

--- a/backend/src/src-schedule/src/main/resources/sw360.properties
+++ b/backend/src/src-schedule/src/main/resources/sw360.properties
@@ -7,8 +7,11 @@
 # without any warranty.
 
 #in seconds of today: 0*60*60 = 0 means midnight
-schedule.firstOffset.seconds = 0
+schedule.cvesearch.firstOffset.seconds = 0
 
 #in seconds: 24*60*60 = 86400 means every 24 hours
-schedule.interval.seconds = 86400
+schedule.cvesearch.interval.seconds = 86400
 
+#general pattern for scheduling multiple services: autostart = service1,service2,service3,...
+#for scheduling the cvesearchService, uncomment the following line:
+#autostart = cvesearchService

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/common/PortalConstants.java
@@ -161,6 +161,13 @@ public class PortalConstants {
     //! Specialized keys for users
     public static final String CUSTOM_FIELD_PROJECT_GROUP_FILTER = "ProjectGroupFilter";
 
+    //! Specialized keys for scheduling
+    public static final String CVESEARCH_IS_SCHEDULED = "cveSearchIsScheduled";
+    public static final String ANY_SERVICE_IS_SCHEDULED = "anyServiceIsScheduled";
+    public static final String CVESEARCH_OFFSET = "cvesearchOffset";
+    public static final String CVESEARCH_INTERVAL = "cvesearchInterval";
+    public static final String CVESEARCH_NEXT_SYNC = "cvesearchNextSync";
+    
     //! Specialized keys for licenseInfo
     public static final String LICENSE_INFO_OUTPUT_FORMATS = "licenseInfoOutputFormats";
     public static final String LICENSE_INFO_SELECTED_OUTPUT_FORMAT = "licenseInfoSelectedOutputFormat";
@@ -178,8 +185,6 @@ public class PortalConstants {
     public static final String WHERE = "where";
     public static final String WHERE_ARRAY = "where[]";
     public static final String HOW = "how";
-
-
 
     //! Serve resource keywords
 

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/scheduleAdmin/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/scheduleAdmin/view.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="com.siemens.sw360.portal.common.PortalConstants" %><%--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016.
   ~
   ~ All rights reserved. This program and the accompanying materials
@@ -11,6 +11,12 @@
 <%-- the following is needed by liferay to display error messages--%>
 <%@include file="/html/utils/includes/errorKeyToMessage.jspf"%>
 <link rel="stylesheet" href="<%=request.getContextPath()%>/css/sw360.css">
+<jsp:useBean id='cveSearchIsScheduled' type="java.lang.Boolean" scope="request"/>
+<jsp:useBean id='anyServiceIsScheduled' type="java.lang.Boolean" scope="request"/>
+<jsp:useBean id='cvesearchOffset' type="java.lang.String" scope="request"/>
+<jsp:useBean id='cvesearchInterval' type="java.lang.String" scope="request"/>
+<jsp:useBean id='cvesearchNextSync' type="java.lang.String" scope="request"/>
+
 
 <portlet:defineObjects/>
 <liferay-theme:defineObjects/>
@@ -28,11 +34,26 @@
 <p class="pageHeader"><span class="pageHeaderBigSpan">Schedule Task Administration</span> </p>
 
 <h4 class="withTopMargin">CVE Search: </h4>
-<input type="button" class="addButton" onclick="window.location.href='<%=scheduleCvesearchURL%>'" value="Schedule CveSearch Updates">
+<br/>
+<b>Settings for scheduling the CVE search service:</b><br/>
+Offset: ${cvesearchOffset} (hh:mm:ss)<br/>
+Interval: ${cvesearchInterval} (hh:mm:ss)<br/>
+Next Synchronization: ${cvesearchNextSync}<br/>
+<br/>
+<input type="button"
+       <core_rt:if test="${cveSearchIsScheduled}">class="notApplicableButton"</core_rt:if>
+       <core_rt:if test="${not cveSearchIsScheduled}">class="addButton" onclick="window.location.href='<%=scheduleCvesearchURL%>'"</core_rt:if>
+       value="Schedule CveSearch Updates">
 
-<input type="button" class="addButton" onclick="window.location.href='<%=unscheduleCvesearchURL%>'" value="Cancel Scheduled CveSearch Updates">
+<input type="button"
+       <core_rt:if test="${cveSearchIsScheduled}">class="addButton"  onclick="window.location.href='<%=unscheduleCvesearchURL%>'"</core_rt:if>
+       <core_rt:if test="${not cveSearchIsScheduled}">class="notApplicableButton"</core_rt:if>
+       value="Cancel Scheduled CveSearch Updates">
 
 <h4 class="withTopMargin">All Services:</h4>
 
-<input type="button" class="addButton" onclick="window.location.href='<%=unscheduleAllServicesURL%>'" value="Cancel All Scheduled Tasks">
+<input type="button"
+       <core_rt:if test="${anyServiceIsScheduled}">class="addButton" onclick="window.location.href='<%=unscheduleAllServicesURL%>'" </core_rt:if>
+       <core_rt:if test="${not anyServiceIsScheduled}">class="notApplicableButton" </core_rt:if>
+       value="Cancel All Scheduled Tasks">
 

--- a/frontend/sw360-theme/src/main/webapp/css/navigation.css
+++ b/frontend/sw360-theme/src/main/webapp/css/navigation.css
@@ -131,7 +131,7 @@
 	background-color:#666666;
 }
 
-.addButton, .cancelButton, .acceptButton, .ignoreButton, .postponeButton {
+.addButton, .cancelButton, .acceptButton, .ignoreButton, .postponeButton, .notApplicableButton {
 	color: white;
     border: none;
     height: 25px;
@@ -161,27 +161,31 @@
     background-color: #767676;
 }
 
-.acceptButton{
+.acceptButton {
 	 background-color: #41e958;
  }
 
-.acceptButton:hover{
+.acceptButton:hover {
 	background-color: #1a875e;
 }
 
-.ignoreButton{
+.ignoreButton {
 	background-color: #ad1ae9;
 }
 
-.ignoreButton:hover{
+.ignoreButton:hover {
 	background-color: #4b2e88;
 }
 
-
-.postponeButton{
+.postponeButton {
 	background-color: #6860e9;
 }
 
-.postponeButton:hover{
+.postponeButton:hover {
 	background-color: #1a1ce9;
 }
+
+.notApplicableButton {
+	background-color: #bbbbbb;
+}
+

--- a/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/CommonUtils.java
+++ b/libraries/lib-datahandler/src/main/java/com/siemens/sw360/datahandler/common/CommonUtils.java
@@ -9,15 +9,12 @@
 package com.siemens.sw360.datahandler.common;
 
 import com.google.common.base.*;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.collect.*;
-import com.siemens.sw360.datahandler.thrift.DocumentState;
-import com.siemens.sw360.datahandler.thrift.ModerationState;
-import com.siemens.sw360.datahandler.thrift.RequestStatus;
-import com.siemens.sw360.datahandler.thrift.RequestSummary;
-import com.siemens.sw360.datahandler.thrift.attachments.Attachment;
-import com.siemens.sw360.datahandler.thrift.attachments.AttachmentContent;
-import com.siemens.sw360.datahandler.thrift.attachments.AttachmentType;
-import com.siemens.sw360.datahandler.thrift.attachments.CheckStatus;
+import com.siemens.sw360.datahandler.thrift.*;
+import com.siemens.sw360.datahandler.thrift.attachments.*;
+import com.siemens.sw360.datahandler.thrift.components.ClearingState;
 import com.siemens.sw360.datahandler.thrift.components.Release;
 import com.siemens.sw360.datahandler.thrift.licenses.Todo;
 import com.siemens.sw360.datahandler.thrift.moderation.ModerationRequest;
@@ -36,6 +33,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
 import java.util.Optional;
+import java.util.function.*;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.apache.log4j.LogManager.getLogger;
@@ -186,9 +184,11 @@ public class CommonUtils {
     public static boolean allAreEmptyOrNull(Collection... collections) {
         return !atLeastOneIsNotEmpty(collections);
     }
+
     public static boolean allAreEmptyOrNull(Map... maps) {
         return !atLeastOneIsNotEmpty(maps);
     }
+
     public static boolean allAreEmptyOrNull(String... strings) {
         return !atLeastOneIsNotEmpty(strings);
     }
@@ -531,6 +531,17 @@ public class CommonUtils {
             getLogger(CommonUtils.class).error("List contained more then one item but was treated as \"Optional\".");
         }
         return Optional.of(thriftOutput.get(0));
+    }
+
+    public static String formatTime(int seconds) {
+        if (seconds < 0) {
+            return "not set";
+        }
+        int hours = seconds / 3600;
+        int remainder = seconds % 3600;
+        int minutes = remainder / 60;
+        seconds = remainder % 60;
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
     }
 
     public static Map<String, Set<String>> mergeMapIntoMap(Map<String, Set<String>> source, Map<String, Set<String>> destination) {

--- a/libraries/lib-datahandler/src/main/thrift/schedule.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/schedule.thrift
@@ -16,6 +16,7 @@ namespace java com.siemens.sw360.datahandler.thrift.schedule
 namespace php sw360.thrift.schedule
 
 typedef sw360.RequestStatus RequestStatus
+typedef sw360.RequestStatusWithBoolean RequestStatusWithBoolean
 typedef sw360.RequestSummary RequestSummary
 typedef users.User User
 
@@ -27,7 +28,7 @@ service ScheduleService {
      *
      * user has to be admin, otherwise FAILURE is returned
      */
-    RequestSummary scheduleService(1: string serviceName, 2: User user);
+    RequestSummary scheduleService(1: string serviceName);
 
     /*
      * all tasks with  name serviceName are cancelled
@@ -40,4 +41,15 @@ service ScheduleService {
      * user has to be admin, otherwise FAILURE is returned
      */
     RequestStatus unscheduleAllServices(1: User user);
+
+
+    RequestStatusWithBoolean isServiceScheduled(1: string serviceName, 2: User user);
+
+    RequestStatusWithBoolean isAnyServiceScheduled(1: User user);
+
+    i32 getFirstRunOffset(string serviceName);
+
+    string getNextSync(string serviceName);
+
+    i32 getInterval(string serviceName);
 }

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -49,10 +49,10 @@ enum VerificationState {
 }
 
 struct VerificationStateInfo {
-    1: required string checkedOn,
-    2: required string checkedBy,
-    3: optional string comment,
-    4: required VerificationState verificationState,
+  1: required string checkedOn,
+  2: required string checkedBy,
+  3: optional string comment,
+  4: required VerificationState verificationState,
 }
 
 struct DocumentState {
@@ -73,4 +73,9 @@ struct CustomProperties {
     3: optional string type = "customproperties",
     4: optional string documentType,
     5: map<string, set<string>> propertyToValues;
+}
+
+struct RequestStatusWithBoolean {
+  1: required RequestStatus requestStatus;
+  2: optional bool answerPositive;
 }

--- a/libraries/lib-datahandler/src/test/java/com/siemens/sw360/datahandler/common/CommonUtilsTest.java
+++ b/libraries/lib-datahandler/src/test/java/com/siemens/sw360/datahandler/common/CommonUtilsTest.java
@@ -10,6 +10,7 @@ package com.siemens.sw360.datahandler.common;
 
 import org.junit.Test;
 
+import static com.siemens.sw360.datahandler.common.CommonUtils.formatTime;
 import static com.siemens.sw360.datahandler.common.CommonUtils.getTargetNameOfUrl;
 import static com.siemens.sw360.datahandler.common.CommonUtils.isValidUrl;
 import static org.hamcrest.core.Is.is;
@@ -19,7 +20,6 @@ import static org.junit.Assert.assertThat;
  * @author daniele.fognini@tngtech.com
  */
 public class CommonUtilsTest {
-
 
     @Test
     public void testIsUrl() throws Exception {
@@ -94,6 +94,31 @@ public class CommonUtilsTest {
     @Test
     public void testNameOfUrl7() throws Exception {
         assertThat(getTargetNameOfUrl("http://www.google.com/dir/file.ext?cookie=14&cr=345"), is("file.ext"));
+    }
+
+    @Test
+    public void testFormatTime0() throws Exception {
+        assertThat(formatTime(0), is("00:00:00"));
+    }
+
+    @Test
+    public void testFormatTimeSecond() throws Exception {
+        assertThat(formatTime(1), is("00:00:01"));
+    }
+
+    @Test
+    public void testFormatTimeMinute() throws Exception {
+        assertThat(formatTime(60), is("00:01:00"));
+    }
+
+    @Test
+    public void testFormatTimeHour() throws Exception {
+        assertThat(formatTime(3600), is("01:00:00"));
+    }
+
+    @Test
+    public void testFormatTime24Hours() throws Exception {
+        assertThat(formatTime(86400), is("24:00:00"));
     }
 
 }


### PR DESCRIPTION
This PR adds the functionality missed in the previous PR about cve search functionality.

* buttons enabled/disabled depending on whether or not cvesearch is scheduled
* offset, interval and nextScheduledSync displayed as settings

autostart scheduling

* after deployment, the scheduling service schedules all services that are registered in
the autostart property in the sw360.properties file
* if property file or one of the properties (offset, interval) is not present use default value
* if one of the properties is invalid, log this and do not schedule service
* default: cvesearch service is _not_ auto-scheduled