### PR TITLE
unified sorting of releases in different views and license info files

### DIFF
--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -348,54 +348,59 @@ public class ComponentDatabaseHandlerTest {
         // we wrap the potentially infinite loop in an executor
         final ExecutorService service = Executors.newSingleThreadExecutor();
 
-        final Future<List<ReleaseLink>> completionFuture = service.submit(new Callable<List<ReleaseLink>>() {
-            @Override
-            public List<ReleaseLink> call() throws Exception {
-                return handler.getLinkedReleases(relations);
-            }
-        });
+        final Future<List<ReleaseLink>> completionFuture = service.submit(() -> handler.getLinkedReleases(relations));
 
         service.shutdown();
         service.awaitTermination(10, TimeUnit.SECONDS);
 
         final List<ReleaseLink> linkedReleases = completionFuture.get();
 
-        ReleaseLink releaseLinkR1B_R2B = new ReleaseLink("R1B",vendors.get(r1B.getVendorId()).getFullname(), componentMap.get(r1B.getComponentId()).getName(),r1B.getVersion())
+        ReleaseLink releaseLinkR1B_R2B = createReleaseLinkTo(r1B)
                 .setReleaseRelationship(ReleaseRelationship.CONTAINED)
                 .setNodeId("R1B_2")
                 .setParentNodeId("R2B_2")
                 .setSubreleases(Collections.emptyList());
-        ReleaseLink releaseLinkR2B_exp = new ReleaseLink("R2B", vendors.get(r2B.getVendorId()).getFullname(), componentMap.get(r2B.getComponentId()).getName(), r2B.getVersion())
+        ReleaseLink releaseLinkR2B_exp = createReleaseLinkTo(r2B)
                 .setReleaseRelationship(ReleaseRelationship.CONTAINED)
                 .setNodeId("R2B_2")
                 .setParentNodeId("R2A_2")
                 .setSubreleases(Arrays.asList(releaseLinkR1B_R2B));
-        ReleaseLink releaseLinkR2B = new ReleaseLink("R2B", vendors.get(r2B.getVendorId()).getFullname(), componentMap.get(r2B.getComponentId()).getName(), r2B.getVersion())
+        ReleaseLink releaseLinkR2B = createReleaseLinkTo(r2B)
                 .setReleaseRelationship(ReleaseRelationship.CONTAINED)
                 .setNodeId("R2B_1")
                 .setParentNodeId("R2A_1")
                 .setSubreleases(Collections.emptyList());
-        ReleaseLink releaseLinkR2A_R1B = new ReleaseLink("R2A", vendors.get(r2A.getVendorId()).getFullname(), componentMap.get(r2A.getComponentId()).getName(), r2A.getVersion())
+        ReleaseLink releaseLinkR2A_R1B = createReleaseLinkTo(r2A)
                 .setReleaseRelationship(ReleaseRelationship.REFERRED)
                 .setNodeId("R2A_1")
                 .setParentNodeId("R1B_1")
                 .setSubreleases(Arrays.asList(releaseLinkR2B));
-        ReleaseLink releaseLinkR2A_R1A = new ReleaseLink("R2A", vendors.get(r2A.getVendorId()).getFullname(), componentMap.get(r2A.getComponentId()).getName(), r2A.getVersion())
+        ReleaseLink releaseLinkR2A_R1A = createReleaseLinkTo(r2A)
                 .setReleaseRelationship(ReleaseRelationship.REFERRED)
                 .setNodeId("R2A_2")
                 .setParentNodeId("R1A_1")
                 .setSubreleases(Arrays.asList(releaseLinkR2B_exp));
-        ReleaseLink releaseLinkR1B_R1A = new ReleaseLink("R1B",vendors.get(r1B.getVendorId()).getFullname(), componentMap.get(r1B.getComponentId()).getName(),r1B.getVersion())
+        ReleaseLink releaseLinkR1B_R1A = createReleaseLinkTo(r1B)
                 .setReleaseRelationship(ReleaseRelationship.CONTAINED)
                 .setNodeId("R1B_1")
                 .setParentNodeId("R1A_1")
                 .setSubreleases(Arrays.asList(releaseLinkR2A_R1B));
-        ReleaseLink releaseLinkR1A = new ReleaseLink("R1A",vendors.get(r1A.getVendorId()).getFullname(), componentMap.get(r1A.getComponentId()).getName(), r1A.getVersion())
+        ReleaseLink releaseLinkR1A = createReleaseLinkTo(r1A)
                 .setComment("Important linked release")
                 .setNodeId("R1A_1")
-                .setSubreleases(Arrays.asList(releaseLinkR2A_R1A, releaseLinkR1B_R1A));
+                .setSubreleases(Arrays.asList(releaseLinkR1B_R1A, releaseLinkR2A_R1A));
 
         assertThat(linkedReleases, contains(releaseLinkR1A));
+    }
+
+    @NotNull
+    private ReleaseLink createReleaseLinkTo(Release release) {
+        release.setVendor(vendors.get(release.getVendorId()));
+        return new ReleaseLink(release.getId(),
+                vendors.get(release.getVendorId()).getShortname(),
+                componentMap.get(release.getComponentId()).getName(),
+                release.getVersion(),
+                printFullname(release));
     }
 
     @Test
