### PR TITLE
stop CveSearch tests from failing behind proxy

### DIFF
--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/service/CveSearchHandler.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/service/CveSearchHandler.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2016.
+ * With modifications by Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
@@ -33,6 +34,7 @@ import static org.eclipse.sw360.cvesearch.helper.VulnerabilityUtils.*;
 
 public class CveSearchHandler implements CveSearchService.Iface {
 
+    public static final String CVESEARCH_HOST_PROPERTY = "cvesearch.host";
     VulnerabilityConnector vulnerabilityConnector;
     CveSearchWrapper cveSearchWrapper;
     Logger log = Logger.getLogger(CveSearchHandler.class);
@@ -46,7 +48,7 @@ public class CveSearchHandler implements CveSearchService.Iface {
         }
 
         Properties props = CommonUtils.loadProperties(CveSearchHandler.class, "/cvesearch.properties");
-        String host = props.getProperty("cvesearch.host","https://localhost:5000");
+        String host = props.getProperty(CVESEARCH_HOST_PROPERTY, "https://localhost:5000");
 
         cveSearchWrapper = new CveSearchWrapper(new CveSearchApiImpl(host));
     }

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchApiImplTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchApiImplTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2016.
+ * With modifications by Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
@@ -10,12 +11,16 @@
 package org.eclipse.sw360.cvesearch.datasource;
 
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.cvesearch.service.CveSearchHandler;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
+
+import static org.eclipse.sw360.cvesearch.datasource.CveSearchDataTestHelper.isUrlReachable;
 
 public class CveSearchApiImplTest {
 
@@ -29,7 +34,8 @@ public class CveSearchApiImplTest {
     @Before
     public void setUp() {
         Properties props = CommonUtils.loadProperties(CveSearchApiImplTest.class, "/cvesearch.properties");
-        String host = props.getProperty("cvesearch.host","https://localhost:5000");
+        String host = props.getProperty(CveSearchHandler.CVESEARCH_HOST_PROPERTY, "https://localhost:5000");
+        Assume.assumeTrue("CVE Search host is reachable", isUrlReachable(host));
         cveSearchApi = new CveSearchApiImpl(host);
     }
 

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchDataTestHelper.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchDataTestHelper.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2016.
+ * With modifications by Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
@@ -9,12 +10,17 @@
  */
 package org.eclipse.sw360.cvesearch.datasource;
 
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class CveSearchDataTestHelper {
 
+
+    private static final int CONNECT_TIMEOUT = 10000;
 
     public static boolean isEquivalent(List<CveSearchData> l1, List<CveSearchData> l2){
         int s = l1.size();
@@ -26,5 +32,16 @@ public class CveSearchDataTestHelper {
         return IntStream.range(0,s)
                 .mapToObj(i -> ids1.get(i).equals(ids2.get(i)))
                 .reduce(true, Boolean::logicalAnd);
+    }
+
+    public static boolean isUrlReachable(String url) {
+        try {
+            final URLConnection connection = new URL(url).openConnection();
+            connection.setConnectTimeout(CONNECT_TIMEOUT);
+            connection.connect();
+            return true;
+        } catch (final IOException e) {
+            return false;
+        }
     }
 }

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchGuesserTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchGuesserTest.java
@@ -1,13 +1,28 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2016.
+ * With modifications by Siemens AG, 2016.
+ * Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.sw360.cvesearch.datasource;
 
 import org.eclipse.sw360.cvesearch.datasource.matcher.Match;
+import org.eclipse.sw360.cvesearch.service.CveSearchHandler;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
+import static org.eclipse.sw360.cvesearch.datasource.CveSearchDataTestHelper.isUrlReachable;
 import static org.junit.Assert.*;
 
 public class CveSearchGuesserTest {
@@ -17,7 +32,10 @@ public class CveSearchGuesserTest {
 
     @Before
     public void setup() throws IOException {
-        cveSearchApi = new CveSearchApiImpl("https://cve.circl.lu");
+        Properties props = CommonUtils.loadProperties(CveSearchGuesserTest.class, "/cvesearch.properties");
+        String host = props.getProperty(CveSearchHandler.CVESEARCH_HOST_PROPERTY, "https://cve.circl.lu");
+        Assume.assumeTrue("CVE Search host is reachable", isUrlReachable(host));
+        cveSearchApi = new CveSearchApiImpl(host);
         this.cveSearchGuesser = new CveSearchGuesser(cveSearchApi);
     }
 

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchWrapperTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchWrapperTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2016.
+ * With modifications by Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
@@ -12,6 +13,8 @@ package org.eclipse.sw360.cvesearch.datasource;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+import org.eclipse.sw360.cvesearch.service.CveSearchHandler;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -22,6 +25,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static org.eclipse.sw360.cvesearch.datasource.CveSearchDataTestHelper.isEquivalent;
+import static org.eclipse.sw360.cvesearch.datasource.CveSearchDataTestHelper.isUrlReachable;
 
 public class CveSearchWrapperTest {
     CveSearchApi cveSearchApi;
@@ -113,7 +117,8 @@ public class CveSearchWrapperTest {
     @Before
     public void setUp() {
         Properties props = CommonUtils.loadProperties(CveSearchWrapperTest.class, "/cvesearch.properties");
-        String host = props.getProperty("cvesearch.host","https://cve.circl.lu");
+        String host = props.getProperty(CveSearchHandler.CVESEARCH_HOST_PROPERTY, "https://cve.circl.lu");
+        Assume.assumeTrue("CVE Search host is reachable", isUrlReachable(host));
         cveSearchApi = new CveSearchApiImpl(host);
 
         cveSearchWrapper = new CveSearchWrapper(cveSearchApi);

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/entitytranslation/CveSearchDataTranslatorTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/entitytranslation/CveSearchDataTranslatorTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Bosch Software Innovations GmbH 2016.
+ * With modifications by Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
@@ -11,9 +12,11 @@ package org.eclipse.sw360.cvesearch.entitytranslation;
 
 import org.eclipse.sw360.cvesearch.datasource.CveSearchApiImpl;
 import org.eclipse.sw360.cvesearch.datasource.CveSearchData;
+import org.eclipse.sw360.cvesearch.service.CveSearchHandler;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.CVEReference;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,9 +24,9 @@ import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class CveSearchDataTranslatorTest {
+import static org.eclipse.sw360.cvesearch.datasource.CveSearchDataTestHelper.isUrlReachable;
 
-    String HOST = "https://cve.circl.lu";
+public class CveSearchDataTranslatorTest {
 
     CveSearchData cveSearchData;
     String host;
@@ -96,7 +99,8 @@ public class CveSearchDataTranslatorTest {
         cveSearchDataToVulnerabilityTranslator = new CveSearchDataToVulnerabilityTranslator();
 
         Properties props = CommonUtils.loadProperties(CveSearchDataTranslatorTest.class, "/cvesearch.properties");
-        host = props.getProperty("cvesearch.host","http://localhost:5000");
+        host = props.getProperty(CveSearchHandler.CVESEARCH_HOST_PROPERTY, "http://localhost:5000");
+        Assume.assumeTrue("CVE Search host is reachable", isUrlReachable(host));
     }
 
     @Test


### PR DESCRIPTION
I couldn't find a way to make the tests actually work. No combination of options seemed to work in my environment. So I added JUnit's Assume assumptions to the failing tests, such that when the cvesearch host is not reachable, the test is ignored instead of failing.

Needs to be tested in an environment where a cvesearch host is actually available to make sure the tests aren't ignored there.

closes #279 
