### PR TITLE
Improved License Portlet error handling

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
@@ -23,6 +23,7 @@ public class ErrorMessages {
     public static final String RELEASE_DUPLICATE ="Release could not be added, since a release with the same name and version already exists.";
     public static final String ERROR_GETTING_PROJECT = "Error fetching project from backend.";
     public static final String ERROR_GETTING_COMPONENT = "Error fetching component from backend.";
+    public static final String ERROR_GETTING_LICENSE = "Error fetching license from backend.";
     public static final String ERROR_GETTING_RELEASE = "Error fetching release from backend.";
     public static final String LICENSE_USED_BY_RELEASE =  "Request could not be processed, as license is used by at least one release!";
     public static final String DOCUMENT_USED_BY_PROJECT_OR_RELEASE = "Document could not be processed, as it is used by other Projects or Releases!";
@@ -68,6 +69,7 @@ public class ErrorMessages {
             .add(ERROR_GETTING_PROJECT)
             .add(ERROR_GETTING_COMPONENT)
             .add(ERROR_GETTING_RELEASE)
+            .add(ERROR_GETTING_LICENSE)
             .build();
 
     private ErrorMessages() {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/licenses/LicensesPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/licenses/LicensesPortlet.java
@@ -21,6 +21,7 @@ import org.eclipse.sw360.datahandler.thrift.licenses.*;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.exporter.LicenseExporter;
+import org.eclipse.sw360.portal.common.ErrorMessages;
 import org.eclipse.sw360.portal.common.PortalConstants;
 import org.eclipse.sw360.portal.common.UsedAsLiferayAction;
 import org.eclipse.sw360.portal.portlets.Sw360Portlet;
@@ -114,6 +115,7 @@ public class LicensesPortlet extends Sw360Portlet {
             request.setAttribute(LICENSE_TYPE_CHOICE, licenseTypes);
         }catch(TException e){
             log.error("Error fetching license types from backend", e);
+            setSW360SessionError(request, ErrorMessages.ERROR_GETTING_LICENSE);
         }
 
         if (id != null) {
@@ -123,6 +125,7 @@ public class LicensesPortlet extends Sw360Portlet {
                 addLicenseBreadcrumb(request, response, license);
             } catch (TException e) {
                 log.error("Error fetching license details from backend", e);
+                setSW360SessionError(request, ErrorMessages.ERROR_GETTING_LICENSE);
             }
         } else {
             if (request.getAttribute(KEY_LICENSE_DETAIL) == null){
@@ -183,6 +186,7 @@ public class LicensesPortlet extends Sw360Portlet {
 
             } catch (TException e) {
                 log.error("Error fetching license details from backend", e);
+                setSW360SessionError(request, ErrorMessages.ERROR_GETTING_LICENSE);
             }
         }
     }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayLicensesEdit.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayLicensesEdit.java
@@ -8,22 +8,13 @@
  */
 package org.eclipse.sw360.portal.tags;
 
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import org.eclipse.sw360.datahandler.thrift.ThriftClients;
-import org.eclipse.sw360.datahandler.thrift.licenses.License;
-import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
-import org.eclipse.sw360.portal.users.UserCacheHolder;
 
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-
-import static com.google.common.collect.Collections2.transform;
-import static org.eclipse.sw360.datahandler.thrift.ThriftUtils.extractField;
-import static org.eclipse.sw360.datahandler.thrift.ThriftUtils.extractId;
 
 /**
  * This displays a user in Edit mode
@@ -60,11 +51,7 @@ public class DisplayLicensesEdit extends NameSpaceAwareTag {
         try {
 
             if (licenseIds != null && !licenseIds.isEmpty()) {
-                LicenseService.Iface licenseClient = new ThriftClients().makeLicenseClient();
-                String department = UserCacheHolder.getUserFromEmail(userEmail).getDepartment();
-
-                printLicenses(display, licenseClient.getByIds(licenseIds,department));
-
+                printLicenses(display, licenseIds);
             } else {
                 printEmptyLicenses(display);
             }
@@ -82,15 +69,11 @@ public class DisplayLicensesEdit extends NameSpaceAwareTag {
                 .append(String.format("<input class=\"clickable\" type=\"text\" readonly=\"\" placeholder=\"Click to set Licenses\" id=\"%sDisplay\" onclick=\"%s\" />", id, onclick));
     }
 
-    private void printLicenses(StringBuilder display, Collection<License> licenses) {
-        Joiner commaJoiner = Joiner.on(", ");
-        Function<License, String> nameExtract = extractField(License._Fields.FULLNAME, String.class);
-
-        String licenseIdsStr = commaJoiner.join(transform(licenses, extractId()));
-        String licenseNamesStr = commaJoiner.join(transform(licenses, nameExtract));
+    private void printLicenses(StringBuilder display, Collection<String> licenseIds) {
+        String licenseIdsStr = Joiner.on(", ").join(licenseIds);
 
         display.append(String.format("<label class=\"textlabel stackedLabel\" for=\"%sDisplay\">Licenses</label>", id))
                 .append(String.format("<input type=\"hidden\" readonly=\"\" value=\"%s\" id=\"%s\" name=\"%s%s\"/>", licenseIdsStr, id, namespace, id))
-                .append(String.format("<input class=\"clickable\" type=\"text\" readonly=\"\" value=\"%s\" id=\"%sDisplay\" onclick=\"%s\" />", licenseNamesStr, id, onclick));
+                .append(String.format("<input class=\"clickable\" type=\"text\" readonly=\"\" value=\"%s\" id=\"%sDisplay\" onclick=\"%s\" />", licenseIdsStr, id, onclick));
     }
 }

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/detail.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/detail.jsp
@@ -1,3 +1,4 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
@@ -14,18 +15,20 @@
 
 <portlet:defineObjects/>
 <liferay-theme:defineObjects/>
-
-<jsp:useBean id="selectedTab" class="java.lang.String" scope="request"/>
-<jsp:useBean id="licenseDetail" class="org.eclipse.sw360.datahandler.thrift.licenses.License" scope="request"/>
-<jsp:useBean id="moderationLicenseDetail" class="org.eclipse.sw360.datahandler.thrift.licenses.License"
-             scope="request"/>
-<jsp:useBean id="added_todos_from_moderation_request"
-             type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenses.Todo>" scope="request"/>
-<jsp:useBean id="db_todos_from_moderation_request"
-             type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenses.Todo>" scope="request"/>
-<jsp:useBean id="isUserAtLeastClearingAdmin" class="java.lang.String" scope="request"/>
-<jsp:useBean id="obligationList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenses.Obligation>"
-             scope="request"/>
+<c:catch var="attributeNotFoundException">
+    <jsp:useBean id="selectedTab" class="java.lang.String" scope="request"/>
+    <jsp:useBean id="licenseDetail" class="org.eclipse.sw360.datahandler.thrift.licenses.License" scope="request"/>
+    <jsp:useBean id="moderationLicenseDetail" class="org.eclipse.sw360.datahandler.thrift.licenses.License"
+                 scope="request"/>
+    <jsp:useBean id="added_todos_from_moderation_request"
+                 type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenses.Todo>" scope="request"/>
+    <jsp:useBean id="db_todos_from_moderation_request"
+                 type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenses.Todo>" scope="request"/>
+    <jsp:useBean id="isUserAtLeastClearingAdmin" class="java.lang.String" scope="request"/>
+    <jsp:useBean id="obligationList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenses.Obligation>"
+                 scope="request"/>
+</c:catch>
+<%@include file="/html/utils/includes/logError.jspf" %>
 
 <portlet:actionURL var="editLicenseTodosURL" name="updateWhiteList">
     <portlet:param name="<%=PortalConstants.LICENSE_ID%>" value="${licenseDetail.id}"/>
@@ -42,20 +45,20 @@
 <portlet:actionURL var="editExternalLinkURL" name="editExternalLink">
     <portlet:param name="<%=PortalConstants.LICENSE_ID%>" value="${licenseDetail.id}" />
 </portlet:actionURL>
-
-<div id="header"></div>
-<p class="pageHeader"><span
-        class="pageHeaderBigSpan">License: ${licenseDetail.fullname} (${licenseDetail.shortname})</span>
-    <core_rt:if test="${isUserAtLeastClearingAdmin == 'Yes'}">
+<core_rt:if test="${empty attributeNotFoundException}">
+    <div id="header"></div>
+    <p class="pageHeader"><span
+            class="pageHeaderBigSpan">License: ${licenseDetail.fullname} (${licenseDetail.shortname})</span>
+        <core_rt:if test="${isUserAtLeastClearingAdmin == 'Yes'}">
          <span class="pull-right">
              <input type="button" onclick="editLicense()" id="edit" value="Edit License Details and Text"
                     class="addButton">
          </span>
-    </core_rt:if>
-</p>
-<core_rt:set var="editMode" value="true" scope="request"/>
-<%@include file="includes/detailOverview.jspf" %>
-
+        </core_rt:if>
+    </p>
+    <core_rt:set var="editMode" value="true" scope="request"/>
+    <%@include file="includes/detailOverview.jspf" %>
+</core_rt:if>
 <script>
     var Y = YUI().use(
             'aui-tabview',

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/edit.jsp
@@ -6,6 +6,7 @@
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v10.html
   --%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%@ page import="com.liferay.portlet.PortletURLFactoryUtil" %>
 <%@ page import="javax.portlet.PortletRequest" %>
@@ -14,13 +15,18 @@
 <%@include file="/html/init.jsp"%>
 <%-- the following is needed by liferay to display error messages--%>
 <%@include file="/html/utils/includes/errorKeyToMessage.jspf"%>
+
 <portlet:defineObjects />
 <liferay-theme:defineObjects />
 
-<jsp:useBean id="licenseDetail" class="org.eclipse.sw360.datahandler.thrift.licenses.License" scope="request" />
-<jsp:useBean id="licenseTypeChoice" class="java.util.ArrayList" scope="request" />
-
-<core_rt:set  var="addMode"  value="${empty licenseDetail.id}" />
+<link rel="stylesheet" href="<%=request.getContextPath()%>/css/external/jquery-ui.css">
+<link rel="stylesheet" href="<%=request.getContextPath()%>/css/external/jquery-confirm.min.css">
+<link rel="stylesheet" href="<%=request.getContextPath()%>/css/sw360.css">
+<script src="<%=request.getContextPath()%>/js/external/jquery-1.11.1.min.js" type="text/javascript"></script>
+<script src="<%=request.getContextPath()%>/js/external/jquery.validate.min.js" type="text/javascript"></script>
+<script src="<%=request.getContextPath()%>/js/external/additional-methods.min.js" type="text/javascript"></script>
+<script src="<%=request.getContextPath()%>/js/external/jquery-confirm.min.js" type="text/javascript"></script>
+<script src="<%=request.getContextPath()%>/js/external/jquery-ui.min.js"></script>
 
 <portlet:actionURL var="updateURL" name="update">
     <portlet:param name="<%=PortalConstants.LICENSE_ID%>" value="${licenseDetail.id}" />
@@ -29,98 +35,96 @@
     <portlet:param name="<%=PortalConstants.LICENSE_ID%>" value="${licenseDetail.id}"/>
 </portlet:actionURL>
 
-<link rel="stylesheet" href="<%=request.getContextPath()%>/css/sw360.css">
-<link rel="stylesheet" href="<%=request.getContextPath()%>/css/external/jquery-ui.css">
-<link rel="stylesheet" href="<%=request.getContextPath()%>/css/external/jquery-confirm.min.css">
-<script src="<%=request.getContextPath()%>/js/external/jquery-1.11.1.min.js" type="text/javascript"></script>
-<script src="<%=request.getContextPath()%>/js/external/jquery.validate.min.js" type="text/javascript"></script>
-<script src="<%=request.getContextPath()%>/js/external/additional-methods.min.js" type="text/javascript"></script>
-<script src="<%=request.getContextPath()%>/js/external/jquery-confirm.min.js" type="text/javascript"></script>
-<script src="<%=request.getContextPath()%>/js/external/jquery-ui.min.js"></script>
+<c:catch var="attributeNotFoundException">
+    <jsp:useBean id="licenseDetail" type="org.eclipse.sw360.datahandler.thrift.licenses.License" scope="request" />
+    <jsp:useBean id="licenseTypeChoice" class="java.util.ArrayList" scope="request" />
+    <core_rt:set  var="addMode"  value="${empty licenseDetail.id}" />
+</c:catch>
+<%@include file="/html/utils/includes/logError.jspf" %>
+<core_rt:if test="${empty attributeNotFoundException || exceptionInBackend}">
 
-<div id="where" class="content1">
-    <p class="pageHeader"><span class="pageHeaderBigSpan"><sw360:out value="${licenseDetail.shortname}"/></span>
+    <div id="where" class="content1">
+        <p class="pageHeader"><span class="pageHeaderBigSpan"><sw360:out value="${licenseDetail.shortname}"/></span>
+            <core_rt:if test="${not addMode}" >
+                <input type="button" class="addButton" onclick="deleteConfirmed('Do you really want to delete the license <b><sw360:LicenseName license="${licenseDetail}"/></b> ?', deleteLicense)"
+                       value="Delete <sw360:LicenseName license="${licenseDetail}"/>"
+                >
+            </core_rt:if>
+        </p>
         <core_rt:if test="${not addMode}" >
-            <input type="button" class="addButton" onclick="deleteConfirmed('Do you really want to delete the license <b><sw360:LicenseName license="${licenseDetail}"/></b> ?', deleteLicense)"
-                   value="Delete <sw360:LicenseName license="${licenseDetail}"/>"
-            >
+            <input type="button" id="formSubmit" value="Update License" class="addButton">
+            <input type="button" value="Cancel" onclick="cancel()" class="cancelButton">
         </core_rt:if>
-    </p>
-    <core_rt:if test="${not addMode}" >
-        <input type="button" id="formSubmit" value="Update License" class="addButton">
-        <input type="button" value="Cancel" onclick="cancel()" class="cancelButton">
-    </core_rt:if>
-    <core_rt:if test="${addMode}" >
-        <input type="button" id="formSubmit" value="Add License" class="addButton">
-        <input type="button" value="Cancel" onclick="cancel()" class="cancelButton">
-    </core_rt:if>
-</div>
+        <core_rt:if test="${addMode}" >
+            <input type="button" id="formSubmit" value="Add License" class="addButton">
+            <input type="button" value="Cancel" onclick="cancel()" class="cancelButton">
+        </core_rt:if>
+    </div>
 
-<div id="editField" class="content2">
+    <div id="editField" class="content2">
 
-    <form  id="licenseEditForm" name="licenseEditForm" action="<%=updateURL%>" method="post" >
-        <%@include file="/html/licenses/includes/editDetailSummary.jspf"%>
-        <%@include file="/html/licenses/includes/editDetailText.jspf"%>
-    </form>
-</div>
+        <form  id="licenseEditForm" name="licenseEditForm" action="<%=updateURL%>" method="post" >
+            <%@include file="/html/licenses/includes/editDetailSummary.jspf"%>
+            <%@include file="/html/licenses/includes/editDetailText.jspf"%>
+        </form>
+    </div>
 
-
-
-
-
-<script>
-    var Y = YUI().use(
-            'aui-tabview',
-            function(Y) {
-                new Y.TabView(
-                        {
-                            srcNode: '#myTab',
-                            stacked: true,
-                            type: 'tab'
-                        }
-                ).render();
-            }
-
-    );
-
-    function editLicense() {
-        window.location ='<portlet:renderURL ><portlet:param name="<%=PortalConstants.LICENSE_ID%>" value="${licenseDetail.id}"/><portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.PAGENAME_EDIT%>"/></portlet:renderURL>'
-    }
-
-    function deleteLicense() {
-        window.location.href = '<%=deleteURL%>';
-    }
-
-    function cancel() {
-        var baseUrl = '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>';
-        var portletURL = Liferay.PortletURL.createURL( baseUrl )
-                <core_rt:if test="${not addMode}" >
-                .setParameter('<%=PortalConstants.PAGENAME%>','<%=PortalConstants.PAGENAME_DETAIL%>')
-                </core_rt:if>
-                <core_rt:if test="${addMode}" >
-                .setParameter('<%=PortalConstants.PAGENAME%>','<%=PortalConstants.PAGENAME_VIEW%>')
-                </core_rt:if>
-
-                .setParameter('<%=PortalConstants.LICENSE_ID%>','${licenseDetail.id}');
-        window.location = portletURL.toString();
-    }
-
-    var contextpath;
-    $( document ).ready(function() {
-        contextpath = '<%=request.getContextPath()%>';
-        $('#licenseEditForm').validate({
-            ignore: [],
-            invalidHandler: invalidHandlerShowErrorTab
-        });
-
-        $('#formSubmit').click(
-                function() {
-                    $('#licenseEditForm').submit();
+    <script>
+        var Y = YUI().use(
+                'aui-tabview',
+                function(Y) {
+                    new Y.TabView(
+                            {
+                                srcNode: '#myTab',
+                                stacked: true,
+                                type: 'tab'
+                            }
+                    ).render();
                 }
+
         );
 
-        $('#lic_shortname').autocomplete({
-            source: <%=PortalConstants.LICENSE_IDENTIFIERS%>
+        function editLicense() {
+            window.location ='<portlet:renderURL ><portlet:param name="<%=PortalConstants.LICENSE_ID%>" value="${licenseDetail.id}"/><portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.PAGENAME_EDIT%>"/></portlet:renderURL>'
+        }
+
+        function deleteLicense() {
+            window.location.href = '<%=deleteURL%>';
+        }
+
+        function cancel() {
+            var baseUrl = '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>';
+            var portletURL = Liferay.PortletURL.createURL( baseUrl )
+            <core_rt:if test="${not addMode}" >
+                    .setParameter('<%=PortalConstants.PAGENAME%>','<%=PortalConstants.PAGENAME_DETAIL%>')
+                    </core_rt:if>
+                    <core_rt:if test="${addMode}" >
+                    .setParameter('<%=PortalConstants.PAGENAME%>','<%=PortalConstants.PAGENAME_VIEW%>')
+                    </core_rt:if>
+
+                    .setParameter('<%=PortalConstants.LICENSE_ID%>','${licenseDetail.id}');
+            window.location = portletURL.toString();
+        }
+
+        var contextpath;
+        $( document ).ready(function() {
+            contextpath = '<%=request.getContextPath()%>';
+            $('#licenseEditForm').validate({
+                ignore: [],
+                invalidHandler: invalidHandlerShowErrorTab
+            });
+
+            $('#formSubmit').click(
+                    function() {
+                        $('#licenseEditForm').submit();
+                    }
+            );
+
+            $('#lic_shortname').autocomplete({
+                source: <%=PortalConstants.LICENSE_IDENTIFIERS%>
+            });
         });
-    });
-</script>
+    </script>
+</core_rt:if>
+
+

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/logError.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/logError.jspf
@@ -1,0 +1,7 @@
+<%@ page import="org.apache.log4j.Logger" %>
+<%Logger log = Logger.getLogger(getClass());%>
+
+<core_rt:set var="exceptionMessage" value="${attributeNotFoundException}"/>
+<core_rt:if test="${not empty attributeNotFoundException}">
+    <%log.error("Error in useBeans: "+ pageContext.getAttribute("exceptionMessage").toString());%>
+</core_rt:if>


### PR DESCRIPTION
* if license links are broken, they are still displayed, but on click
  error message is displayed in LicensePortlet
* edit view of LicensePortlet displays error messages if error occurs in backend
* in edit view of release: if license is not available, id is still displayed and selected in searchLicense-popup
* closes https://github.com/bsinno/sw360/issues/279