### PR TITLE
Lock projects with clearing state CLOSED for editing

### DIFF
--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.moderation.DocumentType;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
@@ -251,9 +252,11 @@ public class ModerationDatabaseHandler {
 
         // Define moderators
         Set<String> moderators = new HashSet<>();
-        CommonUtils.add(moderators, dbproject.getCreatedBy());
-        CommonUtils.add(moderators, dbproject.getProjectResponsible());
-        CommonUtils.addAll(moderators, dbproject.getModerators());
+        if (dbproject.getClearingState() != ProjectClearingState.CLOSED){
+            CommonUtils.add(moderators, dbproject.getCreatedBy());
+            CommonUtils.add(moderators, dbproject.getProjectResponsible());
+            CommonUtils.addAll(moderators, dbproject.getModerators());
+        }
         CommonUtils.addAll(moderators, getUsersAtLeast(UserGroup.CLEARING_ADMIN, dbproject.getBusinessUnit()));
         CommonUtils.addAll(moderators, getUsersAtLeast(UserGroup.ADMIN));
         ModerationRequest request = createStubRequest(user.getEmail(), isDeleteRequest, project.getId(), moderators);

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissions.java
@@ -91,10 +91,11 @@ public abstract class DocumentPermissions<T> {
         RequestedAction out = null;
         boolean isAllowed = true;
 
-        for (RequestedAction requestedAction : ImmutableSet.of(READ, WRITE, ATTACHMENTS, DELETE, USERS, CLEARING)) {
-            isAllowed  = getStandardPermissions(requestedAction);
-            if(!isAllowed) return out;
-            out=requestedAction;
+        for (RequestedAction requestedAction : ImmutableSet.of(READ, WRITE, WRITE_ECC, ATTACHMENTS, DELETE, USERS, CLEARING)) {
+            isAllowed = isActionAllowed(requestedAction);
+            if (isAllowed) {
+                out = requestedAction;
+            }
         }
 
         return out;

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissionsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -25,6 +25,7 @@ import static org.eclipse.sw360.datahandler.thrift.users.UserGroup.*;
 
 /**
  * @author johannes.najjar@tngtech.com
+ * @author alex.borodin@evosoft.com
  */
 
 @RunWith(DataProviderRunner.class)
@@ -55,6 +56,7 @@ public class ProjectPermissionsTest extends ScenarioTest<GivenProject, WhenCompu
                 //strangers: rights increase with user group
                 {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, USER, READ },
                 {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, CLEARING_ADMIN, ATTACHMENTS },
+                {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, ECC_ADMIN, READ },
                 {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, ADMIN, CLEARING },
         };
         // @formatter:on
@@ -64,6 +66,36 @@ public class ProjectPermissionsTest extends ScenarioTest<GivenProject, WhenCompu
     @UseDataProvider("highestAllowedActionProvider")
     public void testHighestAllowedAction(GivenProject.ProjectRole role, String user, String requestingUser, UserGroup requestingUserGroup, RequestedAction highestAllowedAction) throws Exception {
         given().a_project_with_$_$(role,user);
+        when().the_highest_allowed_action_is_computed_for_user_$_with_user_group_$(requestingUser, requestingUserGroup);
+        then().the_highest_allowed_action_should_be(highestAllowedAction);
+    }
+
+    @DataProvider
+    public static Object[][] highestAllowedActionForClosedProjectProvider() {
+        // @formatter:off
+        return new Object[][] {
+                //own permissions checks
+                //very privileged
+                {GivenProject.ProjectRole.CREATED_BY, theUser, theUser, USER, READ },
+                {GivenProject.ProjectRole.MODERATOR, theUser, theUser, USER, READ },
+                {GivenProject.ProjectRole.PROJECT_RESPONSIBLE, theUser, theUser, USER, READ },
+                //less privileged
+                {GivenProject.ProjectRole.LEAD_ARCHITECT, theUser, theUser, USER, READ },
+                {GivenProject.ProjectRole.CONTRIBUTOR, theUser, theUser, USER, READ },
+
+                //strangers: rights increase with user group
+                {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, USER, READ },
+                {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, CLEARING_ADMIN, ATTACHMENTS },
+                {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, ECC_ADMIN, READ },
+                {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, ADMIN, CLEARING },
+        };
+        // @formatter:on
+    }
+
+    @Test
+    @UseDataProvider("highestAllowedActionForClosedProjectProvider")
+    public void testHighestAllowedActionForClosedProject(GivenProject.ProjectRole role, String user, String requestingUser, UserGroup requestingUserGroup, RequestedAction highestAllowedAction) throws Exception {
+        given().a_closed_project_with_$_$(role,user);
         when().the_highest_allowed_action_is_computed_for_user_$_with_user_group_$(requestingUser, requestingUserGroup);
         then().the_highest_allowed_action_should_be(highestAllowedAction);
     }

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/GivenProject.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/GivenProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,12 +16,14 @@ import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import com.tngtech.jgiven.Stage;
 import com.tngtech.jgiven.annotation.Quoted;
 import com.tngtech.jgiven.annotation.ScenarioState;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState;
 import org.mockito.Mockito;
 
 import static org.mockito.Mockito.mock;
 
 /**
  * @author johannes.najjar@tngtech.com
+ * @author alex.borodin@evosoft.com
  */
 public class GivenProject extends Stage<GivenProject> {
     @ScenarioState
@@ -67,6 +69,12 @@ public class GivenProject extends Stage<GivenProject> {
                 break;
         }
 
+        return self();
+    }
+
+    public GivenProject a_closed_project_with_$_$(ProjectRole role, @Quoted String user){
+        a_project_with_$_$(role, user);
+        Mockito.when(project.getClearingState()).thenReturn(ProjectClearingState.CLOSED);
         return self();
     }
 


### PR DESCRIPTION
No user, whether creator, contributor or moderator, is allowed to edit projects in Clearing State CLOSED. Only Clearing Admins and higher can change such projects without triggering a moderation request

closes #323