### PR TITLE
Handling Closed Moderation Requests

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
  * All rights reserved. This program and the accompanying materials
@@ -22,6 +22,7 @@ import java.util.Set;
  * @author gerrit.grenzebach@tngtech.com
  * @author andreas.reichel@tngtech.com
  * @author stefan.jaeger@evosoft.com
+ * @author alex.borodin@evosoft.com
  */
 public class PortalConstants {
 
@@ -73,6 +74,7 @@ public class PortalConstants {
     public static final String MODERATION_ID = "moderationId";
     public static final String MODERATION_REQUEST = "moderationRequest";
     public static final String MODERATION_REQUESTS = "moderationRequests";
+    public static final String CLOSED_MODERATION_REQUESTS = "closedModerationRequests";
     public static final String DELETE_MODERATION_REQUEST = "deleteModerationRequest";
 
     //! Specialized keys for components

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyTaskAssignmentsPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyTaskAssignmentsPortlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@ import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.portal.common.PortalConstants;
 import org.eclipse.sw360.portal.portlets.Sw360Portlet;
+import org.eclipse.sw360.portal.portlets.moderation.ModerationPortletUtils;
 import org.eclipse.sw360.portal.users.UserCacheHolder;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
@@ -22,6 +23,7 @@ import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.log4j.Logger.getLogger;
 
@@ -38,16 +40,17 @@ public class MyTaskAssignmentsPortlet extends Sw360Portlet {
 
     @Override
     public void doView(RenderRequest request, RenderResponse response) throws IOException, PortletException {
-        List<ModerationRequest> moderations=null;
+        List<ModerationRequest> openModerations=null;
 
         try {
             User user = UserCacheHolder.getUserFromRequest(request);
-            moderations = thriftClients.makeModerationClient().getRequestsByModerator(user);
+            List<ModerationRequest> moderations = thriftClients.makeModerationClient().getRequestsByModerator(user);
+            openModerations = moderations.stream().filter(ModerationPortletUtils::isOpenModerationRequest).collect(Collectors.toList());
         } catch (TException e) {
             log.error("Could not fetch your moderations from backend", e);
         }
 
-        request.setAttribute(PortalConstants.MODERATION_REQUESTS,  CommonUtils.nullToEmptyList(moderations));
+        request.setAttribute(PortalConstants.MODERATION_REQUESTS,  CommonUtils.nullToEmptyList(openModerations));
 
         super.doView(request, response);
     }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyTaskSubmissionsPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyTaskSubmissionsPortlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -10,12 +10,11 @@ package org.eclipse.sw360.portal.portlets.homepage;
 
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
-import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
-import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.portal.common.PortalConstants;
 import org.eclipse.sw360.portal.portlets.Sw360Portlet;
+import org.eclipse.sw360.portal.portlets.moderation.ModerationPortletUtils;
 import org.eclipse.sw360.portal.users.UserCacheHolder;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
@@ -45,21 +44,8 @@ public class MyTaskSubmissionsPortlet extends Sw360Portlet {
         }
     }
     private void serveDeleteModerationRequest(ResourceRequest request, ResourceResponse response) throws IOException {
-        RequestStatus requestStatus = deleteModerationRequest(request, log);
+        RequestStatus requestStatus = ModerationPortletUtils.deleteModerationRequest(request, log);
         serveRequestStatus(request, response, requestStatus, "Problem removing moderation request", log);
-    }
-    public static RequestStatus deleteModerationRequest(PortletRequest request, Logger log) {
-        String id = request.getParameter(PortalConstants.MODERATION_ID);
-        if (id != null) {
-            try {
-                ModerationService.Iface client = new ThriftClients().makeModerationClient();
-                return client.deleteModerationRequest(id, UserCacheHolder.getUserFromRequest(request));
-
-            } catch (TException e) {
-                log.error("Could not delete moderation request from DB", e);
-            }
-        }
-        return RequestStatus.FAILURE;
     }
     @Override
     public void doView(RenderRequest request, RenderResponse response) throws IOException, PortletException {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,8 +13,10 @@ import com.liferay.portal.model.Organization;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.ModerationState;
 import org.eclipse.sw360.datahandler.thrift.RemoveModeratorRequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
@@ -27,6 +29,7 @@ import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorService;
 import org.eclipse.sw360.portal.common.PortalConstants;
@@ -50,6 +53,7 @@ import static org.eclipse.sw360.portal.common.PortalConstants.*;
  *
  * @author daniele.fognini@tngtech.com
  * @author johannes.najjar@tngtech.com
+ * @author alex.borodin@evosoft.com
  */
 public class ModerationPortlet extends FossologyAwarePortlet {
 
@@ -58,11 +62,18 @@ public class ModerationPortlet extends FossologyAwarePortlet {
     @Override
     public void serveResource(ResourceRequest request, ResourceResponse response) throws IOException, PortletException {
         String action = request.getParameter(PortalConstants.ACTION);
-        if (PortalConstants.ACTION_REMOVEME.equals(action)){
+        if (PortalConstants.ACTION_REMOVEME.equals(action)) {
             removeMeFromModerators(request, response);
+        } else if (PortalConstants.DELETE_MODERATION_REQUEST.equals(action)) {
+            serveDeleteModerationRequest(request, response);
         } else if (isGenericAction(action)) {
             dealWithGenericAction(request, response, action);
         }
+    }
+
+    private void serveDeleteModerationRequest(ResourceRequest request, ResourceResponse response) throws IOException {
+        RequestStatus requestStatus = ModerationPortletUtils.deleteModerationRequest(request, log);
+        serveRequestStatus(request, response, requestStatus, "Problem removing moderation request", log);
     }
 
     private void removeMeFromModerators(ResourceRequest request, ResourceResponse response){
@@ -257,16 +268,26 @@ public class ModerationPortlet extends FossologyAwarePortlet {
     }
 
     public void renderStandardView(RenderRequest request, RenderResponse response) throws IOException, PortletException {
-        List<ModerationRequest> moderationRequests = null;
+        User user = UserCacheHolder.getUserFromRequest(request);
+
+        List<ModerationRequest> openModerationRequests = null;
+        List<ModerationRequest> closedModerationRequests = null;
+
         try {
             ModerationService.Iface client = thriftClients.makeModerationClient();
-            User user = UserCacheHolder.getUserFromRequest(request);
-            moderationRequests = client.getRequestsByModerator(user);
+            List<ModerationRequest> moderationRequests = client.getRequestsByModerator(user);
+            Map<Boolean, List<ModerationRequest>> partitionedModerationRequests = moderationRequests
+                    .stream()
+                    .collect(Collectors.groupingBy(ModerationPortletUtils::isOpenModerationRequest));
+            openModerationRequests = partitionedModerationRequests.get(true);
+            closedModerationRequests = partitionedModerationRequests.get(false);
         } catch (TException e) {
-            log.error("Could not fetch license summary from backend!", e);
+            log.error("Could not fetch moderation requests from backend!", e);
         }
 
-        request.setAttribute(MODERATION_REQUESTS, CommonUtils.nullToEmptyList(moderationRequests));
+        request.setAttribute(MODERATION_REQUESTS, CommonUtils.nullToEmptyList(openModerationRequests));
+        request.setAttribute(CLOSED_MODERATION_REQUESTS, CommonUtils.nullToEmptyList(closedModerationRequests));
+        request.setAttribute(IS_USER_AT_LEAST_CLEARING_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user) ? "Yes" : "Nope");
         super.doView(request, response);
     }
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.portal.portlets.moderation;
+
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.ModerationState;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
+import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
+import org.eclipse.sw360.portal.common.PortalConstants;
+import org.eclipse.sw360.portal.users.UserCacheHolder;
+
+import javax.portlet.PortletRequest;
+
+/**
+ * @author: alex.borodin@evosoft.com
+ */
+public class ModerationPortletUtils {
+    private static final Logger log = Logger.getLogger(ModerationPortletUtils.class);
+
+    private ModerationPortletUtils() {
+        // Utility class with only static functions
+    }
+
+
+    public static RequestStatus deleteModerationRequest(PortletRequest request, Logger log) {
+        String id = request.getParameter(PortalConstants.MODERATION_ID);
+        if (id != null) {
+            try {
+                ModerationService.Iface client = new ThriftClients().makeModerationClient();
+                return client.deleteModerationRequest(id, UserCacheHolder.getUserFromRequest(request));
+            } catch (TException e) {
+                log.error("Could not delete moderation request from DB", e);
+            }
+        }
+        return RequestStatus.FAILURE;
+    }
+
+    public static boolean isOpenModerationRequest(ModerationRequest mr) {
+        return mr.getModerationState() == ModerationState.PENDING || mr.getModerationState() == ModerationState.INPROGRESS;
+    }
+}

--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -188,22 +188,24 @@ div.content2 {
     height: 160px;
 }
 
-.searchbar {
+#searchInput .searchbar {
     display: inline-block;
     color: #cccccc;
-    margin-left: 1em;
-
     width: 90%;
     padding: 5px;
     height: 20px;
 }
 
-.searchbutton {
+#searchInput .searchbutton {
     display: inline-block;
 
-    /*padding: 5px 20px 5px 20px; */
-    /*border: none; */
-    /*font-weight:bold;*/
+    padding: 5px 20px 5px 20px;
+    border: none;
+    font-weight:bold;
+}
+
+#searchInput table {
+    width: 100%;
 }
 
 .nav-tabs {

--- a/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
@@ -119,8 +119,8 @@
             <tr>
                 <td>
                     <label for="component_type">Component Type</label>
-                    <select class="toplabelledInput filterInput" id="component_type" name="<portlet:namespace/><%=Component._Fields.COMPONENT_TYPE%>"
-                            style="min-width: 162px; min-height: 28px;">
+                    <select class="searchbar toplabelledInput filterInput" id="component_type" name="<portlet:namespace/><%=Component._Fields.COMPONENT_TYPE%>"
+                            style="min-height: 28px;">
                         <option value="<%=PortalConstants.NO_FILTER%>" class="textlabel stackedLabel">Any</option>
                         <sw360:DisplayEnumOptions type="<%=ComponentType.class%>" selectedName="${componentType}" useStringValues="true"/>
                     </select>

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
@@ -10,82 +10,123 @@
 <%@include file="/html/init.jsp" %>
 <%-- the following is needed by liferay to display error messages--%>
 <%@include file="/html/utils/includes/errorKeyToMessage.jspf"%>
-<%@ page import="com.liferay.portlet.PortletURLFactoryUtil" %>
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 
 <portlet:defineObjects/>
 <liferay-theme:defineObjects/>
 
-
 <%@ taglib prefix="sw360" uri="/WEB-INF/customTags.tld" %>
 
+<portlet:resourceURL var="deleteModerationRequestAjaxURL">
+    <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.DELETE_MODERATION_REQUEST%>'/>
+</portlet:resourceURL>
 
 <jsp:useBean id="moderationRequests" type="java.util.List<org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest>"
              scope="request"/>
+<jsp:useBean id="closedModerationRequests" type="java.util.List<org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest>"
+             scope="request"/>
+<jsp:useBean id="isUserAtLeastClearingAdmin" class="java.lang.String" scope="request" />
 
 <div id="header"></div>
 <p class="pageHeader">
-    <span class="pageHeaderBigSpan">Moderations</span> <span class="pageHeaderSmallSpan">(${moderationRequests.size()})</span>
+    <span class="pageHeaderBigSpan">Moderations</span> <span class="pageHeaderSmallSpan" title="Count of open/closed moderation requests">(${moderationRequests.size()}/${closedModerationRequests.size()})</span>
 </p>
 
 
-<div id="searchInput" class="content1">
-    <table >
-        <thead>
-        <tr>
-            <th class="infoheading">
-                Display Filter
-            </th>
-        </tr>
-        </thead>
-        <tbody style="background-color: #f8f7f7; border: none;">
-        <tr>
-            <td>
-                <input type="text" class="searchbar"
-                       id="keywordsearchinput" value="" onkeyup="useSearch('keywordsearchinput')">
+<div id="content">
+    <div class="container-fluid">
+        <div id="myTab" class="row-fluid">
+            <ul class="nav nav-tabs span2">
+                <div id="searchInput">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th class="infoheading">
+                                Display Filter
+                            </th>
+                        </tr>
+                        </thead>
+                        <tbody style="background-color: #f8f7f7; border: none;">
+                        <tr>
+                            <td>
+                                <input type="text" class="searchbar"
+                                       id="keywordsearchinput" value="" onkeyup="useSearch('keywordsearchinput')">
+                                <br/>
+                                <input class="searchbutton" type="button"
+                                       name="searchBtn" value="Search" onclick="useSearch('keywordsearchinput')">
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
                 <br/>
-                <input class="searchbutton" type="button"
-                       name="searchBtn" value="Search" onclick="useSearch('keywordsearchinput')">
-            </td>
-        </tr>
-        </tbody>
-    </table>
-</div>
-<div id="moderationsTableDiv" class="content2">
-    <table id="moderationsTable" cellpadding="0" cellspacing="0" border="0" class="display">
-        <tfoot>
-        <tr>
-            <th colspan="5"></th>
-        </tr>
-        </tfoot>
-    </table>
+                <li class="active"><a href="#tab-Open">Open</a></li>
+                <li><a href="#tab-Closed">Closed</a></li>
+            </ul>
+            <div class="tab-content span10">
+                <div id="tab-Open" class="tab-pane">
+                    <table id="moderationsTable" cellpadding="0" cellspacing="0" border="0" class="display">
+                        <tfoot>
+                        <tr>
+                            <th colspan="5"></th>
+                        </tr>
+                        </tfoot>
+                    </table>
+                </div>
+                <div id="tab-Closed">
+                    <table id="closedModerationsTable" cellpadding="0" cellspacing="0" border="0" class="display">
+                        <tfoot>
+                        <tr>
+                            <th colspan="5"></th>
+                        </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
-<link rel="stylesheet" href="<%=request.getContextPath()%>/css/external/jquery-ui.css">
-<script src="<%=request.getContextPath()%>/js/external/jquery-1.11.1.min.js"></script>
+<script src="<%=request.getContextPath()%>/js/external/jquery-1.11.1.min.js" type="text/javascript"></script>
+<script src="<%=request.getContextPath()%>/js/external/jquery.validate.min.js" type="text/javascript"></script>
+<script src="<%=request.getContextPath()%>/js/external/additional-methods.min.js" type="text/javascript"></script>
 <script src="<%=request.getContextPath()%>/js/external/jquery-ui.min.js"></script>
-<script type="text/javascript" src="<%=request.getContextPath()%>/js/external/jquery.dataTables.js"></script>
+<script src="<%=request.getContextPath()%>/js/external/jquery.dataTables.js"></script>
+<script src="<%=request.getContextPath()%>/js/external/jquery-confirm.min.js" type="text/javascript"></script>
 
 <script>
-    var moderationsTable;
+    var tabView;
+    var Y = YUI().use(
+        'aui-tabview',
+        function (Y) {
+            tabView = new Y.TabView(
+                {
+                    srcNode: '#myTab',
+                    stacked: true,
+                    type: 'tab'
+                }
+            ).render();
+        }
+    );
+
+    var moderationsDataTable;
+    var closedModerationsDataTable;
 
     //This can not be document ready function as liferay definitions need to be loaded first
     $(window).load(function () {
-        createModerationsTable();
+        moderationsDataTable = createModerationsTable("#moderationsTable", prepareModerationsData());
+        closedModerationsDataTable = createModerationsTable("#closedModerationsTable", prepareClosedModerationsData());
     });
 
     function useSearch(searchFieldId) {
-        moderationsTable.fnFilter( $('#'+searchFieldId).val());
+        var searchText = $('#'+searchFieldId).val();
+        moderationsDataTable.search(searchText).draw();
+        closedModerationsDataTable.search(searchText).draw();
     }
 
-    function createModerationsTable() {
-
+    function prepareModerationsData() {
         var result = [];
-
         <core_rt:forEach items="${moderationRequests}" var="moderation">
-        <core_rt:set var="isOpenModerationRequest" value="${moderation.getModerationState().toString()== 'INPROGRESS' ||
-        moderation.getModerationState().toString()== 'PENDING'}" scope="request"/>
-        <core_rt:if test="${isOpenModerationRequest}">
             result.push({
                 "DT_RowId": "${moderation.id}",
                 "0": '<a href=\'<portlet:renderURL ><portlet:param name="<%=PortalConstants.MODERATION_ID%>" value="${moderation.id}"/><portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.PAGENAME_EDIT%>"/></portlet:renderURL>\' target=\'_self\'><sw360:out value="${moderation.documentName}"/></a>',
@@ -94,22 +135,36 @@
                 "3": '<sw360:DisplayEnum value="${moderation.moderationState}"/>',
                 "4": 'TODO'
             });
-        </core_rt:if>
-        <core_rt:if test="${!isOpenModerationRequest}">
-        result.push({
-            "DT_RowId": "${moderation.id}",
-            "0": '<sw360:out value="${moderation.documentName}"/>',
-            "1": '<sw360:DisplayUserEmail email="${moderation.requestingUser}"/>',
-            "2": '<sw360:DisplayUserEmailCollection value="${moderation.moderators}"/>',
-            "3": '<sw360:DisplayEnum value="${moderation.moderationState}"/>',
-            "4": 'READY'
-        });
-        </core_rt:if>
         </core_rt:forEach>
+        return result;
+    }
 
-        moderationsTable = $('#moderationsTable').dataTable({
+    function prepareClosedModerationsData() {
+        var result = [];
+        <core_rt:forEach items="${closedModerationRequests}" var="moderation">
+            result.push({
+                "DT_RowId": "${moderation.id}",
+                "0": '<sw360:out value="${moderation.documentName}"/>',
+                "1": '<sw360:DisplayUserEmail email="${moderation.requestingUser}"/>',
+                "2": '<sw360:DisplayUserEmailCollection value="${moderation.moderators}"/>',
+                "3": '<sw360:DisplayEnum value="${moderation.moderationState}"/>',
+                <core_rt:if test="${isUserAtLeastClearingAdmin == 'Yes'}">
+                "4": "<img src='<%=request.getContextPath()%>/images/Trash.png' onclick=\"deleteModerationRequest('${moderation.id}','<b>${moderation.documentName}</b>')\"  alt='Delete' title='Delete'>"
+                </core_rt:if>
+                <core_rt:if test="${isUserAtLeastClearingAdmin != 'Yes'}">
+                "4": "READY"
+                </core_rt:if>
+
+            });
+        </core_rt:forEach>
+        return result;
+
+    }
+
+    function createModerationsTable(tableId, tableData) {
+        var tbl = $(tableId).DataTable({
             pagingType: "full_numbers",
-            data: result,
+            data: tableData,
             columns: [
                 {"title": "Document Name"},
                 {"title": "Requesting User"},
@@ -119,13 +174,42 @@
             ]
         });
 
-        $('#moderationsTable_filter').hide();
-        $('#moderationsTable_first').hide();
-        $('#moderationsTable_last').hide();
+        $(tableId+'_filter').hide();
+        $(tableId+'_first').hide();
+        $(tableId+'_last').hide();
 
+        return tbl;
     }
 
+    function deleteModerationRequest(id, docName) {
+
+        function deleteModerationRequestInternal() {
+            jQuery.ajax({
+                type: 'POST',
+                url: '<%=deleteModerationRequestAjaxURL%>',
+                cache: false,
+                data: {
+                    <portlet:namespace/>moderationId: id
+                },
+                success: function (data) {
+                    if (data.result == 'SUCCESS') {
+                        closedModerationsDataTable.row('#' + id).remove().draw(false);
+                    }
+                    else {
+                        $.alert("I could not delete the moderation request!");
+                    }
+                },
+                error: function () {
+                    $.alert("I could not delete the moderation request!");
+                }
+            });
+        }
+
+        deleteConfirmed("Do you really want to delete the moderation request for " + docName + " ?", deleteModerationRequestInternal);
+    }
 </script>
 
 <link rel="stylesheet" href="<%=request.getContextPath()%>/css/dataTable_Siemens.css">
 <link rel="stylesheet" href="<%=request.getContextPath()%>/css/sw360.css">
+<link rel="stylesheet" href="<%=request.getContextPath()%>/css/external/jquery-ui.css">
+<link rel="stylesheet" href="<%=request.getContextPath()%>/css/external/jquery-confirm.min.css">

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -86,10 +86,10 @@
         <tbody style="background-color: #f8f7f7; border: none;">
         <tr>
             <td>
-                <input type="text" style="width: 90%; padding: 5px; color: gray;height:20px;"
+                <input type="text" class="searchbar"
                        id="keywordsearchinput" value="" onkeyup="useSearch('keywordsearchinput')" />
                 <br/>
-                <input style="padding: 5px 20px 5px 20px; border: none; font-weight:bold;" type="button"
+                <input type="button" class="searchbutton"
                        name="searchBtn" value="Search" onclick="useSearch('keywordsearchinput')" />
             </td>
         </tr>
@@ -109,29 +109,29 @@
             <tr>
                 <td>
                     <label for="project_name">Project Name</label>
-                    <input type="text" style="width: 90%; padding: 5px; color: gray;height:20px;" name="<portlet:namespace/><%=Project._Fields.NAME%>"
+                    <input type="text" class="searchbar" name="<portlet:namespace/><%=Project._Fields.NAME%>"
                            value="${name}" id="project_name" class="filterInput">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="project_type">Project Type</label>
-                    <input type="text" style="width: 90%; padding: 5px; color: gray;height:20px;" name="<portlet:namespace/><%=Project._Fields.PROJECT_TYPE%>"
+                    <input type="text" class="searchbar" name="<portlet:namespace/><%=Project._Fields.PROJECT_TYPE%>"
                            value="${projectType}" id="project_type" class="filterInput">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="project_responsible">Project Responsible (Email)</label>
-                    <input type="text" style="width: 90%; padding: 5px; color: gray;height:20px;" name="<portlet:namespace/><%=Project._Fields.PROJECT_RESPONSIBLE%>"
+                    <input type="text" class="searchbar" name="<portlet:namespace/><%=Project._Fields.PROJECT_RESPONSIBLE%>"
                            value="${projectResponsible}" id="project_responsible" class="filterInput">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="group">Group</label>
-                    <select class="toplabelledInput, filterInput" id="group" name="<portlet:namespace/><%=Project._Fields.BUSINESS_UNIT%>"
-                            style="width: 90%; padding: 5px; color: gray; min-height: 28px;">
+                    <select class="searchbar toplabelledInput filterInput" id="group" name="<portlet:namespace/><%=Project._Fields.BUSINESS_UNIT%>"
+                            style="min-height: 28px;">
                         <option value="" class="textlabel stackedLabel"
                                 <core_rt:if test="${empty businessUnit}"> selected="selected"</core_rt:if>
                         ></option>
@@ -146,14 +146,14 @@
             <tr>
                 <td>
                     <label for="state">State</label>
-                    <input type="text" style="width: 90%; padding: 5px; color: gray;height:20px;" name="<portlet:namespace/><%=Project._Fields.STATE%>"
+                    <input type="text" class="searchbar" name="<portlet:namespace/><%=Project._Fields.STATE%>"
                            value="${state}" id="state" class="filterInput">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="tag">Tag</label>
-                    <input type="text" style="width: 90%; padding: 5px; color: gray;height:20px;" name="<portlet:namespace/><%=Project._Fields.TAG%>"
+                    <input type="text" class="searchbar" name="<portlet:namespace/><%=Project._Fields.TAG%>"
                            value="${tag}" id="tag" class="filterInput">
                 </td>
             </tr>


### PR DESCRIPTION
To improve handling of closed moderation requests and reduce clutter in the Moderation table, the table is split into two tables in separate tabs: one for open moderation requests (NEW and PENDING) and one for closed (APPROVED and REJECTED) ones. Also, Clearing Admins and Admins get the possibility to delete closed moderation requests via a button in the Actions column.

closes #313