### PR TITLE
License Entries removal feature at Admin portal

### DIFF
--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
@@ -13,9 +13,11 @@ package org.eclipse.sw360.licenses;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.licenses.*;
 import org.eclipse.sw360.datahandler.thrift.CustomProperties;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.licenses.db.LicenseDatabaseHandler;
 import org.apache.thrift.TException;
 
@@ -293,4 +295,12 @@ public class LicenseHandler implements LicenseService.Iface {
         }
         return handler.addOrUpdateCustomProperties(customProperties);
     }
+@Override
+    public RequestSummary deleteAllLicenseInformation(User user) {
+        if(! PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user)){
+            return new RequestSummary().setRequestStatus(RequestStatus.FAILURE);
+        }
+        return handler.deleteAllLicenseInformation();
+    }
+
 }

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
@@ -295,9 +295,10 @@ public class LicenseHandler implements LicenseService.Iface {
         }
         return handler.addOrUpdateCustomProperties(customProperties);
     }
-@Override
+
+    @Override
     public RequestSummary deleteAllLicenseInformation(User user) {
-        if(! PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user)){
+        if(! PermissionUtils.isUserAtLeast(UserGroup.ADMIN, user)){
             return new RequestSummary().setRequestStatus(RequestStatus.FAILURE);
         }
         return handler.deleteAllLicenseInformation();

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -131,6 +131,8 @@ public class PortalConstants {
     public static final String DUPLICATE_RELEASE_SOURCES = "duplicateReleaseSources";
     public static final String DUPLICATE_COMPONENTS = "duplicateComponents";
     public static final String DUPLICATE_PROJECTS = "duplicateProjects";
+    public static final String ACTION_DELETE_ALL_LICENSE_INFORMATION = "deleteAllLicenseInformation";
+
 
     //! Specialized keys for vulnerability management
     public static final String VULNERABILITY = "vulnerability";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/DatabaseSanitation.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/DatabaseSanitation.java
@@ -9,10 +9,14 @@
 package org.eclipse.sw360.portal.portlets.admin;
 
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.portal.common.PortalConstants;
 import org.eclipse.sw360.portal.portlets.Sw360Portlet;
+import org.eclipse.sw360.portal.users.UserCacheHolder;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 
@@ -44,6 +48,9 @@ public class DatabaseSanitation extends Sw360Portlet {
         if (PortalConstants.DUPLICATES.equals(action)) {
                  serveDuplicates(request,response);
         }
+        if(PortalConstants.ACTION_DELETE_ALL_LICENSE_INFORMATION.equals(action)){
+            deleteAllLicenseInformation(request, response);
+        }
     }
 
     private void serveDuplicates(ResourceRequest request, ResourceResponse response) throws IOException, PortletException {
@@ -73,6 +80,17 @@ public class DatabaseSanitation extends Sw360Portlet {
             request.setAttribute(PortalConstants.DUPLICATE_COMPONENTS, duplicateComponents);
             request.setAttribute(PortalConstants.DUPLICATE_PROJECTS, duplicateProjects);
             include("/html/admin/databaseSanitation/duplicatesAjax.jsp", request, response, PortletRequest.RESOURCE_PHASE);
+        }
+    }
+
+    private void deleteAllLicenseInformation(ResourceRequest request, ResourceResponse response){
+        User user = UserCacheHolder.getUserFromRequest(request);
+        LicenseService.Iface licenseClient = thriftClients.makeLicenseClient();
+        try {
+            RequestSummary requestSummary = licenseClient.deleteAllLicenseInformation(user);
+            renderRequestSummary(request, response, requestSummary);
+        } catch (TException te){
+            log.error("Got TException when trying to delete all license information." ,te);
         }
     }
 }

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/databaseSanitation/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/databaseSanitation/view.jsp
@@ -14,8 +14,13 @@
 <portlet:defineObjects/>
 <liferay-theme:defineObjects/>
 
-<portlet:resourceURL var="getDuplicatesURL" >
-  <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.DUPLICATES%>'/>
+<portlet:resourceURL var="getDuplicatesURL">
+    <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.DUPLICATES%>'/>
+</portlet:resourceURL>
+
+<portlet:resourceURL var="deleteAllLicenseInformationURL">
+    <portlet:param name="<%=PortalConstants.ACTION%>"
+                   value='<%=PortalConstants.ACTION_DELETE_ALL_LICENSE_INFORMATION%>'/>
 </portlet:resourceURL>
 
 <script src="<%=request.getContextPath()%>/js/external/jquery-1.11.1.min.js"></script>
@@ -23,22 +28,31 @@
 <script src="<%=request.getContextPath()%>/js/external/jquery.dataTables.js"></script>
 
 <div id="header"></div>
-<p class="pageHeader"><span class="pageHeaderBigSpan">DB Administration</span> </p>
+<p class="pageHeader"><span class="pageHeaderBigSpan">DB Administration</span></p>
 
 <table class="info_table">
-  <thead>
-  <tr>
-    <th colspan="2"> Actions</th>
-  </tr>
-  </thead>
+    <thead>
+    <tr>
+        <th colspan="2"> Actions</th>
+    </tr>
+    </thead>
 
-  <tbody>
-  <tr>
-    <td>Search DB for duplicate identifiers</td>
-    <td> <img src="<%=request.getContextPath()%>/images/search.png" alt="CleanUp" onclick="findDuplicates()" width="25px" height="25px" >
-    </td>
-  </tr>
-  </tbody>
+    <tbody>
+    <tr>
+        <td>Search DB for duplicate identifiers</td>
+        <td><img src="<%=request.getContextPath()%>/images/search.png" alt="CleanUp" onclick="findDuplicates()"
+                 width="25px" height="25px">
+        </td>
+    </tr>
+    <br/>
+    <tr>
+        <td>Delete all license information</td>
+        <td><img src="<%=request.getContextPath()%>/images/Trash.png"
+                                                alt=" Delete all license information"
+                                                onclick="deleteAllLicenseInformation()">
+        </td>
+    </tr>
+    </tbody>
 </table>
 
 <div id="DuplicateSearch">
@@ -47,47 +61,69 @@
 <br/>
 
 <script>
-function findDuplicates(){
+    function findDuplicates() {
 
-  var field =   $('#DuplicateSearch');
-    field.html("Looking for duplicate identifiers ... ");
-  jQuery.ajax({
-    type: 'POST',
-    url: '<%=getDuplicatesURL%>',
-    cache: false,
-    data: "",
-    success: function (data) {
-      var html;
-      if(data.result == 'SUCCESS')
-        html = "No duplicate identifiers were found";
-      else if( data.result == 'FAILURE'){
-        html = "Error in looking for duplicate identifiers";
-      } else {
-        html = data;
-      }
-      field.html(html);
-      setupPagination('#duplicateReleasesTable');
-      setupPagination('#duplicateReleaseSourcesTable');
-      setupPagination('#duplicateComponentsTable');
-      setupPagination('#duplicateProjectsTable');
-    },
-    error: function () {
-      html = "Error in looking for duplicate identifiers";
-      field.html(html);
-    }
-  });
-}
-function setupPagination(tableId){
-    if ($(tableId)){
-        $(tableId).dataTable({
-            "sPaginationType": "full_numbers"
+        var field = $('#DuplicateSearch');
+        field.html("Looking for duplicate identifiers ... ");
+        jQuery.ajax({
+            type: 'POST',
+            url: '<%=getDuplicatesURL%>',
+            cache: false,
+            data: "",
+            success: function (data) {
+                var html;
+                if (data.result == 'SUCCESS')
+                    html = "No duplicate identifiers were found";
+                else if (data.result == 'FAILURE') {
+                    html = "Error in looking for duplicate identifiers";
+                } else {
+                    html = data;
+                }
+                field.html(html);
+                setupPagination('#duplicateReleasesTable');
+                setupPagination('#duplicateReleaseSourcesTable');
+                setupPagination('#duplicateComponentsTable');
+                setupPagination('#duplicateProjectsTable');
+            },
+            error: function () {
+                html = "Error in looking for duplicate identifiers";
+                field.html(html);
+            }
         });
-
-        $(tableId+'_filter').hide();
-        $(tableId+'_first').hide();
-        $(tableId+'_last').hide();
     }
-}
+    function setupPagination(tableId) {
+        if ($(tableId)) {
+            $(tableId).dataTable({
+                "sPaginationType": "full_numbers"
+            });
+
+            $(tableId + '_filter').hide();
+            $(tableId + '_first').hide();
+            $(tableId + '_last').hide();
+        }
+    }
+
+    function deleteAllLicenseInformation() {
+        if (confirm("Do you really want to delete all licenses, license types, todos, obligations, risks, risk categories and todo custom properties from the db? " +
+                        "\nN.B.: other documents might use the licenses." +
+                        "\nThis function is meant to be followed by a new license import.")) {
+            jQuery.ajax({
+                type: 'POST',
+                url: '<%=deleteAllLicenseInformationURL%>',
+                cache: false,
+                success: function (data) {
+                    if (data.result == 'SUCCESS')
+                        alert("I deleted " + data.totalAffectedObjects + " of " + data.totalObjects + " total documents in the DB.");
+                    else {
+                        alert("I could not delete the license information!");
+                    }
+                },
+                error: function () {
+                    alert("I could not delete the license information!");
+                }
+            });
+        }
+    }
 </script>
 
 <link rel="stylesheet" href="<%=request.getContextPath()%>/css/dataTable_Siemens.css">

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/databaseSanitation/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/databaseSanitation/view.jsp
@@ -59,7 +59,8 @@
 </div>
 
 <br/>
-
+<link rel="stylesheet" href="<%=request.getContextPath()%>/css/external/jquery-confirm.min.css">
+<script src="<%=request.getContextPath()%>/js/external/jquery-confirm.min.js" type="text/javascript"></script>
 <script>
     function findDuplicates() {
 
@@ -104,25 +105,29 @@
     }
 
     function deleteAllLicenseInformation() {
-        if (confirm("Do you really want to delete all licenses, license types, todos, obligations, risks, risk categories and todo custom properties from the db? " +
-                        "\nN.B.: other documents might use the licenses." +
-                        "\nThis function is meant to be followed by a new license import.")) {
+
+        function deleteAllLicenseInformationInternal() {
             jQuery.ajax({
                 type: 'POST',
                 url: '<%=deleteAllLicenseInformationURL%>',
                 cache: false,
                 success: function (data) {
                     if (data.result == 'SUCCESS')
-                        alert("I deleted " + data.totalAffectedObjects + " of " + data.totalObjects + " total documents in the DB.");
+                        $.alert("I deleted " + data.totalAffectedObjects + " of " + data.totalObjects + " total documents in the DB.");
                     else {
-                        alert("I could not delete the license information!");
+                        $.alert("I could not delete the license information!");
                     }
                 },
                 error: function () {
-                    alert("I could not delete the license information!");
+                    $.alert("I could not delete the license information!");
                 }
             });
         }
+
+        var confirmMessage = "Do you really want to delete all licenses, license types, todos, obligations, risks, risk categories and todo custom properties from the db? " +
+                "\nN.B.: other documents might use the licenses." +
+                "\nThis function is meant to be followed by a new license import.";
+        deleteConfirmed(confirmMessage, deleteAllLicenseInformationInternal);
     }
 </script>
 

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
@@ -59,7 +59,7 @@ public class CommonUtils {
     public static final Joiner COMMA_JOINER = Joiner.on(", ");
 
     private static final Comparator<CheckStatus> CHECK_STATUS_COMPARATOR = Comparator.comparingInt(cs -> {
-        switch (cs){
+        switch (cs) {
             case ACCEPTED:
                 return 2;
             case NOTCHECKED:
@@ -195,21 +195,21 @@ public class CommonUtils {
 
     public static boolean atLeastOneIsNotEmpty(Collection... collections) {
         for (Collection collection : collections) {
-                if(collection!=null && !collection.isEmpty()) return true;
+            if (collection != null && !collection.isEmpty()) return true;
         }
         return false;
     }
 
     public static boolean atLeastOneIsNotEmpty(Map... maps) {
         for (Map map : maps) {
-            if(map!=null && !map.isEmpty()) return true;
+            if (map != null && !map.isEmpty()) return true;
         }
         return false;
     }
 
     public static boolean atLeastOneIsNotEmpty(String... strings) {
         for (String string : strings) {
-            if(!Strings.isNullOrEmpty(string)) return true;
+            if (!Strings.isNullOrEmpty(string)) return true;
         }
         return false;
     }
@@ -224,7 +224,7 @@ public class CommonUtils {
 
         for (Object object : objects) {
             if (object instanceof Collection)
-                if(!((Collection) object).isEmpty()) return true;
+                if (!((Collection) object).isEmpty()) return true;
         }
 
         return false;
@@ -273,8 +273,8 @@ public class CommonUtils {
         };
     }
 
-    public static boolean isInProgressOrPending(ModerationRequest moderationRequest){
-        return  moderationRequest.getModerationState().equals(ModerationState.INPROGRESS) ||
+    public static boolean isInProgressOrPending(ModerationRequest moderationRequest) {
+        return moderationRequest.getModerationState().equals(ModerationState.INPROGRESS) ||
                 moderationRequest.getModerationState().equals(ModerationState.PENDING);
     }
 
@@ -431,6 +431,17 @@ public class CommonUtils {
         }).toList();
     }
 
+    public static RequestSummary addRequestSummaries(RequestSummary left, RequestSummary right) {
+        RequestSummary result = new RequestSummary();
+        result.requestStatus = left.isSetRequestStatus() && left.requestStatus.equals(RequestStatus.SUCCESS)
+                            && right.isSetRequestStatus() && right.requestStatus.equals(RequestStatus.SUCCESS)
+                            ? RequestStatus.SUCCESS
+                            : RequestStatus.FAILURE;
+        result.setTotalElements(left.getTotalElements() + right.getTotalElements());
+        result.setTotalAffectedElements(left.getTotalAffectedElements() + right.getTotalAffectedElements());
+        return result;
+    }
+
     @NotNull
     public static Map<String, List<String>> getIdentifierToListOfDuplicates(ListMultimap<String, String> identifierToIds) {
         Map<String, List<String>> output = new HashMap<>();
@@ -448,14 +459,17 @@ public class CommonUtils {
     @NotNull
     public static RequestSummary getRequestSummary(List<String> ids, List<DocumentOperationResult> documentOperationResults) {
         final RequestSummary requestSummary = new RequestSummary();
-        if (documentOperationResults.isEmpty()) {
-            requestSummary.setRequestStatus(RequestStatus.SUCCESS);
-        } else {
-            requestSummary.setRequestStatus(RequestStatus.FAILURE);
-        }
-
+        requestSummary.requestStatus = documentOperationResults.isEmpty() ? RequestStatus.SUCCESS : RequestStatus.FAILURE;
         requestSummary.setTotalElements(ids.size());
         requestSummary.setTotalAffectedElements(ids.size() - documentOperationResults.size());
+        return requestSummary;
+    }
+
+    public static RequestSummary getRequestSummary(int total, int failures) {
+        final RequestSummary requestSummary = new RequestSummary();
+        requestSummary.requestStatus = failures == 0 ? RequestStatus.SUCCESS : RequestStatus.FAILURE;
+        requestSummary.setTotalElements(total);
+        requestSummary.setTotalAffectedElements(total - failures);
         return requestSummary;
     }
 
@@ -475,9 +489,9 @@ public class CommonUtils {
             getLogger(clazz).error("Error opening resources " + propertiesFilePath + ".", e);
         }
 
-        if(useSystemConfig){
+        if (useSystemConfig) {
             File systemPropertiesFile = new File(SYSTEM_CONFIGURATION_PATH, propertiesFilePath);
-            if(systemPropertiesFile.exists()){
+            if (systemPropertiesFile.exists()) {
                 try (InputStream resourceAsStream = new FileInputStream(systemPropertiesFile.getPath())) {
                     if (resourceAsStream == null)
                         throw new IOException("cannot open " + systemPropertiesFile.getPath());
@@ -500,14 +514,14 @@ public class CommonUtils {
         }
     }
 
-    public static Optional<Attachment> getBestClearingReport(Release release){
+    public static Optional<Attachment> getBestClearingReport(Release release) {
         return nullToEmptyCollection(release.getAttachments())
                 .stream()
                 .filter(att -> att.getAttachmentType() == AttachmentType.CLEARING_REPORT)
                 .max(Comparator.comparing(Attachment::getCheckStatus, CHECK_STATUS_COMPARATOR));
     }
 
-    public static boolean isTemporaryTodo(Todo todo){
+    public static boolean isTemporaryTodo(Todo todo) {
         return todo.isSetId() && todo.getId().startsWith(TMP_TODO_ID_PREFIX);
     }
 

--- a/libraries/lib-datahandler/src/main/thrift/licenses.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenses.thrift
@@ -18,6 +18,7 @@ typedef users.RequestedAction RequestedAction
 typedef sw360.RequestStatus RequestStatus
 typedef sw360.DocumentState DocumentState
 typedef sw360.CustomProperties CustomProperties
+typedef sw360.RequestSummary RequestSummary
 
 struct Obligation {
 	1: optional string id,
@@ -276,5 +277,10 @@ service LicenseService {
 
     list<CustomProperties> getCustomProperties(1: string documentType);
 
-    RequestStatus updateCustomProperties(1: CustomProperties customProperties, 2: User user )
+    RequestStatus updateCustomProperties(1: CustomProperties customProperties, 2: User user );
+
+   /**
+    * removes all licenses, license types, todos, obligations, risks, risk categories from db
+    **/
+    RequestSummary deleteAllLicenseInformation(1: User user);
 }


### PR DESCRIPTION
This PR adds functionality to the admin portlet that all licenses and related datastructures can be removed from the database. This is helpful if someone wants to do a complete reimport of all licenses with risks, todos etc and don't want to have conflicts with already existing entries in the db. E.g. if a new version of externally packaged license information in a lics archive is to be imported into the database this feature can be useful.