### PR TITLE
Fix permission problem in `uploadFromSW360` script

### DIFF
--- a/backend/src/src-fossology/src/main/resources/scripts/uploadFromSW360
+++ b/backend/src/src-fossology/src/main/resources/scripts/uploadFromSW360
@@ -57,7 +57,7 @@ checkNotEmpty "$uploadId" || die 4 "cannot parse cp2foss output:" "$cp2foss"
 
 # schedule scanning with all known agents
 # to restrict agents use e.g. "-A agent_monk,agent_nomos"
-fossjobs=$( runWithUserAndPass fossjobs -U "$uploadId" )
+fossjobs=$( runWithUserAndPass fossjobs --groupname "$groupname" -U "$uploadId" )
 
 (($?!=0)) && echo "agent scheduling failed" "$fossjobs"
 


### PR DESCRIPTION
previously the jobs were not scheduled due to missing permissions. If the user sw360 schedules the jobs in the name of the target group, everything works well

This is sadly not related to #178