### PR TITLE
Improvements At Linked Projects And LicenseInfo Generation

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -259,6 +259,7 @@ public class ProjectDatabaseHandler {
                 out.add(projectLinkOptional.get());
             }
         }
+        out.sort(Comparator.comparing(ProjectLink::getName).thenComparing(ProjectLink::getVersion));
         return out;
     }
 
@@ -274,10 +275,13 @@ public class ProjectDatabaseHandler {
                     projectLink.setLinkedReleases(nullToEmptyList(linkedReleases));
                 }
 
-                projectLink.setNodeId(generateNodeId(id, visitedIds));
-                projectLink.setParentNodeId(generateNodeId(parentId, visitedIds));
-                projectLink.setRelation(relationship);
-                projectLink.setVersion(project.getVersion());
+                projectLink
+                        .setNodeId(generateNodeId(id, visitedIds))
+                        .setParentNodeId(generateNodeId(parentId, visitedIds))
+                        .setRelation(relationship)
+                        .setVersion(project.getVersion())
+                        .setProjectType(project.getProjectType())
+                        .setClearingState(project.getClearingState());
                 if (project.isSetLinkedProjects()) {
                     List<ProjectLink> subprojectLinks = iterateProjectRelationShips(project.getLinkedProjects(), id, visitedIds, projectMap, releaseMap);
                     projectLink.setSubprojects(subprojectLinks);

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -390,7 +390,7 @@ public class ComponentDatabaseHandlerTest {
         ReleaseLink releaseLinkR1A = new ReleaseLink("R1A",vendors.get(r1A.getVendorId()).getFullname(), componentMap.get(r1A.getComponentId()).getName(), r1A.getVersion())
                 .setComment("Important linked release")
                 .setNodeId("R1A_1")
-                .setSubreleases(Arrays.asList(releaseLinkR1B_R1A, releaseLinkR2A_R1A));
+                .setSubreleases(Arrays.asList(releaseLinkR2A_R1A, releaseLinkR1B_R1A));
 
         assertThat(linkedReleases, contains(releaseLinkR1A));
     }
@@ -441,7 +441,7 @@ public class ComponentDatabaseHandlerTest {
         ReleaseLink releaseLinkR1A = new ReleaseLink("R1A",vendors.get(r1A.getVendorId()).getFullname(), componentMap.get(r1A.getComponentId()).getName(), r1A.getVersion())
                 .setComment("Important linked release")
                 .setNodeId("R1A_1")
-                .setSubreleases(Arrays.asList(releaseLinkR1B, releaseLinkR2A_R1A));
+                .setSubreleases(Arrays.asList(releaseLinkR2A_R1A, releaseLinkR1B));
 
         assertThat(linkedReleases, contains(releaseLinkR1A));
     }

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ProjectDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ProjectDatabaseHandlerTest.java
@@ -16,6 +16,8 @@ import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
 import org.eclipse.sw360.datahandler.db.ProjectDatabaseHandler;
 import org.eclipse.sw360.datahandler.entitlement.ProjectModerator;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
@@ -55,6 +57,7 @@ public class ProjectDatabaseHandlerTest {
     private List<Project> projects;
     private List<Vendor> vendors;
     private List<Release> releases;
+    private List<Component> components;
     private ProjectDatabaseHandler handler;
 
     @Mock
@@ -77,6 +80,10 @@ public class ProjectDatabaseHandlerTest {
         releases.add(release2a);
         Release release2b = new Release().setId("R2B").setComponentId("C2").setName("component2").setVersion("releaseB").setVendorId("V1");
         releases.add(release2b);
+
+        components = new ArrayList<>();
+        Component component1 = new Component().setId("C1").setName("component1").setDescription("d1").setComponentType(ComponentType.OSS);
+        components.add(component1);
 
         projects = new ArrayList<>();
         Project project1 = new Project().setId("P1").setName("project1").setLinkedProjects(ImmutableMap.of("P2", ProjectRelationship.CONTAINED));
@@ -106,6 +113,9 @@ public class ProjectDatabaseHandlerTest {
         for (Release release : releases) {
             databaseConnector.add(release);
         }
+        for (Component component : components) {
+            databaseConnector.add(component);
+        }
         for (Project project : projects) {
             databaseConnector.add(project);
         }
@@ -132,8 +142,8 @@ public class ProjectDatabaseHandlerTest {
 
         final List<ProjectLink> linkedProjects = completionFuture.get();
 
-        ReleaseLink releaseLinkR1A = new ReleaseLink("R1A", "vendor", "component1", "releaseA").setComment("used").setNodeId("R1A_1");
-        ReleaseLink releaseLinkR1B = new ReleaseLink("R1B", "vendor", "component1", "releaseB").setComment("abused").setNodeId("R1B_1");
+        ReleaseLink releaseLinkR1A = new ReleaseLink("R1A", "vendor", "component1", "releaseA").setComment("used").setNodeId("R1A_1").setComponentType(ComponentType.OSS);
+        ReleaseLink releaseLinkR1B = new ReleaseLink("R1B", "vendor", "component1", "releaseB").setComment("abused").setNodeId("R1B_1").setComponentType(ComponentType.OSS);
         ReleaseLink releaseLinkR2A = new ReleaseLink("R2A", "vendor", "component2", "releaseA").setComment("used").setNodeId("R2A_1");
         ReleaseLink releaseLinkR2B = new ReleaseLink("R2B", "vendor", "component2", "releaseB").setComment("considered for use").setNodeId("R2B_1");
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
@@ -24,6 +24,7 @@ import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.cvesearch.UpdateType;
 import org.eclipse.sw360.datahandler.thrift.cvesearch.VulnerabilityUpdateStatus;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectState;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectType;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -92,6 +93,10 @@ public class PortletUtils {
         return ProjectState.findByValue(parseInt(enumNumber));
     }
 
+    public static ProjectClearingState getProjectClearingStateFromString(String enumNumber) {
+        return ProjectClearingState.findByValue(parseInt(enumNumber));
+    }
+
     public static ProjectType getProjectTypeFromString(String enumNumber) {
         return ProjectType.findByValue(parseInt(enumNumber));
     }
@@ -141,6 +146,8 @@ public class PortletUtils {
             return getMainlineStatefromString(value);
         else if (field == Project._Fields.STATE)
             return getProjectStateFromString(value);
+        else if (field == Project._Fields.CLEARING_STATE)
+            return getProjectClearingStateFromString(value);
         else if (field == Project._Fields.PROJECT_TYPE)
             return getProjectTypeFromString(value);
         else if (field == Project._Fields.VISBILITY)

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/OutTag.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/OutTag.java
@@ -13,6 +13,8 @@ import org.apache.taglibs.standard.tag.common.core.OutSupport;
 
 import javax.servlet.jsp.JspException;
 
+import java.io.IOException;
+
 import static java.util.regex.Matcher.quoteReplacement;
 
 /**
@@ -38,9 +40,14 @@ public class OutTag extends OutSupport {
     @Override
     public int doStartTag() throws JspException {
         if (value instanceof String) {
+            boolean abbreviated = false;
             String candidate = (String) this.value;
+            String originalValue = candidate;
             if (maxChar > 4) {
                 candidate = StringUtils.abbreviate(candidate, maxChar);
+                if (!originalValue.equals(candidate)){
+                    abbreviated = true;
+                }
             }
 
             if (stripNewlines){
@@ -52,6 +59,17 @@ public class OutTag extends OutSupport {
                 candidate = escapeInDoubleQuote(candidate);
             }
             this.value = candidate;
+
+            if (abbreviated) {
+                try {
+                    this.pageContext.getOut().write("<span title=\"" + escapeInDoubleQuote(originalValue) + "\">");
+                    int i = super.doStartTag();
+                    this.pageContext.getOut().write("</span>");
+                    return i;
+                } catch (IOException e) {
+                    throw new JspException(e.toString(), e);
+                }
+            }
         }
         return super.doStartTag();
     }

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/linkedProjects.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/linkedProjects.jspf
@@ -22,16 +22,18 @@
 <link rel="stylesheet" href="<%=request.getContextPath()%>/css/jquery.treetable.theme.sw360.css"/>
 <script src="<%=request.getContextPath()%>/js/external/jquery.treetable.js"></script>
 
-<table class="table info_table" id="LinkedProjectsInfo" title="Linked Releases And Projects">
+<table class="table info_table" id="LinkedProjectsInfo" title="Linked Releases And Projects" style="table-layout: auto">
     <thead>
     <tr>
-        <th colspan="4" class="headlabel">Linked Releases And Projects</th>
+        <th colspan="6" class="headlabel">Linked Releases And Projects</th>
     </tr>
     <tr>
-        <th width="25%">Name</th>
-        <th width="25%">Version</th>
-        <th width="25%">Relation</th>
-        <th width="25%">Main Licenses</th>
+        <th>Name</th>
+        <th>Version</th>
+        <th>Relation</th>
+        <th>Type</th>
+        <th>Clearing State</th>
+        <th>Main Licenses</th>
     </tr>
     </thead>
     <tbody>
@@ -44,13 +46,19 @@
         >
             <td>
                 <a href="<sw360:DisplayProjectLink projectId="${projectLink.id}" bare="true" />"><sw360:out
-                        value="${projectLink.name}"/></a>
+                        value="${projectLink.name}" maxChar="50"/></a>
             </td>
             <td>
                 <sw360:out value="${projectLink.version}"/>
             </td>
             <td>
                 <sw360:DisplayEnum value="${projectLink.relation}"/>
+            </td>
+            <td>
+                <sw360:DisplayEnum value="${projectLink.projectType}"/>
+            </td>
+            <td>
+                <sw360:DisplayEnum value="${projectLink.clearingState}"/>
             </td>
             <td>
             </td>
@@ -63,9 +71,7 @@
             >
                 <td>
                     <a href="<sw360:DisplayReleaseLink releaseId="${releaseLink.id}" bare="true" />">
-                        <sw360:out value="${releaseLink.vendor}"/><core_rt:if
-                            test="${not empty releaseLink.vendor}">&nbsp;</core_rt:if><sw360:out
-                            value="${releaseLink.name}"/>
+                        <sw360:out value="${releaseLink.vendor} ${releaseLink.name}" maxChar="50"/>
                     </a>
                 </td>
                 <td>
@@ -78,6 +84,12 @@
                     <core_rt:if test="${releaseLink.setReleaseRelationship}">
                         <sw360:out value="${releaseLink.releaseRelationship}"/>
                     </core_rt:if>
+                </td>
+                <td>
+                    <sw360:DisplayEnum value="${releaseLink.componentType}"/>
+                </td>
+                <td>
+                    <sw360:DisplayEnum value="${releaseLink.clearingState}"/>
                 </td>
                 <td>
                     <core_rt:if test="${releaseLink.setLicenseIds}">

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/basicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/basicInfo.jspf
@@ -11,6 +11,7 @@
 <%@ page import="org.eclipse.sw360.datahandler.thrift.projects.ProjectType" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.projects.ProjectState" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.Visibility" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState" %>
 
 <core_rt:set var="clearingTeamsStringSet" value='<%=PortalConstants.SET_CLEARING_TEAMS_STRING%>'/>
 
@@ -50,11 +51,13 @@
 
     <tr>
         <td width="33%">
-            <label class="textlabel stackedLabel" for="proj_desc">Description</label>
-                <textarea class="toplabelledInput" id="proj_desc"
-                          name="<portlet:namespace/><%=Project._Fields.DESCRIPTION%>" rows="4" cols="30"
-                          style="width:200px; height: 25px; resize:both;"
-                          placeholder="Enter Description"><sw360:out value="${project.description}" stripNewlines="false"/></textarea>
+            <label class="textlabel stackedLabel" for="proj_projectclearingstate">Project clearing state</label>
+            <select class="toplabelledInput" id="proj_projectclearingstate"
+                    name="<portlet:namespace/><%=Project._Fields.CLEARING_STATE%>"
+                    style="min-width: 162px; min-height: 28px;">
+
+                <sw360:DisplayEnumOptions type="<%=ProjectClearingState.class%>" selected="${project.clearingState}"/>
+            </select>
         </td>
 
         <td width="33%">
@@ -80,6 +83,14 @@
 
     <tr>
         <td width="33%">
+            <label class="textlabel stackedLabel" for="proj_desc">Description</label>
+            <textarea class="toplabelledInput" id="proj_desc"
+                      name="<portlet:namespace/><%=Project._Fields.DESCRIPTION%>" rows="4" cols="30"
+                      style="width: 200px; height: 25px; resize:both;"
+                      placeholder="Enter Description"><sw360:out value="${project.description}" stripNewlines="false"/></textarea>
+        </td>
+
+        <td width="33%">
             <label class="textlabel stackedLabel" for="proj_tag">Tag</label>
             <input class="toplabelledInput" id="proj_tag" name="<portlet:namespace/><%=Project._Fields.TAG%>"
                    type="text"
@@ -92,12 +103,20 @@
                    type="URL"
                    value="<sw360:out value="${project.homepage}"/>" placeholder="Enter Home Url"/>
         </td>
+    </tr>
 
+    <tr>
         <td width="33%">
             <label class="textlabel stackedLabel" for="proj_wiki">Wiki URL</label>
             <input class="toplabelledInput" id="proj_wiki" name="<portlet:namespace/><%=Project._Fields.WIKI%>"
                    type="URL"
                    value="<sw360:out value="${project.wiki}"/>" placeholder="Enter Wiki Url"/>
+        </td>
+
+        <td width="33%">
+        </td>
+
+        <td width="33%">
         </td>
 
     </tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/summary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/summary.jspf
@@ -31,6 +31,10 @@
         <td><sw360:DisplayEnum value="${project.visbility}"/></td>
     </tr>
     <tr>
+        <td>Project clearing state:</td>
+        <td><sw360:DisplayEnum value="${project.clearingState}"/></td>
+    </tr>
+    <tr>
         <td>Clearing details:</td>
         <td>
             New releases:

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/licenseInfo.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/licenseInfo.jsp
@@ -51,11 +51,13 @@
         <table class="table info_table" id="LinkedProjectsInfo" title="Linked Releases And Projects" style="table-layout: auto">
             <thead>
             <tr>
-                <th colspan="4" class="headlabel">Linked Releases And Projects</th>
+                <th colspan="6" class="headlabel">Linked Releases And Projects</th>
             </tr>
             <tr>
                 <th><input type="checkbox" checked="checked" id="selectAllCheckbox"/></th>
                 <th>Name</th>
+                <th>Type</th>
+                <th>Clearing State</th>
                 <th>Uploaded by</th>
                 <th>Clearing Team</th>
             </tr>
@@ -71,7 +73,14 @@
                         <td></td>
                         <td>
                             <a href="<sw360:DisplayProjectLink projectId="${projectLink.id}" bare="true" />"><sw360:out
-                                    value="${projectLink.name} ${projectLink.version}"/></a>
+                                    value="${projectLink.name}" maxChar="50"/> <sw360:out
+                                    value="${projectLink.version}"/></a>
+                        </td>
+                        <td>
+                            <sw360:DisplayEnum value="${projectLink.projectType}"/>
+                        </td>
+                        <td>
+                            <sw360:DisplayEnum value="${projectLink.clearingState}"/>
                         </td>
                         <td>
                         </td>
@@ -89,11 +98,15 @@
                     >
                         <td></td>
                         <td>
-                            <a href="<sw360:DisplayReleaseLink releaseId="${releaseLink.id}" bare="true" />">
-                                <sw360:out value="${releaseLink.vendor}"/><core_rt:if
-                                    test="${not empty releaseLink.vendor}">&nbsp;</core_rt:if><sw360:out
-                                    value="${releaseLink.name} ${releaseLink.version}"/>
-                            </a>
+                            <a href="<sw360:DisplayReleaseLink releaseId="${releaseLink.id}" bare="true" />"><sw360:out
+                                    value="${releaseLink.vendor} ${releaseLink.name}" maxChar="50"/> <sw360:out
+                                    value="${releaseLink.version}"/></a>
+                        </td>
+                        <td>
+                            <sw360:DisplayEnum value="${releaseLink.componentType}"/>
+                        </td>
+                        <td>
+                            <sw360:DisplayEnum value="${releaseLink.clearingState}"/>
                         </td>
                         <td>
                         </td>
@@ -119,6 +132,10 @@
                             <td>
                                 <sw360:out value="${attachment.filename}"/>
                             </td>
+                            </td>
+                            <td>
+                            </td>
+                            <td>
                             <td>
                                 <sw360:DisplayUserEmail email="${attachment.createdBy}"/>
                             </td>

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
@@ -19,6 +19,7 @@ import org.eclipse.sw360.datahandler.thrift.Visibility;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
 import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
 import org.eclipse.sw360.datahandler.thrift.components.*;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectState;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectType;
@@ -33,6 +34,7 @@ import java.util.Map;
  * @author Gerrit.Grenzebach@tngtech.com
  * @author Johannes.Najjar@tngtech.com
  * @author Andreas.Reichel@tngtech.com
+ * @author alex.borodin@evosoft.com
  */
 
 public class ThriftEnumUtils {
@@ -166,6 +168,11 @@ public class ThriftEnumUtils {
             ProjectState.PHASE_OUT, "Phase out" ,
             ProjectState.UNKNOWN, "Unknown");
 
+    private static final ImmutableMap<ProjectClearingState, String> MAP_PROJECT_CLEARING_STATE_STRING = ImmutableMap.of(
+            ProjectClearingState.OPEN, "Open",
+            ProjectClearingState.IN_PROGRESS, "In Progress",
+            ProjectClearingState.CLOSED, "Closed");
+
     private static final ImmutableMap<UserGroup, String> MAP_USER_GROUP_STRING = ImmutableMap.of(
             UserGroup.USER, "User" ,
             UserGroup.CLEARING_ADMIN, "Clearing Admin" ,
@@ -201,6 +208,7 @@ public class ThriftEnumUtils {
             .put(UserGroup.class, MAP_USER_GROUP_STRING)
             .put(Visibility.class, MAP_VISIBILITY_STRING)
             .put(ProjectState.class, MAP_PROJECT_STATE_STRING)
+            .put(ProjectClearingState.class, MAP_PROJECT_CLEARING_STATE_STRING)
             .put(CheckStatus.class,MAP_CHECK_STATUS_STRING)
             .put(VerificationState.class, MAP_VERIFICATION_STATUS_STRING)
             .put(VulnerabilityRatingForProject.class, MAP_VULNERABILITY_RATING_FOR_PROJECT_STRING)

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -279,6 +279,7 @@ struct ReleaseLink{
 
     31: optional ClearingState clearingState,
     32: optional list<Attachment> attachments,
+    33: optional ComponentType componentType,
     100: optional set<string> licenseIds,
     101: optional set<string> licenseNames
 }

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -47,6 +47,12 @@ enum ProjectRelationship {
     DUPLICATE = 3,
 }
 
+enum ProjectClearingState {
+    OPEN = 0,
+    IN_PROGRESS = 1,
+    CLOSED = 2,
+}
+
 struct Project {
 
     // General information
@@ -67,6 +73,7 @@ struct Project {
     13: optional ProjectState state,
     15: optional ProjectType projectType,
     16: optional string tag,// user defined tags
+    17: optional ProjectClearingState clearingState,
 
     // User details
     21: optional string createdBy,
@@ -111,6 +118,8 @@ struct ProjectLink {
 //    5: optional string parentId,
     6: optional string nodeId,
     7: optional string parentNodeId,
+    8: optional ProjectType projectType,
+    9: optional ProjectClearingState clearingState,
     10: optional list<ReleaseLink> linkedReleases,
     11: optional list<ProjectLink> subprojects,
 }


### PR DESCRIPTION
- on both pages, added columns for Clearing State and Type of project or release's component
- added field Clearing State to projects, displayed on both pages and in project details. editable manually
- sorted children of each node in the tree by names
- on both pages, abbreviated displayed names of releases and projects in the treetable at max 50 chars. full names displayed in a tooltip when necessary

closes #287 