### PR TITLE
fix: linked projects and linked releases tree-tables expand wrong node

### DIFF
--- a/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/CountingStack.java
+++ b/backend/src-common/src/main/java/com/siemens/sw360/datahandler/db/CountingStack.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package com.siemens.sw360.datahandler.db;
+
+import java.util.HashMap;
+import java.util.Stack;
+
+/**
+ * A Stack that counts how many times each item has been pushed during the lifetime of the stack object.
+ * (i.e. counts are not decremented when an item is popped.)
+ *
+ * @author: alex.borodin@evosoft.com
+ */
+class CountingStack<E> extends Stack<E> {
+    private HashMap<E, Integer> counts = new HashMap<>();
+
+    @Override
+    public E push(E item) {
+        int count = getCount(item);
+        counts.put(item, count + 1);
+        return super.push(item);
+    }
+
+    public int getCount(E item) {
+        return counts.containsKey(item) ? counts.get(item) : 0;
+    }
+}

--- a/backend/src/src-components/src/test/java/com/siemens/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/com/siemens/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -357,30 +357,37 @@ public class ComponentDatabaseHandlerTest {
 
         ReleaseLink releaseLinkR1B_R2B = new ReleaseLink("R1B",vendors.get(r1B.getVendorId()).getFullname(), componentMap.get(r1B.getComponentId()).getName(),r1B.getVersion())
                 .setReleaseRelationship(ReleaseRelationship.CONTAINED)
-                .setParentId("R2B")
+                .setNodeId("R1B_2")
+                .setParentNodeId("R2B_2")
                 .setSubreleases(Collections.emptyList());
         ReleaseLink releaseLinkR2B_exp = new ReleaseLink("R2B", vendors.get(r2B.getVendorId()).getFullname(), componentMap.get(r2B.getComponentId()).getName(), r2B.getVersion())
                 .setReleaseRelationship(ReleaseRelationship.CONTAINED)
-                .setParentId("R2A")
+                .setNodeId("R2B_2")
+                .setParentNodeId("R2A_2")
                 .setSubreleases(Arrays.asList(releaseLinkR1B_R2B));
         ReleaseLink releaseLinkR2B = new ReleaseLink("R2B", vendors.get(r2B.getVendorId()).getFullname(), componentMap.get(r2B.getComponentId()).getName(), r2B.getVersion())
                 .setReleaseRelationship(ReleaseRelationship.CONTAINED)
-                .setParentId("R2A")
+                .setNodeId("R2B_1")
+                .setParentNodeId("R2A_1")
                 .setSubreleases(Collections.emptyList());
         ReleaseLink releaseLinkR2A_R1B = new ReleaseLink("R2A", vendors.get(r2A.getVendorId()).getFullname(), componentMap.get(r2A.getComponentId()).getName(), r2A.getVersion())
                 .setReleaseRelationship(ReleaseRelationship.REFERRED)
-                .setParentId("R1B")
+                .setNodeId("R2A_1")
+                .setParentNodeId("R1B_1")
                 .setSubreleases(Arrays.asList(releaseLinkR2B));
         ReleaseLink releaseLinkR2A_R1A = new ReleaseLink("R2A", vendors.get(r2A.getVendorId()).getFullname(), componentMap.get(r2A.getComponentId()).getName(), r2A.getVersion())
                 .setReleaseRelationship(ReleaseRelationship.REFERRED)
-                .setParentId("R1A")
+                .setNodeId("R2A_2")
+                .setParentNodeId("R1A_1")
                 .setSubreleases(Arrays.asList(releaseLinkR2B_exp));
         ReleaseLink releaseLinkR1B_R1A = new ReleaseLink("R1B",vendors.get(r1B.getVendorId()).getFullname(), componentMap.get(r1B.getComponentId()).getName(),r1B.getVersion())
                 .setReleaseRelationship(ReleaseRelationship.CONTAINED)
-                .setParentId("R1A")
+                .setNodeId("R1B_1")
+                .setParentNodeId("R1A_1")
                 .setSubreleases(Arrays.asList(releaseLinkR2A_R1B));
         ReleaseLink releaseLinkR1A = new ReleaseLink("R1A",vendors.get(r1A.getVendorId()).getFullname(), componentMap.get(r1A.getComponentId()).getName(), r1A.getVersion())
                 .setComment("Important linked release")
+                .setNodeId("R1A_1")
                 .setSubreleases(Arrays.asList(releaseLinkR1B_R1A, releaseLinkR2A_R1A));
 
         assertThat(linkedReleases, contains(releaseLinkR1A));
@@ -409,12 +416,7 @@ public class ComponentDatabaseHandlerTest {
         // we wrap the potentially infinite loop in an executor
         final ExecutorService service = Executors.newSingleThreadExecutor();
 
-        final Future<List<ReleaseLink>> completionFuture = service.submit(new Callable<List<ReleaseLink>>() {
-            @Override
-            public List<ReleaseLink> call() throws Exception {
-                return handler.getLinkedReleases(relations);
-            }
-        });
+        final Future<List<ReleaseLink>> completionFuture = service.submit(() -> handler.getLinkedReleases(relations));
 
         service.shutdown();
         service.awaitTermination(10, TimeUnit.SECONDS);
@@ -423,16 +425,20 @@ public class ComponentDatabaseHandlerTest {
 
         ReleaseLink releaseLinkR2A_R1A = new ReleaseLink("R2A", vendors.get(r2A.getVendorId()).getFullname(), componentMap.get(r2A.getComponentId()).getName(), r2A.getVersion())
                 .setReleaseRelationship(ReleaseRelationship.REFERRED)
-                .setParentId("R1A");
+                .setNodeId("R2A_2")
+                .setParentNodeId("R1A_1");
         ReleaseLink releaseLinkR2A_R1B = new ReleaseLink("R2A", vendors.get(r2A.getVendorId()).getFullname(), componentMap.get(r2A.getComponentId()).getName(), r2A.getVersion())
                 .setReleaseRelationship(ReleaseRelationship.CONTAINED)
-                .setParentId("R1B");
+                .setNodeId("R2A_1")
+                .setParentNodeId("R1B_1");
         ReleaseLink releaseLinkR1B = new ReleaseLink("R1B",vendors.get(r1B.getVendorId()).getFullname(), componentMap.get(r1B.getComponentId()).getName(),r1B.getVersion())
                 .setReleaseRelationship(ReleaseRelationship.CONTAINED)
-                .setParentId("R1A")
+                .setNodeId("R1B_1")
+                .setParentNodeId("R1A_1")
                 .setSubreleases(Arrays.asList(releaseLinkR2A_R1B));
         ReleaseLink releaseLinkR1A = new ReleaseLink("R1A",vendors.get(r1A.getVendorId()).getFullname(), componentMap.get(r1A.getComponentId()).getName(), r1A.getVersion())
                 .setComment("Important linked release")
+                .setNodeId("R1A_1")
                 .setSubreleases(Arrays.asList(releaseLinkR1B, releaseLinkR2A_R1A));
 
         assertThat(linkedReleases, contains(releaseLinkR1A));

--- a/backend/src/src-components/src/test/java/com/siemens/sw360/components/db/ProjectDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/com/siemens/sw360/components/db/ProjectDatabaseHandlerTest.java
@@ -132,27 +132,31 @@ public class ProjectDatabaseHandlerTest {
 
         final List<ProjectLink> linkedProjects = completionFuture.get();
 
-        ReleaseLink releaseLinkR1A = new ReleaseLink("R1A", "vendor", "component1", "releaseA").setComment("used");
-        ReleaseLink releaseLinkR1B = new ReleaseLink("R1B", "vendor", "component1", "releaseB").setComment("abused");
-        ReleaseLink releaseLinkR2A = new ReleaseLink("R2A", "vendor", "component2", "releaseA").setComment("used");
-        ReleaseLink releaseLinkR2B = new ReleaseLink("R2B", "vendor", "component2", "releaseB").setComment("considered for use");
+        ReleaseLink releaseLinkR1A = new ReleaseLink("R1A", "vendor", "component1", "releaseA").setComment("used").setNodeId("R1A_1");
+        ReleaseLink releaseLinkR1B = new ReleaseLink("R1B", "vendor", "component1", "releaseB").setComment("abused").setNodeId("R1B_1");
+        ReleaseLink releaseLinkR2A = new ReleaseLink("R2A", "vendor", "component2", "releaseA").setComment("used").setNodeId("R2A_1");
+        ReleaseLink releaseLinkR2B = new ReleaseLink("R2B", "vendor", "component2", "releaseB").setComment("considered for use").setNodeId("R2B_1");
 
         ProjectLink link3 = new ProjectLink("P3", "project3")
                 .setRelation(ProjectRelationship.REFERRED)
-                .setParentId("P2")
+                .setNodeId("P3_1")
+                .setParentNodeId("P2_1")
                 .setLinkedReleases(Arrays.asList(releaseLinkR2A, releaseLinkR2B))
                 .setSubprojects(Collections.emptyList());
         ProjectLink link4 = new ProjectLink("P4", "project4")
                 .setRelation(ProjectRelationship.CONTAINED)
-                .setParentId("P2")
+                .setNodeId("P4_1")
+                .setParentNodeId("P2_1")
                 .setSubprojects(Collections.emptyList());
         ProjectLink link2 = new ProjectLink("P2", "project2")
                 .setRelation(ProjectRelationship.CONTAINED)
-                .setParentId("P1")
+                .setNodeId("P2_1")
+                .setParentNodeId("P1_1")
                 .setLinkedReleases(Arrays.asList(releaseLinkR1A, releaseLinkR1B))
                 .setSubprojects(Arrays.asList(link3, link4));
         ProjectLink link1 = new ProjectLink("P1", "project1")
                 .setRelation(ProjectRelationship.UNKNOWN)
+                .setNodeId("P1_1")
                 .setSubprojects(Arrays.asList(link2));
 
         assertThat(linkedProjects, contains(link1));
@@ -173,18 +177,21 @@ public class ProjectDatabaseHandlerTest {
 
         ProjectLink link7_5 = new ProjectLink("P7", "project7")
                 .setRelation(ProjectRelationship.CONTAINED)
-                .setParentId("P5");
-//                .setSubprojects(Collections.emptyList());
+                .setNodeId("P7_2")
+                .setParentNodeId("P5_1");
         ProjectLink link7_6 = new ProjectLink("P7", "project7")
                 .setRelation(ProjectRelationship.CONTAINED)
-                .setParentId("P6");
-//                .setSubprojects(Collections.emptyList());
+                .setNodeId("P7_1")
+                .setParentNodeId("P6_1");
+
         ProjectLink link6 = new ProjectLink("P6", "project6")
                 .setRelation(ProjectRelationship.CONTAINED)
-                .setParentId("P5")
+                .setNodeId("P6_1")
+                .setParentNodeId("P5_1")
                 .setSubprojects(Arrays.asList(link7_6));
         ProjectLink link5 = new ProjectLink("P5", "project5")
                 .setRelation(ProjectRelationship.CONTAINED)
+                .setNodeId("P5_1")
                 .setSubprojects(Arrays.asList(link6, link7_5));
 
         assertThat(linkedProjects, contains(link5));

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/linkedProjects.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/linkedProjects.jspf
@@ -47,8 +47,8 @@
     <tbody>
     <%--directly linked releases--%>
     <core_rt:forEach items="${requestScope.releaseList}" var="releaseLink" varStatus="loop">
-        <core_rt:if test="${empty releaseLink.parentId}"> <%--take only those that don't have parents, i.e. are directly linked by the current project--%>
-            <tr id="releaseLinkRow${loop.count}" data-tt-id="${releaseLink.id}">
+        <core_rt:if test="${empty releaseLink.parentNodeId}"> <%--take only those that don't have parents, i.e. are directly linked by the current project--%>
+            <tr id="releaseLinkRow${loop.count}" data-tt-id="${releaseLink.nodeId}">
                 <td>
                     <a href="<sw360:DisplayReleaseLink releaseId="${releaseLink.id}" bare="true" />">
                         <sw360:out value="${releaseLink.vendor}"/><core_rt:if
@@ -78,9 +78,9 @@
     </core_rt:forEach>
     <%--linked projects and their linked projects--%>
     <core_rt:forEach items="${projectList}" var="projectLink" varStatus="loop">
-        <tr id="projectLinkRow${loop.count}" data-tt-id="${projectLink.id}"
+        <tr id="projectLinkRow${loop.count}" data-tt-id="${projectLink.nodeId}"
             <core_rt:if
-                    test="${not empty projectLink.parentId}">data-tt-parent-id="${projectLink.parentId}"</core_rt:if>
+                    test="${not empty projectLink.parentNodeId}">data-tt-parent-id="${projectLink.parentNodeId}"</core_rt:if>
         >
             <td>
                 <a href="<sw360:DisplayProjectLink projectId="${projectLink.id}" bare="true" />"><sw360:out
@@ -97,8 +97,8 @@
         </tr>
         <%--linked releases of linked projects--%>
         <core_rt:forEach items="${projectLink.linkedReleases}" var="releaseLink" varStatus="releaseloop">
-            <tr id="releaseLinkRow${loop.count}_${releaseloop.count}" data-tt-id="${releaseLink.id}"
-                data-tt-parent-id="${projectLink.id}">
+            <tr id="releaseLinkRow${loop.count}_${releaseloop.count}" data-tt-id="${releaseLink.nodeId}"
+                data-tt-parent-id="${projectLink.nodeId}">
                 <td>
                     <a href="<sw360:DisplayReleaseLink releaseId="${releaseLink.id}" bare="true" />">
                         <sw360:out value="${releaseLink.vendor}"/><core_rt:if

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/linkedReleaseDetails.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/linkedReleaseDetails.jspf
@@ -37,9 +37,9 @@
     </thead>
     <tbody>
     <core_rt:forEach items="${releaseList}" var="releaseLink" varStatus="loop">
-        <tr id="releaseLinkRow${loop.count}" data-tt-id="${releaseLink.id}"
+        <tr id="releaseLinkRow${loop.count}" data-tt-id="${releaseLink.nodeId}"
             <core_rt:if
-                    test="${not empty releaseLink.parentId}">data-tt-parent-id="${releaseLink.parentId}"</core_rt:if>
+                    test="${not empty releaseLink.parentNodeId}">data-tt-parent-id="${releaseLink.parentNodeId}"</core_rt:if>
         >
             <td>
                 <a href="<sw360:DisplayReleaseLink releaseId="${releaseLink.id}" bare="true" />">

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -271,8 +271,10 @@ struct ReleaseLink{
     10: required string version,
     15: optional string comment,
     16: optional ReleaseRelationship releaseRelationship,
-    20: optional string parentId,
+//    20: optional string parentId,
     21: optional list<ReleaseLink> subreleases,
+    25: optional string nodeId,
+    26: optional string parentNodeId,
 
     31: optional ClearingState clearingState,
     100: optional set<string> licenseIds,

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -107,7 +107,9 @@ struct ProjectLink {
     2: required string name,
     3: optional ProjectRelationship relation,
     4: optional string version,
-    5: optional string parentId,
+//    5: optional string parentId,
+    6: optional string nodeId,
+    7: optional string parentNodeId,
     10: optional list<ReleaseLink> linkedReleases,
     11: optional list<ProjectLink> subprojects,
 }


### PR DESCRIPTION
fix: linked projects and linked releases tree-tables expand wrong node when the same project or release is present elsewhere in the table.

#### Background
For tree-table expanding/collapsing to work correctly, values of `data-tt-id` attribute must be unique within the table. Previously, every project or release could only occur once in the table and couchdb ids were used for `data-tt-id`, but PR #264 allowed the same object to be included multiple times in the table, which broke the expanding/collapsing functionality as `data-tt-id`s were not unique anymore.