### PR TITLE
cveSearch: only allow matches that have consumed something

### DIFF
--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/heuristics/SearchLevels.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/heuristics/SearchLevels.java
@@ -168,7 +168,7 @@ public class SearchLevels {
 
         return vendorProductList.stream()
                 .map(match -> new NeedleWithMeta(cpeBuilder.apply(match.getNeedle()),
-                        "heuristic (dist. " + match.getDistance() + ")"))
+                        "heuristic (dist. " + (useVersionInformation ? "0" : "1") + match.getDistance() + ")"))
                 .collect(Collectors.toList());
     }
 

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/matcher/ModifiedLevenshteinDistance.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/matcher/ModifiedLevenshteinDistance.java
@@ -9,13 +9,61 @@
  */
 package org.eclipse.sw360.cvesearch.datasource.matcher;
 
+import java.util.Optional;
+
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyString;
 
 public class ModifiedLevenshteinDistance {
 
     public static Match levenshteinMatch(String needle, String haystack){
         return new Match(needle,
-                calculateModifiedLevenshteinDistance(needle,nullToEmptyString(haystack).toLowerCase().replace(' ', '_')));
+                calculateModifiedLevenshteinDistance(needle, nullToEmptyString(haystack).replace(' ', '_')));
+    }
+
+    public static class LevenshteinCost {
+
+        private final int d;
+        private final boolean consumed;
+
+        public LevenshteinCost(int d){
+            this.d = d;
+            this.consumed = false;
+        }
+
+        private LevenshteinCost(int d, boolean consumed){
+            this.d = d;
+            this.consumed = consumed;
+        }
+
+        public int getD() {
+            return d;
+        }
+
+        public boolean hasConsumed() {
+            return consumed;
+        }
+
+        public LevenshteinCost increment() {
+            return new LevenshteinCost(d + 1, consumed);
+        }
+
+        public LevenshteinCost incrementOrConsume(boolean hasConsumed) {
+            if(hasConsumed){
+                return new LevenshteinCost(d, true);
+            }else{
+                return this.increment();
+            }
+        }
+
+        public LevenshteinCost merge(LevenshteinCost le){
+            if(d > le.getD()){
+                return le;
+            }
+            if(d == le.getD()){
+                return new LevenshteinCost(d, consumed || le.hasConsumed());
+            }
+            return this;
+        }
     }
 
     /**
@@ -50,48 +98,49 @@ public class ModifiedLevenshteinDistance {
         int needleLength = needle.length() + 1;
         int haystackLength = haystack.length() + 1;
 
-        int[] oldcost = new int[needleLength];
-        int[] curcost = new int[needleLength];
+        LevenshteinCost[] oldcost = new LevenshteinCost[needleLength];
+        LevenshteinCost[] curcost = new LevenshteinCost[needleLength];
 
-        for (int i = 0; i < needleLength; i++) oldcost[i] = i;
+        for (int i = 0; i < needleLength; i++) oldcost[i] = new LevenshteinCost(i);
 
-        int savedCostsWhenSkippedSpaceSeparatedPrefix     = 0;
-        int minimalCostsWhenSkippedSpaceSeperatedPostfix = Integer.MAX_VALUE;
+        int savedCostsWhenSkippedSpaceSeparatedPrefix                 = 0;
+        LevenshteinCost minimalCostsWhenSkippedSpaceSeperatedPostfix = new LevenshteinCost(Integer.MAX_VALUE);
         for (int j = 1; j < haystackLength; j++) {
             //=========================================================================================================
             if (j > 0 && haystack.charAt(j - 1) == space) {
                 // skipping prefix of haystack does not cost anything, if it ends with a space
                 savedCostsWhenSkippedSpaceSeparatedPrefix = j;
             }
-            curcost[0] = j - savedCostsWhenSkippedSpaceSeparatedPrefix;
+            curcost[0] = new LevenshteinCost(j - savedCostsWhenSkippedSpaceSeparatedPrefix);
 
             //=========================================================================================================
             for(int i = 1; i < needleLength; i++) {
-                int costReplaceCurChar = (needle.charAt(i - 1) == haystack.charAt(j - 1)) ? 0 : 1;
+                boolean charsMatch = Character.toLowerCase(needle.charAt(i - 1)) == Character.toLowerCase(haystack.charAt(j - 1));
+                LevenshteinCost costReplace = oldcost[i - 1].incrementOrConsume(charsMatch);
+                LevenshteinCost costInsert  = oldcost[i].increment();
+                LevenshteinCost costDelete  = curcost[i - 1].increment();
 
-                int costReplace = oldcost[i - 1] + costReplaceCurChar;
-                int costInsert  = oldcost[i] + 1;
-                int costDelete  = curcost[i - 1] + 1;
-
-                curcost[i] = minimum(costInsert, costDelete, costReplace);
+                curcost[i] = costReplace.merge(costInsert).merge(costDelete);
             }
 
             //=========================================================================================================
             if(haystack.charAt(j - 1) == space) {
                 // skipping postfix of haystack does not cost anything, if it starts with a space
-                minimalCostsWhenSkippedSpaceSeperatedPostfix = Math.min(
-                        minimalCostsWhenSkippedSpaceSeperatedPostfix,
-                        oldcost[needleLength - 1]);
+                minimalCostsWhenSkippedSpaceSeperatedPostfix =
+                        minimalCostsWhenSkippedSpaceSeperatedPostfix.merge(oldcost[needleLength - 1]);
             }
 
             //=========================================================================================================
-            int[] swap = oldcost; oldcost = curcost; curcost = swap;
+            LevenshteinCost[] swap = oldcost; oldcost = curcost; curcost = swap;
         }
 
-        return Math.min(oldcost[needleLength - 1], minimalCostsWhenSkippedSpaceSeperatedPostfix);
-    }
+        LevenshteinCost finalCost = oldcost[needleLength - 1]
+                .merge(minimalCostsWhenSkippedSpaceSeperatedPostfix);
 
-    private static int minimum(int a, int b, int c) {
-        return Math.min(Math.min(a, b), c);
+        if(finalCost.hasConsumed()){
+            return finalCost.getD();
+        }else{
+            return Integer.MAX_VALUE;
+        }
     }
 }

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/matcher/ModifiedLevenshteinDistanceTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/matcher/ModifiedLevenshteinDistanceTest.java
@@ -27,56 +27,60 @@ public class ModifiedLevenshteinDistanceTest {
         assertThat(levenshteinMatch(needle,needle).getDistance(), is(0));
 
         // appending or prepending adds 1 to the distance
-        assert(levenshteinMatch(needle,needle + "a").getDistance() == 1);
-        assert(levenshteinMatch(needle, "a" + needle ).getDistance() == 1);
-        assert(levenshteinMatch(needle, "a" + needle + "a").getDistance() == 2);
-        assert(levenshteinMatch(needle, needDle).getDistance() == 1);
-        assert(levenshteinMatch(needDle, needle).getDistance() == 1);
+        assertThat(levenshteinMatch(needle,needle + "a").getDistance(), is(1));
+        assertThat(levenshteinMatch(needle, "a" + needle ).getDistance(), is(1));
+        assertThat(levenshteinMatch(needle, "a" + needle + "a").getDistance(), is(2));
+        assertThat(levenshteinMatch(needle, needDle).getDistance(), is(1));
+        assertThat(levenshteinMatch(needDle, needle).getDistance(), is(1));
 
         // dropping adds 1 to the distance
-        assert(levenshteinMatch(needle, neele).getDistance() == 1);
-        assert(levenshteinMatch(neele, needle).getDistance() == 1);
+        assertThat(levenshteinMatch(needle, neele).getDistance(), is(1));
+        assertThat(levenshteinMatch(neele, needle).getDistance(), is(1));
 
         // should be able to find the best match
-        assert(levenshteinMatch(needle, needle + " " + neele).getDistance() == 0);
-        assert(levenshteinMatch(needle, neele + " " + needle).getDistance() == 0);
+        assertThat(levenshteinMatch(needle, needle + " " + neele).getDistance(), is(0));
+        assertThat(levenshteinMatch(needle, neele + " " + needle).getDistance(), is(0));
 
         // seperated by spaces does not change distance
-        assert(levenshteinMatch(needle,needle + " a").getDistance() == 0);
-        assert(levenshteinMatch(needle, "a " + needle ).getDistance() == 0);
-        assert(levenshteinMatch(needle, "a" + needle + " a").getDistance() == 1);
-        assert(levenshteinMatch(needle, "a " + needle + "a").getDistance() == 1);
-        assert(levenshteinMatch(needle, "a " + needle + " a").getDistance() == 0);
+        assertThat(levenshteinMatch(needle,needle + " a").getDistance(), is(0));
+        assertThat(levenshteinMatch(needle, "a " + needle ).getDistance(), is(0));
+        assertThat(levenshteinMatch(needle, "a" + needle + " a").getDistance(), is(1));
+        assertThat(levenshteinMatch(needle, "a " + needle + "a").getDistance(), is(1));
+        assertThat(levenshteinMatch(needle, "a " + needle + " a").getDistance(), is(0));
     }
 
     @Test
     public void getDistancesEmptyNeedle(){
-        assert(levenshteinMatch("", "haystack").getDistance() == Integer.MAX_VALUE);
+        assertThat(levenshteinMatch("", "haystack").getDistance(), is(Integer.MAX_VALUE));
+        assertThat(levenshteinMatch("", "haystack").getDistance(), is(Integer.MAX_VALUE));
     }
 
     @Test
     public void getDistancesEmptyHaystack(){
-        assert(levenshteinMatch("needle", "").getDistance() == Integer.MAX_VALUE);
+        assertThat(levenshteinMatch("needle", "").getDistance(), is(Integer.MAX_VALUE));
     }
 
     @Test
     public void getDistanceXtoSomethingWithoutX() {
-        assert(levenshteinMatch("x","lorem ipsum").getDistance() > 0);
-        assert(levenshteinMatch("x","y").getDistance() > 0);
-        assert(levenshteinMatch("x","y ").getDistance() > 0);
-        assert(levenshteinMatch("x"," y").getDistance() > 0);
-        assert(levenshteinMatch("x"," y ").getDistance() > 0);
+        assertThat(levenshteinMatch("x","y").getDistance(), is(Integer.MAX_VALUE));
+        assertThat(levenshteinMatch("x","y ").getDistance(), is(Integer.MAX_VALUE));
+        assertThat(levenshteinMatch("x"," y").getDistance(), is(Integer.MAX_VALUE));
+        assertThat(levenshteinMatch("x"," y ").getDistance(), is(Integer.MAX_VALUE));
+        assertThat(levenshteinMatch("x","lorem ipsum").getDistance(), is(Integer.MAX_VALUE));
     }
 
     @Test
     public void getDistanceXToXX() {
-        assert(levenshteinMatch("xx","x").getDistance() == 1);
-        assert(levenshteinMatch("xx","x ").getDistance() == 1);
-        assert(levenshteinMatch("xx"," x").getDistance() == 1);
-        assert(levenshteinMatch("xx"," x ").getDistance() == 1);
-        assert(levenshteinMatch("xx","y x ").getDistance() == 1);
-        assert(levenshteinMatch("xx"," x y").getDistance() == 1);
-        assert(levenshteinMatch("xx","y x y").getDistance() == 1);
+        assertThat(levenshteinMatch("xx","x").getDistance(), is(1));
+        assertThat(levenshteinMatch("xx","x ").getDistance(), is(1));
+        assertThat(levenshteinMatch("xx"," x").getDistance(), is(1));
+        assertThat(levenshteinMatch("xx"," x ").getDistance(), is(1));
+        assertThat(levenshteinMatch("xx","y x ").getDistance(), is(1));
+        assertThat(levenshteinMatch("xx"," x y").getDistance(), is(1));
+        assertThat(levenshteinMatch("xx","y x y").getDistance(), is(1));
+
+        assertThat(levenshteinMatch("Xx","x").getDistance(), is(1));
+        assertThat(levenshteinMatch("xx","X").getDistance(), is(1));
     }
 
     @Test
@@ -86,8 +90,8 @@ public class ModifiedLevenshteinDistanceTest {
 
         Match match = levenshteinMatch(needle,haystack);
 
-        assert(match.getNeedle().equals(needle));
-        assert(match.getDistance() > 0);
+        assertThat(match.getNeedle(), is(needle));
+        assertThat(match.getDistance(), is(greaterThan(0)));
     }
 
     @Test
@@ -97,7 +101,7 @@ public class ModifiedLevenshteinDistanceTest {
 
         Match match = levenshteinMatch(needle,haystack);
 
-        assert(match.getDistance() == 0);
+        assertThat(match.getDistance(), is(0));
     }
 
     @Test
@@ -107,7 +111,7 @@ public class ModifiedLevenshteinDistanceTest {
 
         Match match = levenshteinMatch(needle,haystack);
 
-        assert(match.getDistance() == 2);
+        assertThat(match.getDistance(), is(2));
     }
 
     @Test
@@ -117,7 +121,7 @@ public class ModifiedLevenshteinDistanceTest {
 
         Match match = levenshteinMatch(needle,haystack);
 
-        assert(match.getDistance() == 0);
+        assertThat(match.getDistance(), is(0));
     }
 
     @Test
@@ -127,7 +131,7 @@ public class ModifiedLevenshteinDistanceTest {
 
         Match match = levenshteinMatch(needle,haystack);
 
-        assert(match.getDistance() == 0);
+        assertThat(match.getDistance(), is(0));
     }
 
     @Test
@@ -138,7 +142,7 @@ public class ModifiedLevenshteinDistanceTest {
 
         Match match = levenshteinMatch(needle,haystack);
 
-        assert(match.getDistance() == 0);
+        assertThat(match.getDistance(), is(0));
     }
 
     @Test
@@ -149,6 +153,6 @@ public class ModifiedLevenshteinDistanceTest {
 
         Match match = levenshteinMatch(needle,haystack);
 
-        assert(match.getDistance() == noise.length()) ;
+        assertThat(match.getDistance(), is(noise.length())) ;
     }
 }

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/matcher/ModifiedLevenshteinDistanceTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/matcher/ModifiedLevenshteinDistanceTest.java
@@ -12,6 +12,8 @@ package org.eclipse.sw360.cvesearch.datasource.matcher;
 import org.junit.Test;
 
 import static org.eclipse.sw360.cvesearch.datasource.matcher.ModifiedLevenshteinDistance.levenshteinMatch;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
 public class ModifiedLevenshteinDistanceTest {
 
@@ -22,7 +24,7 @@ public class ModifiedLevenshteinDistanceTest {
         String needDle = "needDle";
 
         // equal strings have distance 0
-        assert(levenshteinMatch(needle,needle).getDistance() == 0);
+        assertThat(levenshteinMatch(needle,needle).getDistance(), is(0));
 
         // appending or prepending adds 1 to the distance
         assert(levenshteinMatch(needle,needle + "a").getDistance() == 1);


### PR DESCRIPTION
The levenstein distance metric which is used to check if a cve is applicable to a component release, is improved in this PR. It takes now a version mismatch into account, which was not considered before.