### PR TITLE
Improved Performance Of ProjectPortlet's List View

### DIFF
--- a/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -605,19 +605,6 @@ public class ComponentDatabaseHandler {
     // HELPER SERVICES //
     /////////////////////
 
-    /**
-     * Get a summary of release status for a given set of IDs
-     */
-    public ReleaseClearingStateSummary getReleaseClearingStateSummary(Set<String> ids, String clearingTeam) {
-
-        List<Release> releases = null;
-        if (ids != null && ids.size() > 0) {
-            releases = releaseRepository.get(ids);
-        }
-
-        return ReleaseClearingStateSummaryComputer.computeReleaseClearingStateSummary(releases, clearingTeam);
-    }
-
     public List<ReleaseLink> getLinkedReleases(Map<String, ?> relations, Map<String, Release> releaseMap) {
         List<ReleaseLink> out;
 
@@ -708,6 +695,16 @@ public class ComponentDatabaseHandler {
 
     public List<Release> getReleases(Set<String> ids, User user) {
         return releaseRepository.makeSummary(SummaryType.SHORT, ids);
+    }
+
+    /**
+     * Returns full documents straight from repository. Don't want this to get abused, that's why it's package-private.
+     * Used for bulk-computing ReleaseClearingStateSummaries by ProjectDatabaseHandler.
+     * The reason for this hack is that making summaries (like in getReleases()) takes way too long for a lot of
+     * releases.
+     */
+    List<Release> getReleasesForClearingStateSummary(Set<String> ids) {
+        return releaseRepository.get(ids);
     }
 
     public List<Release> getDetailedReleasesForExport(Set<String> ids) {

--- a/backend/src/src-components/src/main/java/com/siemens/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/com/siemens/sw360/components/ComponentHandler.java
@@ -8,7 +8,6 @@
  */
 package com.siemens.sw360.components;
 
-import com.siemens.sw360.attachments.AttachmentHandler;
 import com.siemens.sw360.datahandler.common.DatabaseSettings;
 import com.siemens.sw360.datahandler.db.ComponentDatabaseHandler;
 import com.siemens.sw360.datahandler.db.ComponentSearchHandler;
@@ -40,7 +39,6 @@ public class ComponentHandler implements ComponentService.Iface {
 
     private final ComponentDatabaseHandler handler;
     private final ComponentSearchHandler searchHandler;
-    private final AttachmentHandler attachmentHandler;
 
     public ComponentHandler() throws IOException {
         this(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS);
@@ -49,7 +47,6 @@ public class ComponentHandler implements ComponentService.Iface {
     ComponentHandler(Supplier<HttpClient> httpClient, String dbName, String attachmentDbName) throws IOException {
         handler = new ComponentDatabaseHandler(httpClient, dbName, attachmentDbName);
         searchHandler = new ComponentSearchHandler(httpClient, dbName);
-        attachmentHandler = new AttachmentHandler();
     }
 
     // TODO use dependency injection instead of this constructors mess
@@ -60,7 +57,6 @@ public class ComponentHandler implements ComponentService.Iface {
     ComponentHandler(Supplier<HttpClient> httpClient, String dbName, String attachmentDbName, ThriftClients thriftClients) throws IOException {
         handler = new ComponentDatabaseHandler(httpClient, dbName, attachmentDbName, thriftClients);
         searchHandler = new ComponentSearchHandler(httpClient, dbName);
-        attachmentHandler = new AttachmentHandler();
     }
 
     /////////////////////
@@ -354,14 +350,6 @@ public class ComponentHandler implements ComponentService.Iface {
         assertId(id);
 
         return handler.unsubscribeRelease(id, user);
-    }
-
-    ///////////////////////////////
-    // HELPER METHODS            //
-    ///////////////////////////////
-    @Override
-    public ReleaseClearingStateSummary getReleaseClearingStateSummary(Set<String> ids, String clearingTeam) throws TException {
-        return handler.getReleaseClearingStateSummary(ids, clearingTeam);
     }
 
     /////////////////////

--- a/backend/src/src-projects/src/main/java/com/siemens/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/com/siemens/sw360/projects/ProjectHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,6 @@
  */
 package com.siemens.sw360.projects;
 
-import com.siemens.sw360.attachments.AttachmentHandler;
 import com.siemens.sw360.datahandler.common.CommonUtils;
 import com.siemens.sw360.datahandler.common.DatabaseSettings;
 import com.siemens.sw360.datahandler.thrift.RequestStatus;
@@ -33,6 +32,7 @@ import static com.siemens.sw360.datahandler.common.SW360Assert.*;
  *
  * @author cedric.bodet@tngtech.com
  * @author Johannes.Najjar@tngtech.com
+ * @author alex.borodin@evosoft.com
  */
 public class ProjectHandler implements ProjectService.Iface {
 
@@ -203,6 +203,11 @@ public class ProjectHandler implements ProjectService.Iface {
     @Override
     public Map<String, List<String>> getDuplicateProjects() throws TException {
         return handler.getDuplicateProjects();
+    }
+
+    @Override
+    public List<Project> fillClearingStateSummary(List<Project> projects, User user) throws TException {
+        return handler.fillClearingStateSummary(projects, user);
     }
 
     @Override

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -492,11 +492,6 @@ service ComponentService {
     RequestStatus unsubscribeRelease(1: string id, 2: User user);
 
     /**
-     * Get a summary of release status for a given set of IDs
-     **/
-    ReleaseClearingStateSummary getReleaseClearingStateSummary(1: set<string> ids, 2:string clearingTeam);
-
-    /**
      * Make a list of components for Excel export and component importer
      **/
     list<Component> getComponentSummaryForExport();

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -223,10 +223,14 @@ service ProjectService {
      */
     list<ProjectLink> getLinkedProjects(1:  map<string, ProjectRelationship> relations);
 
-
     /**
      * get a list of duplicated projects matched by `.printName()`
      * returned as map from pretty printed name to list of matching ids
      */
     map <string, list<string>> getDuplicateProjects();
+
+    /**
+    * get the same list of projects back, but with filled release clearing state summaries
+     */
+    list<Project> fillClearingStateSummary(list<Project> projects, User user);
 }


### PR DESCRIPTION
moved computing release clearing state summaries to `ProjectDatabaseHandler` and made `ProjectPortlet` compute in bulk for all projects to save the roundtrips to backend and to the DB

closes #263 