### PR TITLE
support couchdb scurity settings for restricting view access

### DIFF
--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/CouchDbConnectorWithSecurity/CouchDbConnectorWithSecurity.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/CouchDbConnectorWithSecurity/CouchDbConnectorWithSecurity.java
@@ -1,0 +1,98 @@
+/*
+ *
+ * This code is taken from the Ektorp project which is hosted at
+ *     https://github.com/helun/Ektorp
+ * and is licensed under Apache 2.0
+ * The changes were especially introduced via the commit
+ *     https://github.com/helun/Ektorp/commit/1b534a99c689661e81aa497ba4f05e143eca8e04
+ * and are related to following issue in the issue tracker
+ *     https://github.com/helun/Ektorp/issues/201
+ *
+ */
+package org.eclipse.sw360.datahandler.couchdb.CouchDbConnectorWithSecurity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.eclipse.sw360.datahandler.couchdb.DatabaseInstance;
+import org.eclipse.sw360.datahandler.couchdb.MapperFactory;
+import org.ektorp.http.HttpResponse;
+import org.ektorp.http.StdResponseHandler;
+import org.ektorp.impl.StdCouchDbConnector;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+public class CouchDbConnectorWithSecurity extends StdCouchDbConnector {
+
+    private String adminRole = "_admin";
+
+    public CouchDbConnectorWithSecurity(String dbName, DatabaseInstance instance, MapperFactory mapperFactory) {
+        super(dbName,instance,mapperFactory);
+    }
+
+    private String securityPath() {
+        return String.format("%s_security", dbURI);
+    }
+
+    public Security getSecurity() {
+        return restTemplate.get(securityPath(),
+                new StdResponseHandler<Security>() {
+                    @Override
+                    public Security success(HttpResponse hr) throws Exception {
+                        return objectMapper.readValue(hr.getContent(),
+                                Security.class);
+                    }
+                }
+        );
+    }
+
+    public Status updateSecurity(Security security) {
+        try {
+            return restTemplate.put(securityPath(),
+                    objectMapper.writeValueAsString(security),
+                    new StdResponseHandler<Status>() {
+                        @Override
+                        public Status success(HttpResponse hr) throws Exception {
+                            return objectMapper.readValue(hr.getContent(),
+                                    Status.class);
+                        }
+                    }
+            );
+        } catch(JsonProcessingException e) {
+            throw new IllegalStateException("Failed to update security: " + e.getMessage());
+        }
+    }
+
+    public Optional<Status> restrictAccessToAdmins() {
+        boolean hasChanged = false;
+
+        Function<SecurityGroup,SecurityGroup> addAdminRole = securityGroup -> {
+            List<String> newGroupRoles = securityGroup.getRoles();
+            newGroupRoles.add(adminRole);
+            return new SecurityGroup(securityGroup.getNames(), newGroupRoles);
+        };
+
+        Security security = Optional.ofNullable(getSecurity())
+                .orElse(new Security());
+
+        SecurityGroup adminGroup = Optional.ofNullable(security.getAdmins())
+                .orElse(new SecurityGroup());
+        SecurityGroup memberGroup = Optional.ofNullable(security.getMembers())
+                .orElse(new SecurityGroup());
+
+        if(!adminGroup.getRoles().contains(adminRole)){
+            adminGroup = addAdminRole.apply(adminGroup);
+            hasChanged = true;
+        }
+
+        if(!memberGroup.getRoles().contains(adminRole)){
+            memberGroup = addAdminRole.apply(memberGroup);
+            hasChanged = true;
+        }
+
+        if(hasChanged){
+            return Optional.of(updateSecurity(new Security(adminGroup,memberGroup)));
+        }
+        return Optional.empty();
+    }
+}

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/CouchDbConnectorWithSecurity/Security.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/CouchDbConnectorWithSecurity/Security.java
@@ -1,0 +1,47 @@
+/*
+ *
+ * This code is taken from the Ektorp project which is hosted at
+ *     https://github.com/helun/Ektorp
+ * and is licensed under Apache 2.0
+ * The changes were especially introduced via the commit
+ *     https://github.com/helun/Ektorp/commit/1b534a99c689661e81aa497ba4f05e143eca8e04
+ * and are related to following issue in the issue tracker
+ *     https://github.com/helun/Ektorp/issues/201
+ *
+ */
+package org.eclipse.sw360.datahandler.couchdb.CouchDbConnectorWithSecurity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+
+/**
+ * @author n3integration
+ */
+public class Security implements Serializable {
+
+    private static final long serialVersionUID = -255108257321474837L;
+
+    private final SecurityGroup admins;
+    private final SecurityGroup members;
+
+    public Security() {
+        admins = new SecurityGroup();
+        members = new SecurityGroup();
+    }
+
+    @JsonCreator
+    public Security(@JsonProperty("admins") SecurityGroup admins, @JsonProperty("members") SecurityGroup members) {
+        this.admins = admins;
+        this.members = members;
+    }
+
+    public SecurityGroup getAdmins() {
+        return admins;
+    }
+
+    public SecurityGroup getMembers() {
+        return members;
+    }
+}

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/CouchDbConnectorWithSecurity/SecurityGroup.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/CouchDbConnectorWithSecurity/SecurityGroup.java
@@ -1,0 +1,49 @@
+/*
+ *
+ * This code is taken from the Ektorp project which is hosted at
+ *     https://github.com/helun/Ektorp
+ * and is licensed under Apache 2.0
+ * The changes were especially introduced via the commit
+ *     https://github.com/helun/Ektorp/commit/1b534a99c689661e81aa497ba4f05e143eca8e04
+ * and are related to following issue in the issue tracker
+ *     https://github.com/helun/Ektorp/issues/201
+ *
+ */
+package org.eclipse.sw360.datahandler.couchdb.CouchDbConnectorWithSecurity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author n3integration
+ */
+public class SecurityGroup implements Serializable {
+
+    private static final long serialVersionUID = -346108257321474838L;
+
+    private final List<String> names;
+    private final List<String> roles;
+
+    public SecurityGroup() {
+        this.names = new ArrayList<String>();
+        this.roles = new ArrayList<String>();
+    }
+
+    @JsonCreator
+    public SecurityGroup(@JsonProperty("names") List<String> names, @JsonProperty("roles") List<String> roles) {
+        this.names = names;
+        this.roles = roles;
+    }
+
+    public List<String> getNames() {
+        return names;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+}

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/CouchDbConnectorWithSecurity/Status.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/CouchDbConnectorWithSecurity/Status.java
@@ -1,0 +1,56 @@
+/*
+ *
+ * This code is taken from the Ektorp project which is hosted at
+ *     https://github.com/helun/Ektorp
+ * and is licensed under Apache 2.0
+ * The changes were especially introduced via the commit
+ *     https://github.com/helun/Ektorp/commit/1b534a99c689661e81aa497ba4f05e143eca8e04
+ * and are related to following issue in the issue tracker
+ *     https://github.com/helun/Ektorp/issues/201
+ *
+ */
+package org.eclipse.sw360.datahandler.couchdb.CouchDbConnectorWithSecurity;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *
+ * Standard status response
+ *
+ * @author henrik lundgren
+ *
+ */
+public class Status implements Serializable {
+
+	private static final long serialVersionUID = 6617269292660336903L;
+
+	@JsonProperty("ok")
+	boolean ok;
+
+	private Map<String, Object> unknownFields;
+
+	public boolean isOk() {
+		return ok;
+	}
+
+	private Map<String, Object> unknown() {
+		if (unknownFields == null) {
+			unknownFields = new HashMap<String, Object>();
+		}
+		return unknownFields;
+	}
+
+	@JsonAnySetter
+	public void setUnknown(String key, Object value) {
+		unknown().put(key, value);
+	}
+
+	public Object getField(String key) {
+		return unknown().get(key);
+	}
+}

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseConnector.java
@@ -9,12 +9,11 @@
 package org.eclipse.sw360.datahandler.couchdb;
 
 import com.google.common.collect.ImmutableSet;
+import org.eclipse.sw360.datahandler.couchdb.CouchDbConnectorWithSecurity.CouchDbConnectorWithSecurity;
 import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
-import org.eclipse.sw360.datahandler.thrift.attachments.DatabaseAddress;
 import org.apache.log4j.Logger;
 import org.ektorp.*;
 import org.ektorp.http.HttpClient;
-import org.ektorp.impl.StdCouchDbConnector;
 import org.ektorp.util.Documents;
 
 import java.net.MalformedURLException;
@@ -26,7 +25,7 @@ import java.util.function.Supplier;
  *
  * @author cedric.bodet@tngtech.com
  */
-public class DatabaseConnector extends StdCouchDbConnector {
+public class DatabaseConnector extends CouchDbConnectorWithSecurity {
 
     private static final Logger log = Logger.getLogger(DatabaseConnector.class);
 
@@ -70,6 +69,7 @@ public class DatabaseConnector extends StdCouchDbConnector {
         this.dbName = dbName;
         // Create the database if it does not exists yet
         instance.createDatabase(dbName);
+        restrictAccessToAdmins();
     }
 
     /**


### PR DESCRIPTION
Allows credentials based connections via ektorp layer.
most of the code is taken from the Ektorp project
  - i.e. see https://github.com/helun/Ektorp/commit/1b534a99c689661e81aa497ba4f05e143eca8e04