@@ -428,23 +433,23 @@ public class ComponentDatabaseHandlerTest {
 
         final List<ReleaseLink> linkedReleases = completionFuture.get();
 
-        ReleaseLink releaseLinkR2A_R1A = new ReleaseLink("R2A", vendors.get(r2A.getVendorId()).getFullname(), componentMap.get(r2A.getComponentId()).getName(), r2A.getVersion())
+        ReleaseLink releaseLinkR2A_R1A = createReleaseLinkTo(r2A)
                 .setReleaseRelationship(ReleaseRelationship.REFERRED)
                 .setNodeId("R2A_2")
                 .setParentNodeId("R1A_1");
-        ReleaseLink releaseLinkR2A_R1B = new ReleaseLink("R2A", vendors.get(r2A.getVendorId()).getFullname(), componentMap.get(r2A.getComponentId()).getName(), r2A.getVersion())
+        ReleaseLink releaseLinkR2A_R1B = createReleaseLinkTo(r2A)
                 .setReleaseRelationship(ReleaseRelationship.CONTAINED)
                 .setNodeId("R2A_1")
                 .setParentNodeId("R1B_1");
-        ReleaseLink releaseLinkR1B = new ReleaseLink("R1B",vendors.get(r1B.getVendorId()).getFullname(), componentMap.get(r1B.getComponentId()).getName(),r1B.getVersion())
+        ReleaseLink releaseLinkR1B = createReleaseLinkTo(r1B)
                 .setReleaseRelationship(ReleaseRelationship.CONTAINED)
                 .setNodeId("R1B_1")
                 .setParentNodeId("R1A_1")
                 .setSubreleases(Arrays.asList(releaseLinkR2A_R1B));
-        ReleaseLink releaseLinkR1A = new ReleaseLink("R1A",vendors.get(r1A.getVendorId()).getFullname(), componentMap.get(r1A.getComponentId()).getName(), r1A.getVersion())
+        ReleaseLink releaseLinkR1A = createReleaseLinkTo(r1A)
                 .setComment("Important linked release")
                 .setNodeId("R1A_1")
-                .setSubreleases(Arrays.asList(releaseLinkR2A_R1A, releaseLinkR1B));
+                .setSubreleases(Arrays.asList(releaseLinkR1B, releaseLinkR2A_R1A));
 
         assertThat(linkedReleases, contains(releaseLinkR1A));
     }

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ProjectDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ProjectDatabaseHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -142,10 +142,10 @@ public class ProjectDatabaseHandlerTest {
 
         final List<ProjectLink> linkedProjects = completionFuture.get();
 
-        ReleaseLink releaseLinkR1A = new ReleaseLink("R1A", "vendor", "component1", "releaseA").setComment("used").setNodeId("R1A_1").setComponentType(ComponentType.OSS);
-        ReleaseLink releaseLinkR1B = new ReleaseLink("R1B", "vendor", "component1", "releaseB").setComment("abused").setNodeId("R1B_1").setComponentType(ComponentType.OSS);
-        ReleaseLink releaseLinkR2A = new ReleaseLink("R2A", "vendor", "component2", "releaseA").setComment("used").setNodeId("R2A_1");
-        ReleaseLink releaseLinkR2B = new ReleaseLink("R2B", "vendor", "component2", "releaseB").setComment("considered for use").setNodeId("R2B_1");
+        ReleaseLink releaseLinkR1A = new ReleaseLink("R1A", "vendor", "component1", "releaseA", "vendor component1 releaseA").setComment("used").setNodeId("R1A_1").setComponentType(ComponentType.OSS);
+        ReleaseLink releaseLinkR1B = new ReleaseLink("R1B", "vendor", "component1", "releaseB", "vendor component1 releaseB").setComment("abused").setNodeId("R1B_1").setComponentType(ComponentType.OSS);
+        ReleaseLink releaseLinkR2A = new ReleaseLink("R2A", "vendor", "component2", "releaseA", "vendor component2 releaseA").setComment("used").setNodeId("R2A_1");
+        ReleaseLink releaseLinkR2B = new ReleaseLink("R2B", "vendor", "component2", "releaseB", "vendor component2 releaseB").setComment("considered for use").setNodeId("R2B_1");
 
         ProjectLink link3 = new ProjectLink("P3", "project3")
                 .setRelation(ProjectRelationship.REFERRED)

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Bosch Software Innovations GmbH, 2016.
+ * With modifications by Siemens AG, 2017.
  * Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
@@ -10,23 +11,20 @@
 
 package org.eclipse.sw360.licenseinfo.outputGenerators;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
+import org.apache.log4j.Logger;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.Velocity;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
-import org.apache.log4j.Logger;
-import org.apache.velocity.VelocityContext;
-import org.apache.velocity.app.Velocity;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.StringWriter;
 import java.util.*;
-import java.util.stream.Collectors;
+import java.util.function.Function;
 
-import static org.eclipse.sw360.licenseinfo.LicenseInfoHandler.ACKNOWLEDGEMENTS_CONTEXT_PROPERTY;
-import static org.eclipse.sw360.licenseinfo.LicenseInfoHandler.LICENSE_INFO_RESULTS_CONTEXT_PROPERTY;
-import static org.eclipse.sw360.licenseinfo.LicenseInfoHandler.ALL_LICENSE_NAMES_WITH_TEXTS;
+import static org.eclipse.sw360.licenseinfo.LicenseInfoHandler.*;
 
 public class XhtmlGenerator extends OutputGenerator<String> {
 
@@ -42,43 +40,19 @@ public class XhtmlGenerator extends OutputGenerator<String> {
         try {
             VelocityContext vc = getConfiguredVelocityContext();
 
+            SortedMap<String, LicenseInfoParsingResult> sortedLicenseInfos = getSortedLicenseInfos(projectLicenseInfoResults);
+            vc.put(LICENSE_INFO_RESULTS_CONTEXT_PROPERTY, sortedLicenseInfos);
+
+            List<LicenseNameWithText> licenseNamesWithTexts = getSortedLicenseNameWithTexts(projectLicenseInfoResults);
             int id = 1;
-            for(LicenseInfoParsingResult parsingResult : projectLicenseInfoResults){
-                if(parsingResult.isSetLicenseInfo()) {
-                    Set<LicenseNameWithText> licenseNamesWithTexts = parsingResult.getLicenseInfo().getLicenseNamesWithTexts();
-                    for (LicenseNameWithText licenseNameWithText : licenseNamesWithTexts) {
-                        licenseNameWithText.setId(id);
-                        id++;
-                    }
-                }
+            for(LicenseNameWithText licenseNameWithText : licenseNamesWithTexts){
+                licenseNameWithText.setId(id++);
             }
-
-            Map<String, LicenseInfoParsingResult> licenseInfos = projectLicenseInfoResults.stream()
-                    .collect(Collectors.toMap(this::getComponentLongName, li -> li, (li1, li2) -> li1));
-
-            vc.put(LICENSE_INFO_RESULTS_CONTEXT_PROPERTY, licenseInfos);
-
-            Set<LicenseNameWithText> licenseNamesWithTexts = projectLicenseInfoResults.stream()
-                    .map(LicenseInfoParsingResult::getLicenseInfo)
-                    .filter(Objects::nonNull)
-                    .map(LicenseInfo::getLicenseNamesWithTexts)
-                    .filter(Objects::nonNull)
-                    .reduce(Sets::union)
-                    .orElse(Collections.emptySet());
+            sortLicenseNamesWithinEachLicenseInfoById(projectLicenseInfoResults);
 
             vc.put(ALL_LICENSE_NAMES_WITH_TEXTS, licenseNamesWithTexts);
 
-            Map<String, Set<String>> acknowledgements = Maps.filterValues(Maps.transformValues(licenseInfos, pr -> Optional
-                    .ofNullable(pr.getLicenseInfo())
-                    .map(LicenseInfo::getLicenseNamesWithTexts)
-                    .filter(Objects::nonNull)
-                    .map(s -> s
-                            .stream()
-                            .map(LicenseNameWithText::getAcknowledgements)
-                            .filter(Objects::nonNull)
-                            .collect(Collectors.toSet()))
-                    .orElse(Collections.emptySet())), set -> !set.isEmpty());
-
+            SortedMap<String, Set<String>> acknowledgements = getSortedAcknowledgements(sortedLicenseInfos);
             vc.put(ACKNOWLEDGEMENTS_CONTEXT_PROPERTY, acknowledgements);
 
             StringWriter sw = new StringWriter();
@@ -89,6 +63,26 @@ public class XhtmlGenerator extends OutputGenerator<String> {
             log.error("Could not generate xhtml file", e);
             return "License information could not be generated.\nAn exception occured: " + e.toString();
         }
+    }
+
+    private void sortLicenseNamesWithinEachLicenseInfoById(Collection<LicenseInfoParsingResult> licenseInfoResults) {
+        licenseInfoResults
+                .stream()
+                .map(LicenseInfoParsingResult::getLicenseInfo)
+                .filter(Objects::nonNull)
+                .forEach((LicenseInfo li) -> li.setLicenseNamesWithTexts(sortSet(li.getLicenseNamesWithTexts(), LicenseNameWithText::getId)));
+    }
+
+    @NotNull
+    private static <U, K extends Comparable<K>> SortedSet<U> sortSet(Set<U> unsorted, Function<U, K> keyExtractor) {
+        SortedSet<U> sorted = new TreeSet<>(Comparator.comparing(keyExtractor));
+        sorted.addAll(unsorted);
+        if (sorted.size() != unsorted.size()){
+            // there were key collisions and some data was lost -> throw away the sorted set and sort by U's natural order
+            sorted = new TreeSet<>();
+            sorted.addAll(unsorted);
+        }
+        return sorted;
     }
 }
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
  * All rights reserved. This program and the accompanying materials
@@ -285,8 +285,8 @@ public class ComponentPortlet extends FossologyAwarePortlet {
             for (Release release : client.getReleasesById(new HashSet<>(Arrays.asList(linkedIds)), user)) {
                 final Vendor vendor = release.getVendor();
 
-                final String fullname = vendor != null ? vendor.getFullname() : "";
-                ReleaseLink linkedRelease = new ReleaseLink(release.getId(), fullname, release.getName(), release.getVersion());
+                final String vendorName = vendor != null ? vendor.getShortname() : "";
+                ReleaseLink linkedRelease = new ReleaseLink(release.getId(), vendorName, release.getName(), release.getVersion(), SW360Utils.printFullname(release));
                 linkedRelease.setReleaseRelationship(ReleaseRelationship.CONTAINED);
                 linkedReleases.add(linkedRelease);
             }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -342,9 +342,9 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             ComponentService.Iface client = thriftClients.makeComponentClient();
             for (Release release : client.getReleasesById(new HashSet<>(Arrays.asList(linkedIds)), user)) {
                 final Vendor vendor = release.getVendor();
-                final String fullname = vendor != null ? vendor.getFullname() : "";
+                final String vendorName = vendor != null ? vendor.getShortname() : "";
                 ReleaseLink linkedRelease = new ReleaseLink(release.getId(),
-                        fullname, release.getName(), release.getVersion());
+                        vendorName, release.getName(), release.getVersion(), SW360Utils.printFullname(release));
                 linkedReleases.add(linkedRelease);
             }
         } catch (TException e) {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToRelease.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToRelease.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2015-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
  * All rights reserved. This program and the accompanying materials
@@ -16,17 +16,20 @@ import org.eclipse.sw360.portal.portlets.LinkToPortletConfiguration;
 
 import javax.servlet.jsp.JspException;
 
+import static org.eclipse.sw360.datahandler.common.SW360Utils.printFullname;
 import static org.eclipse.sw360.datahandler.common.SW360Utils.printName;
 import static org.eclipse.sw360.portal.tags.urlutils.UrlWriterImpl.renderUrl;
 
 /**
  * @author daniele.fognini@tngtech.com
+ * @author alex.borodin@evosoft.com
  */
 public class DisplayLinkToRelease extends DisplayLinkAbstract {
     private Release release;
     private PortletReleasePage page = PortletReleasePage.DETAIL;
     private Boolean showName = true;
     private String releaseId;
+    private Boolean showFullname = false;
 
     public void setRelease(Release release) {
         this.release = release;
@@ -44,9 +47,13 @@ public class DisplayLinkToRelease extends DisplayLinkAbstract {
         this.showName = showName;
     }
 
+    public void setShowFullname(Boolean showFullname) {
+        this.showFullname = showFullname;
+    }
+
     @Override
     protected String getTextDisplay() {
-        return showName ? printName(release) : null;
+        return showName ? (showFullname ? printFullname(release) : printName(release)): null;
     }
 
     @Override

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~ With contributions by Bosch Software Innovations GmbH, 2016.
   ~
   ~ All rights reserved. This program and the accompanying materials
@@ -576,6 +576,12 @@
         </attribute>
         <attribute>
             <name>bare</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>showFullname</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
             <rtexprvalue>true</rtexprvalue>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/linkedProjects.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/linkedProjects.jspf
@@ -27,11 +27,10 @@
 <table class="table info_table" id="LinkedProjectsInfo" title="Linked Releases And Projects" style="table-layout: auto">
     <thead>
     <tr>
-        <th colspan="6" class="headlabel">Linked Releases And Projects</th>
+        <th colspan="5" class="headlabel">Linked Releases And Projects</th>
     </tr>
     <tr>
         <th>Name</th>
-        <th>Version</th>
         <th>Relation</th>
         <th>Type</th>
         <th>Clearing State</th>
@@ -48,10 +47,7 @@
         >
             <td>
                 <a href="<sw360:DisplayProjectLink projectId="${projectLink.id}" bare="true" />"><sw360:out
-                        value="${projectLink.name}" maxChar="50"/></a>
-            </td>
-            <td>
-                <sw360:out value="${projectLink.version}"/>
+                        value="${projectLink.name} ${projectLink.version}" maxChar="60"/></a>
             </td>
             <td>
                 <sw360:DisplayEnum value="${projectLink.relation}"/>
@@ -73,11 +69,8 @@
             >
                 <td>
                     <a href="<sw360:DisplayReleaseLink releaseId="${releaseLink.id}" bare="true" />">
-                        <sw360:out value="${releaseLink.vendor} ${releaseLink.name}" maxChar="50"/>
+                        <sw360:out value="${releaseLink.longName}" maxChar="60"/>
                     </a>
-                </td>
-                <td>
-                    <sw360:out value="${releaseLink.version}"/>
                 </td>
                 <td>
                     <core_rt:if test="${!releaseLink.setReleaseRelationship}">
@@ -104,7 +97,7 @@
     </core_rt:forEach>
     <core_rt:if test="${projectList.size() < 1 and $releaseList.size() < 1}">
         <tr>
-            <td colspan="4">No linked releases or projects</td>
+            <td colspan="5">No linked releases or projects</td>
         </tr>
     </core_rt:if>
     </tbody>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/clearingStatus.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/clearingStatus.jspf
@@ -1,6 +1,6 @@
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%--
-  ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
@@ -22,7 +22,11 @@
         <table id="releasesTable" cellpadding="0" cellspacing="0" border="0" class="display">
             <tfoot>
             <tr>
-                <th colspan="5"></th>
+                <th width="30%"></th>
+                <th width="30%"></th>
+                <th></th>
+                <th></th>
+                <th></th>
             </tr>
             </tfoot>
         </table>
@@ -48,11 +52,7 @@
         <core_rt:forEach items="${releasesAndProjects.entrySet()}" var="releasesAndProject">
         result.push({
             "DT_RowId": "${releasesAndProject.key.id}",
-            "0": {
-                display: "<sw360:DisplayReleaseLink release="${releasesAndProject.key}"/>",
-                name: "<sw360:out value="${releasesAndProject.key.name}"/>",
-                version: "<sw360:out value="${releasesAndProject.key.version}"/>"
-            },
+            "0": "<sw360:DisplayReleaseLink release="${releasesAndProject.key}" showFullname="true"/>",
             "1": "<sw360:out value="${releasesAndProject.value}"/>",
             "2": "<span id='releaseClearingState${releasesAndProject.key.id}'><sw360:DisplayEnum value="${releasesAndProject.key.clearingState}"/></span>",
             "3": "<sw360:DisplayEnum value="${releasesAndProject.key.mainlineState}"/>"
@@ -63,7 +63,7 @@
         releaseClearingTable = $('#releasesTable').DataTable({
             data: result,
             columns: [
-                {title: "Release", type: "version", render: renderVersion},
+                {title: "Name"},
                 {title: "Project Origin"},
                 {title: "Release Clearing State"},
                 {title: "Release Mainline State"},

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/linkedReleaseDetails.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/linkedReleaseDetails.jspf
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
   ~ All rights reserved. This program and the accompanying materials
@@ -24,12 +24,10 @@
 <table class="table info_table" id="LinkedReleasesInfo" title="Linked Releases Hierarchy">
     <thead>
     <tr>
-        <th colspan="6" class="headlabel">Linked Releases Hierarchy</th>
+        <th colspan="4" class="headlabel">Linked Releases Hierarchy</th>
     </tr>
     <tr>
-        <th>Release name</th>
-        <th>Vendor</th>
-        <th>Release version</th>
+        <th>Name</th>
         <th>Release relation</th>
         <th>License names</th>
         <th>Clearing state</th>
@@ -43,14 +41,8 @@
         >
             <td>
                 <a href="<sw360:DisplayReleaseLink releaseId="${releaseLink.id}" bare="true" />">
-                    <sw360:out value="${releaseLink.name}"/>
+                    <sw360:out value="${releaseLink.longName}"/>
                 </a>
-            </td>
-            <td>
-                <sw360:out value="${releaseLink.vendor}"/>
-            </td>
-            <td>
-                <sw360:out value="${releaseLink.version}"/>
             </td>
             <td>
                 <core_rt:if test="${!releaseLink.setReleaseRelationship}">
@@ -74,7 +66,7 @@
 
     <core_rt:if test="${releaseList.size() < 1}">
         <tr>
-            <td colspan="6"> No linked releases</td>
+            <td colspan="4"> No linked releases</td>
         </tr>
     </core_rt:if>
 

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -55,6 +55,7 @@ public class SW360Utils {
 
     public static final String FORMAT_DATE = "yyyy-MM-dd";
     public static final String FORMAT_DATE_TIME = "yyyy-MM-dd HH:mm:ss";
+    public static final Comparator<ReleaseLink> RELEASE_LINK_COMPARATOR = Comparator.comparing(rl -> getReleaseFullname(rl.getVendor(), rl.getName(), rl.getVersion()).toLowerCase());
 
     private static Joiner spaceJoiner = Joiner.on(" ");
 
@@ -176,6 +177,27 @@ public class SW360Utils {
         }
 
         return getVersionedName(release.getName(), release.getVersion());
+    }
+
+    public static String printFullname(Release release) {
+        if (release == null || isNullOrEmpty(release.getName())) {
+            return "New Release";
+        }
+        String vendorName = Optional.ofNullable(release.getVendor()).map(Vendor::getShortname).orElse(null);
+        return getReleaseFullname(vendorName, release.getName(), release.getVersion());
+    }
+
+    @NotNull
+    public static String getReleaseFullname(String vendorName, String releaseName, String version) {
+        StringBuilder sb = new StringBuilder();
+        if (!isNullOrEmpty(vendorName)){
+            sb.append(vendorName).append(" ");
+        }
+        sb.append(releaseName);
+        if (!isNullOrEmpty(version)){
+            sb.append(" ").append(version);
+        }
+        return sb.toString();
     }
 
     public static String printName(Project project) {

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
  * All rights reserved. This program and the accompanying materials
@@ -290,6 +290,7 @@ struct ReleaseLink{
     2: required string vendor,
     5: required string name,
     10: required string version,
+    11: required string longName,
     15: optional string comment,
     16: optional ReleaseRelationship releaseRelationship,
 //    20: optional string parentId,


### PR DESCRIPTION
Views unified: project/clearing status, project/linked release hierarchy, project/linked releases and projects, generated text license info file, generated xhtml license info file.
Combined columns at the first three views mentioned above to display the sort key of a release (==fullname=="vendor name version") in a single column.
Also sorted licenses in generated license info files by license names.

closes #294