### PR TITLE
LicenseInfo Parser for Combined CLI Files

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
@@ -73,8 +73,8 @@ public class XhtmlGenerator extends OutputGenerator<String> {
     }
 
     private static <U, K extends Comparable<K>> SortedSet<U> sortSet(Set<U> unsorted, Function<U, K> keyExtractor) {
-        if (unsorted == null) {
-            return null;
+        if (unsorted == null || unsorted.isEmpty()) {
+            return Collections.emptySortedSet();
         }
         SortedSet<U> sorted = new TreeSet<>(Comparator.comparing(keyExtractor));
         sorted.addAll(unsorted);

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
@@ -18,7 +18,6 @@ import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.StringWriter;
 import java.util.*;
@@ -73,8 +72,10 @@ public class XhtmlGenerator extends OutputGenerator<String> {
                 .forEach((LicenseInfo li) -> li.setLicenseNamesWithTexts(sortSet(li.getLicenseNamesWithTexts(), LicenseNameWithText::getId)));
     }
 
-    @NotNull
     private static <U, K extends Comparable<K>> SortedSet<U> sortSet(Set<U> unsorted, Function<U, K> keyExtractor) {
+        if (unsorted == null) {
+            return null;
+        }
         SortedSet<U> sorted = new TreeSet<>(Comparator.comparing(keyExtractor));
         sorted.addAll(unsorted);
         if (sorted.size() != unsorted.size()){

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.licenseinfo.parsers;
+
+import com.google.common.collect.Sets;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.log4j.Logger;
+import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.xpath.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.eclipse.sw360.datahandler.common.CommonUtils.closeQuietly;
+
+/**
+ * Abstract class with common helper methods for CLIParser and CombinedCLIParser
+ *
+ * @author: alex.borodin@evosoft.com
+ */
+public abstract class AbstractCLIParser extends LicenseInfoParser {
+    private static final String LICENSE_CONTENT_ELEMENT_NAME = "Content";
+    private static final String LICENSE_ACKNOWLEDGEMENTS_ELEMENT_NAME = "Acknowledgements";
+    protected static final String XML_FILE_EXTENSION = ".xml";
+    private static final String LICENSENAME_ATTRIBUTE_NAME = "name";
+    private static final String LICENSE_NAME_UNKNOWN = "License name unknown";
+    private static final Logger log = Logger.getLogger(CLIParser.class);
+
+    public AbstractCLIParser(AttachmentConnector attachmentConnector, AttachmentContentProvider attachmentContentProvider) {
+        super(attachmentConnector, attachmentContentProvider);
+    }
+
+    protected static String normalizeEscapedXhtml(Node node) {
+        return StringEscapeUtils.unescapeHtml(StringEscapeUtils.unescapeXml(node.getTextContent().trim()));
+    }
+
+    protected Optional<Node> findNamedAttribute(Node node, String name) {
+        NamedNodeMap childNodes = node.getAttributes();
+        return Optional.ofNullable(childNodes.getNamedItem(name));
+    }
+
+    protected Optional<Node> findNamedSubelement(Node node, String name) {
+        NodeList childNodes = node.getChildNodes();
+        return streamFromNodeList(childNodes).filter(n -> n.getNodeName().equals(name)).findFirst();
+    }
+
+    private Stream<Node> streamFromNodeList(NodeList nodes) {
+        Iterator<Node> iter = new NodeListIterator(nodes);
+        Iterable<Node> iterable = () -> iter;
+        return StreamSupport.stream(iterable.spliterator(), false);
+    }
+
+    protected boolean hasThisXMLRootElement(AttachmentContent content, String rootElementNamespace, String rootElementName) {
+        XMLInputFactory xmlif = XMLInputFactory.newFactory();
+        XMLStreamReader xmlStreamReader = null;
+        InputStream attachmentStream = null;
+        try {
+            attachmentStream = attachmentConnector.getAttachmentStream(content);
+            xmlStreamReader = xmlif.createXMLStreamReader(attachmentStream);
+
+            //skip to first element
+            while (xmlStreamReader.hasNext() && xmlStreamReader.next() != XMLStreamConstants.START_ELEMENT) ;
+            xmlStreamReader.require(XMLStreamConstants.START_ELEMENT, rootElementNamespace, rootElementName);
+            return true;
+        } catch (XMLStreamException | SW360Exception e) {
+            return false;
+        } finally {
+            if (null != xmlStreamReader) {
+                try {
+                    xmlStreamReader.close();
+                } catch (XMLStreamException e) {
+                    // ignore it
+                }
+            }
+            closeQuietly(attachmentStream, log);
+        }
+    }
+
+    protected Document getDocument(InputStream attachmentStream) throws ParserConfigurationException, SAXException, IOException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        return builder.parse(attachmentStream);
+    }
+
+    protected NodeList getNodeListByXpath(Document doc, String xpathString) throws XPathExpressionException {
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        XPathExpression xpathExpression = xpath.compile(xpathString);
+        return (NodeList) xpathExpression.evaluate(doc, XPathConstants.NODESET);
+    }
+
+    protected Set<String> nodeListToStringSet(NodeList nodes) {
+        Set<String> strings = Sets.newHashSet();
+        for (int i = 0; i < nodes.getLength(); i++) {
+            strings.add(normalizeEscapedXhtml(nodes.item(i)));
+        }
+        return strings;
+    }
+
+    protected LicenseNameWithText getLicenseNameWithTextFromLicenseNode(Node node) {
+        return new LicenseNameWithText()
+                .setLicenseText(findNamedSubelement(node, LICENSE_CONTENT_ELEMENT_NAME)
+                        .map(AbstractCLIParser::normalizeEscapedXhtml)
+                        .orElse(null))
+                .setAcknowledgements(findNamedSubelement(node, LICENSE_ACKNOWLEDGEMENTS_ELEMENT_NAME)
+                        .map(AbstractCLIParser::normalizeEscapedXhtml)
+                        .orElse(null))
+                .setLicenseName(findNamedAttribute(node, LICENSENAME_ATTRIBUTE_NAME)
+                        .map(Node::getNodeValue)
+                        .orElse(LICENSE_NAME_UNKNOWN));
+    }
+
+    protected class NodeListIterator implements Iterator<Node> {
+        private final NodeList nodes;
+        private int i;
+
+        public NodeListIterator(NodeList nodes) {
+            this.nodes = nodes;
+            this.i = 0;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return i < nodes.getLength();
+        }
+
+        @Override
+        public Node next() {
+            if (hasNext()) {
+                i++;
+                return nodes.item(i - 1);
+            } else {
+                throw new NoSuchElementException();
+            }
+        }
+    }
+}

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
@@ -9,6 +9,7 @@
 package org.eclipse.sw360.licenseinfo.parsers;
 
 import com.google.common.collect.Sets;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
@@ -102,7 +103,7 @@ public class CLIParser extends LicenseInfoParser {
     private Set<String> nodeListToStringSet(NodeList nodes){
         Set<String> strings = Sets.newHashSet();
         for (int i = 0; i < nodes.getLength(); i++){
-            strings.add(nodes.item(i).getTextContent().trim());
+            strings.add(StringEscapeUtils.unescapeHtml(StringEscapeUtils.unescapeXml(nodes.item(i).getTextContent().trim())));
         }
         return strings;
     }
@@ -112,9 +113,20 @@ public class CLIParser extends LicenseInfoParser {
         for (int i = 0; i < nodes.getLength(); i++){
             licenseNamesWithTexts.add(
                     new LicenseNameWithText()
-                    .setLicenseText(findNamedSubelement(nodes.item(i), LICENSE_CONTENT_ELEMENT_NAME).map(Node::getTextContent).map(String::trim).orElse(null))
-                    .setAcknowledgements(findNamedSubelement(nodes.item(i), LICENSE_ACKNOWLEDGEMENTS_ELEMENT_NAME).map(Node::getTextContent).map(String::trim).orElse(null))
-                    .setLicenseName(Optional.ofNullable(nodes.item(i).getAttributes().getNamedItem(LICENSENAME_ATTRIBUTE_NAME))
+                            .setLicenseText(findNamedSubelement(nodes.item(i), LICENSE_CONTENT_ELEMENT_NAME)
+                                    .map(Node::getTextContent)
+                                    .map(String::trim)
+                                    .map(StringEscapeUtils::unescapeXml)
+                                    .map(StringEscapeUtils::unescapeHtml)
+                                    .orElse(null))
+                            .setAcknowledgements(findNamedSubelement(nodes.item(i), LICENSE_ACKNOWLEDGEMENTS_ELEMENT_NAME)
+                                    .map(Node::getTextContent)
+                                    .map(String::trim)
+                                    .map(StringEscapeUtils::unescapeXml)
+                                    .map(StringEscapeUtils::unescapeHtml)
+                                    .orElse(null))
+                            .setLicenseName(Optional
+                                    .ofNullable(nodes.item(i).getAttributes().getNamedItem(LICENSENAME_ATTRIBUTE_NAME))
                             .map(Node::getNodeValue).orElse(LICENSE_NAME_UNKNOWN))
             );
         }

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -27,10 +27,6 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
 import javax.xml.xpath.*;
 import java.io.IOException;
 import java.io.InputStream;
@@ -71,33 +67,11 @@ public class CLIParser extends LicenseInfoParser {
     }
 
     private boolean hasCLIRootElement(AttachmentContent content) {
-        XMLInputFactory xmlif = XMLInputFactory.newFactory();
-        XMLStreamReader xmlStreamReader = null;
-        InputStream attachmentStream = null;
-        try {
-            attachmentStream = attachmentConnector.getAttachmentStream(content);
-            xmlStreamReader = xmlif.createXMLStreamReader(attachmentStream);
-
-            //skip to first element
-            while(xmlStreamReader.hasNext() && xmlStreamReader.next() != XMLStreamConstants.START_ELEMENT);
-            xmlStreamReader.require(XMLStreamConstants.START_ELEMENT, CLI_ROOT_ELEMENT_NAMESPACE, CLI_ROOT_ELEMENT_NAME);
-            return true;
-        } catch (XMLStreamException | SW360Exception e) {
-            return false;
-        } finally {
-            if (null != xmlStreamReader){
-                try {
-                    xmlStreamReader.close();
-                } catch (XMLStreamException e) {
-                    // ignore it
-                }
-            }
-            closeQuietly(attachmentStream, log);
-        }
+        return hasThisXMLRootElement(content, CLI_ROOT_ELEMENT_NAMESPACE, CLI_ROOT_ELEMENT_NAME);
     }
 
     @Override
-    public LicenseInfoParsingResult getLicenseInfo(Attachment attachment) throws TException {
+    public List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment) throws TException {
         AttachmentContent attachmentContent = attachmentContentProvider.getAttachmentContent(attachment);
         LicenseInfo licenseInfo = new LicenseInfo().setFilenames(Arrays.asList(attachmentContent.getFilename()));
         LicenseInfoParsingResult result = new LicenseInfoParsingResult().setLicenseInfo(licenseInfo);
@@ -122,7 +96,7 @@ public class CLIParser extends LicenseInfoParser {
         } finally {
             closeQuietly(attachmentStream, log);
         }
-        return result;
+        return Collections.singletonList(result);
     }
 
     private Set<String> nodeListToStringSet(NodeList nodes){

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
@@ -9,7 +9,6 @@
 package org.eclipse.sw360.licenseinfo.parsers;
 
 import com.google.common.collect.Sets;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
@@ -21,20 +20,16 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
 import org.w3c.dom.Document;
-import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.*;
+import javax.xml.xpath.XPathExpressionException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static org.eclipse.sw360.datahandler.common.CommonUtils.closeQuietly;
@@ -43,19 +38,13 @@ import static org.eclipse.sw360.datahandler.common.CommonUtils.closeQuietly;
  * Class for extracting copyright and license information from a simple XML file
  * @author: alex.borodin@evosoft.com
  */
-public class CLIParser extends LicenseInfoParser {
+public class CLIParser extends AbstractCLIParser {
 
     private static final Logger log = Logger.getLogger(CLIParser.class);
     private static final String COPYRIGHTS_XPATH = "/ComponentLicenseInformation/Copyright/Content";
     private static final String LICENSES_XPATH = "/ComponentLicenseInformation/License";
-    private static final String LICENSE_CONTENT_ELEMENT_NAME = "Content";
-    private static final String LICENSE_ACKNOWLEDGEMENTS_ELEMENT_NAME = "Acknowledgements";
     private static final String CLI_ROOT_ELEMENT_NAME = "ComponentLicenseInformation";
     private static final String CLI_ROOT_ELEMENT_NAMESPACE = null;
-    private static final String XML_FILE_EXTENSION = ".xml";
-
-    public static final String LICENSENAME_ATTRIBUTE_NAME = "name";
-    public static final String LICENSE_NAME_UNKNOWN = "License name unknown";
 
     public CLIParser(AttachmentConnector attachmentConnector, AttachmentContentProvider attachmentContentProvider) {
         super(attachmentConnector, attachmentContentProvider);
@@ -79,17 +68,15 @@ public class CLIParser extends LicenseInfoParser {
         InputStream attachmentStream = null;
 
         try {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder builder = factory.newDocumentBuilder();
             attachmentStream = attachmentConnector.getAttachmentStream(attachmentContent);
-            Document doc = builder.parse(attachmentStream);
-            XPath xpath = XPathFactory.newInstance().newXPath();
-            XPathExpression copyrightsExpr = xpath.compile(COPYRIGHTS_XPATH);
-            XPathExpression licensesExpr = xpath.compile(LICENSES_XPATH);
-            NodeList copyrightNodes = (NodeList) copyrightsExpr.evaluate(doc, XPathConstants.NODESET);
-            NodeList licenseNodes = (NodeList) licensesExpr.evaluate(doc, XPathConstants.NODESET);
-            licenseInfo.setCopyrights(nodeListToStringSet(copyrightNodes));
-            licenseInfo.setLicenseNamesWithTexts(nodeListToLicenseNamesWithTextsSet(licenseNodes));
+            Document doc = getDocument(attachmentStream);
+
+            Set<String> copyrights = getCopyrights(doc);
+            licenseInfo.setCopyrights(copyrights);
+
+            Set<LicenseNameWithText> licenseNamesWithTexts = getLicenseNameWithTexts(doc);
+            licenseInfo.setLicenseNamesWithTexts(licenseNamesWithTexts);
+
             result.setStatus(LicenseInfoRequestStatus.SUCCESS);
         } catch (ParserConfigurationException | IOException | XPathExpressionException | SAXException | SW360Exception e) {
             log.error(e);
@@ -100,72 +87,21 @@ public class CLIParser extends LicenseInfoParser {
         return Collections.singletonList(result);
     }
 
-    private Set<String> nodeListToStringSet(NodeList nodes){
-        Set<String> strings = Sets.newHashSet();
-        for (int i = 0; i < nodes.getLength(); i++){
-            strings.add(StringEscapeUtils.unescapeHtml(StringEscapeUtils.unescapeXml(nodes.item(i).getTextContent().trim())));
-        }
-        return strings;
+    private Set<LicenseNameWithText> getLicenseNameWithTexts(Document doc) throws XPathExpressionException {
+        NodeList licenseNodes = getNodeListByXpath(doc, LICENSES_XPATH);
+        return nodeListToLicenseNamesWithTextsSet(licenseNodes);
+    }
+
+    private Set<String> getCopyrights(Document doc) throws XPathExpressionException {
+        NodeList copyrightNodes = getNodeListByXpath(doc, COPYRIGHTS_XPATH);
+        return nodeListToStringSet(copyrightNodes);
     }
 
     private Set<LicenseNameWithText> nodeListToLicenseNamesWithTextsSet(NodeList nodes){
         Set<LicenseNameWithText> licenseNamesWithTexts= Sets.newHashSet();
         for (int i = 0; i < nodes.getLength(); i++){
-            licenseNamesWithTexts.add(
-                    new LicenseNameWithText()
-                            .setLicenseText(findNamedSubelement(nodes.item(i), LICENSE_CONTENT_ELEMENT_NAME)
-                                    .map(Node::getTextContent)
-                                    .map(String::trim)
-                                    .map(StringEscapeUtils::unescapeXml)
-                                    .map(StringEscapeUtils::unescapeHtml)
-                                    .orElse(null))
-                            .setAcknowledgements(findNamedSubelement(nodes.item(i), LICENSE_ACKNOWLEDGEMENTS_ELEMENT_NAME)
-                                    .map(Node::getTextContent)
-                                    .map(String::trim)
-                                    .map(StringEscapeUtils::unescapeXml)
-                                    .map(StringEscapeUtils::unescapeHtml)
-                                    .orElse(null))
-                            .setLicenseName(Optional
-                                    .ofNullable(nodes.item(i).getAttributes().getNamedItem(LICENSENAME_ATTRIBUTE_NAME))
-                            .map(Node::getNodeValue).orElse(LICENSE_NAME_UNKNOWN))
-            );
+            licenseNamesWithTexts.add(getLicenseNameWithTextFromLicenseNode(nodes.item(i)));
         }
         return licenseNamesWithTexts;
-    }
-
-    private Optional<Node> findNamedSubelement(Node node, String name){
-        NodeList childNodes = node.getChildNodes();
-        return streamFromNodeList(childNodes).filter(n -> n.getNodeName().equals(name)).findFirst();
-    }
-
-    private Stream<Node> streamFromNodeList(NodeList nodes){
-        Iterator<Node> iter = new NodeListIterator(nodes);
-        Iterable<Node> iterable = () -> iter;
-        return StreamSupport.stream(iterable.spliterator(), false);
-    }
-
-    class NodeListIterator implements Iterator<Node>{
-        private final NodeList nodes;
-        private int i;
-
-        public NodeListIterator(NodeList nodes) {
-            this.nodes = nodes;
-            this.i = 0;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return i < nodes.getLength();
-        }
-
-        @Override
-        public Node next() {
-            if (hasNext()){
-                i++;
-                return nodes.item(i-1);
-            } else {
-                throw new NoSuchElementException();
-            }
-        }
     }
 }

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.licenseinfo.parsers;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
+import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
+import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.eclipse.sw360.datahandler.common.CommonUtils.closeQuietly;
+
+/**
+ * Class for extracting copyright and license information from a simple XML file
+ * @author: alex.borodin@evosoft.com
+ */
+public class CombinedCLIParser extends LicenseInfoParser {
+
+    private static final Logger log = Logger.getLogger(CombinedCLIParser.class);
+    private static final String COPYRIGHTS_XPATH = "/CombinedCLI/Copyright";
+    private static final String LICENSES_XPATH = "/CombinedCLI/License";
+    private static final String COPYRIGHT_CONTENT_ELEMENT_NAME = "Content";
+    private static final String EXTERNAL_ID_ATTRIBUTE_NAME = "srcComponent";
+    private static final String LICENSE_CONTENT_ELEMENT_NAME = "Content";
+    private static final String LICENSE_ACKNOWLEDGEMENTS_ELEMENT_NAME = "Acknowledgements";
+    private static final String COMBINED_CLI_ROOT_ELEMENT_NAME = "CombinedCLI";
+    private static final String COMBINED_CLI_ROOT_ELEMENT_NAMESPACE = null;
+    private static final String XML_FILE_EXTENSION = ".xml";
+
+    private static final String LICENSENAME_ATTRIBUTE_NAME = "name";
+    private static final String LICENSE_NAME_UNKNOWN = "License name unknown";
+    private static final String PROPERTIES_FILE_PATH = "/sw360.properties";
+    public static final String EXTERNAL_ID_CORRELATION_KEY = "combined.cli.parser.external.id.correlation.key";
+
+    private ComponentDatabaseHandler componentDatabaseHandler;
+
+    public CombinedCLIParser(AttachmentConnector attachmentConnector, AttachmentContentProvider attachmentContentProvider, ComponentDatabaseHandler componentDatabaseHandler) {
+        super(attachmentConnector, attachmentContentProvider);
+        this.componentDatabaseHandler = componentDatabaseHandler;
+    }
+
+    String getCorrelationKey(){
+        Properties props = CommonUtils.loadProperties(CombinedCLIParser.class, PROPERTIES_FILE_PATH);
+        String releaseExternalIdCorrelationKey = props.getProperty(EXTERNAL_ID_CORRELATION_KEY);
+        if (isNullOrEmpty(releaseExternalIdCorrelationKey)){
+            log.warn("Property combined.cli.parser.external.id.correlation.key is not set. Combined CLI parsing will not be able to load names of referenced releases");
+        }
+        return releaseExternalIdCorrelationKey;
+    }
+
+    @Override
+    public boolean isApplicableTo(Attachment attachment) throws TException {
+        AttachmentContent attachmentContent = attachmentContentProvider.getAttachmentContent(attachment);
+        return attachmentContent.getFilename().endsWith(XML_FILE_EXTENSION) && hasCombinedCLIRootElement(attachmentContent);
+    }
+
+    private boolean hasCombinedCLIRootElement(AttachmentContent content) {
+        return hasThisXMLRootElement(content, COMBINED_CLI_ROOT_ELEMENT_NAMESPACE, COMBINED_CLI_ROOT_ELEMENT_NAME);
+    }
+
+    @Override
+    public List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment) throws TException {
+        AttachmentContent attachmentContent = attachmentContentProvider.getAttachmentContent(attachment);
+        InputStream attachmentStream = null;
+        List<LicenseInfoParsingResult> parsingResults = new ArrayList<>();
+        Map<String, Release> releasesByExternalId = prepareReleasesByExternalId(getCorrelationKey());
+
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            attachmentStream = attachmentConnector.getAttachmentStream(attachmentContent);
+            Document doc = builder.parse(attachmentStream);
+            XPath xpath = XPathFactory.newInstance().newXPath();
+            XPathExpression copyrightsExpr = xpath.compile(COPYRIGHTS_XPATH);
+            XPathExpression licensesExpr = xpath.compile(LICENSES_XPATH);
+            NodeList copyrightNodes = (NodeList) copyrightsExpr.evaluate(doc, XPathConstants.NODESET);
+            NodeList licenseNodes = (NodeList) licensesExpr.evaluate(doc, XPathConstants.NODESET);
+            Map<String, Set<String>> copyrightSetsByExternalId = nodeListToStringSetsByExternalId(copyrightNodes, EXTERNAL_ID_ATTRIBUTE_NAME, COPYRIGHT_CONTENT_ELEMENT_NAME);
+            Map<String, Set<LicenseNameWithText>> licenseNamesWithTextsByExternalId = nodeListToLicenseNamesWithTextsSetsByExternalId(licenseNodes, EXTERNAL_ID_ATTRIBUTE_NAME);
+            Set<String> allExternalIds = Sets.union(copyrightSetsByExternalId.keySet(), licenseNamesWithTextsByExternalId.keySet());
+            allExternalIds.forEach(extId -> {
+                LicenseInfo licenseInfo = new LicenseInfo().setFilenames(Arrays.asList(attachmentContent.getFilename()));
+                licenseInfo.setCopyrights(copyrightSetsByExternalId.get(extId));
+                licenseInfo.setLicenseNamesWithTexts(licenseNamesWithTextsByExternalId.get(extId));
+                LicenseInfoParsingResult parsingResult = new LicenseInfoParsingResult().setLicenseInfo(licenseInfo);
+                Release release = releasesByExternalId.get(extId);
+                if (release != null) {
+                    parsingResult.setVendor(release.isSetVendor() ? release.getVendor().getShortname() : "");
+                    parsingResult.setName(release.getName());
+                    parsingResult.setVersion(release.getVersion());
+                } else {
+                    parsingResult.setName("No info found for external component ID " + extId);
+                }
+                parsingResult.setStatus(LicenseInfoRequestStatus.SUCCESS);
+                parsingResults.add(parsingResult);
+            });
+        } catch (ParserConfigurationException | IOException | XPathExpressionException | SAXException | SW360Exception e) {
+            log.error(e);
+            parsingResults.add(new LicenseInfoParsingResult()
+                    .setStatus(LicenseInfoRequestStatus.FAILURE)
+                    .setMessage("Error while parsing CLI file: " + e.toString()));
+        } finally {
+            closeQuietly(attachmentStream, log);
+        }
+        return parsingResults;
+    }
+
+    private Map<String, Release> prepareReleasesByExternalId(String correlationKey) {
+        Map<String, Release> idMap = componentDatabaseHandler.getAllReleasesIdMap();
+        Map<String, Release> releasesByExternalId = idMap.values().stream()
+                .filter(r -> r.getExternalIds() != null && r.getExternalIds().containsKey(correlationKey))
+                .collect(Collectors.toMap(r -> r.getExternalIds().get(correlationKey), r -> r, (r1, r2) -> {
+                    throw new RuntimeException(String.format("Duplicate externalId in releases %s and %s", SW360Utils.printFullname(r1), SW360Utils.printFullname(r2)));}));
+        return releasesByExternalId;
+    }
+
+    private Map<String, Set<String>> nodeListToStringSetsByExternalId(NodeList nodes, String externalIdAttributeName, String contentElementName){
+        Map<String, Set<String>> result = Maps.newHashMap();
+        for (int i = 0; i < nodes.getLength(); i++){
+            Optional<Node> externalIdOptional = findNamedAttribute(nodes.item(i), externalIdAttributeName);
+            String externalId = externalIdOptional.map(Node::getNodeValue).orElse(null);
+            String contentText = findNamedSubelement(nodes.item(i), contentElementName).map(Node::getTextContent).map(String::trim).orElse(null);
+            if (!result.containsKey(externalId)){
+                result.put(externalId, Sets.newHashSet());
+            }
+            result.get(externalId).add(contentText);
+        }
+        return result;
+    }
+
+    private Map<String, Set<LicenseNameWithText>> nodeListToLicenseNamesWithTextsSetsByExternalId(NodeList nodes, String externalIdAttributeName){
+        Map<String, Set<LicenseNameWithText>> result = Maps.newHashMap();
+        for (int i = 0; i < nodes.getLength(); i++){
+            Optional<Node> externalIdOptional = findNamedAttribute(nodes.item(i), externalIdAttributeName);
+            String externalId = externalIdOptional.map(Node::getNodeValue).orElse(null);
+
+            LicenseNameWithText licenseNameWithText = new LicenseNameWithText()
+                    .setLicenseText(findNamedSubelement(nodes.item(i), LICENSE_CONTENT_ELEMENT_NAME)
+                            .map(Node::getTextContent)
+                            .map(String::trim)
+                            .orElse(null))
+                    .setAcknowledgements(findNamedSubelement(nodes.item(i), LICENSE_ACKNOWLEDGEMENTS_ELEMENT_NAME)
+                            .map(Node::getTextContent)
+                            .map(String::trim)
+                            .orElse(null))
+                    .setLicenseName(Optional
+                            .ofNullable(nodes.item(i).getAttributes().getNamedItem(LICENSENAME_ATTRIBUTE_NAME))
+                            .map(Node::getNodeValue)
+                            .orElse(LICENSE_NAME_UNKNOWN));
+
+            if (!result.containsKey(externalId)){
+                result.put(externalId, Sets.newHashSet());
+            }
+            result.get(externalId).add(licenseNameWithText);
+
+        }
+        return result;
+    }
+
+    private Optional<Node> findNamedAttribute(Node node, String name){
+        NamedNodeMap childNodes = node.getAttributes();
+        return Optional.ofNullable(childNodes.getNamedItem(name));
+    }
+
+    private Optional<Node> findNamedSubelement(Node node, String name){
+        NodeList childNodes = node.getChildNodes();
+        return streamFromNodeList(childNodes).filter(n -> n.getNodeName().equals(name)).findFirst();
+    }
+
+    private Stream<Node> streamFromNodeList(NodeList nodes){
+        Iterator<Node> iter = new NodeListIterator(nodes);
+        Iterable<Node> iterable = () -> iter;
+        return StreamSupport.stream(iterable.spliterator(), false);
+    }
+
+    class NodeListIterator implements Iterator<Node>{
+        private final NodeList nodes;
+        private int i;
+
+        public NodeListIterator(NodeList nodes) {
+            this.nodes = nodes;
+            this.i = 0;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return i < nodes.getLength();
+        }
+
+        @Override
+        public Node next() {
+            if (hasNext()){
+                i++;
+                return nodes.item(i-1);
+            } else {
+                throw new NoSuchElementException();
+            }
+        }
+    }
+}

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
@@ -146,7 +146,9 @@ public class CombinedCLIParser extends AbstractCLIParser{
         Map<String, Release> releasesByExternalId = idMap.values().stream()
                 .filter(r -> r.getExternalIds() != null && r.getExternalIds().containsKey(correlationKey))
                 .collect(Collectors.toMap(r -> r.getExternalIds().get(correlationKey), r -> r, (r1, r2) -> {
-                    throw new RuntimeException(String.format("Duplicate externalId in releases %s and %s", SW360Utils.printFullname(r1), SW360Utils.printFullname(r2)));}));
+                    log.warn(String.format("Duplicate externalId in releases %s and %s", SW360Utils.printFullname(r1), SW360Utils.printFullname(r2)));
+                    return r1;
+                }));
         return releasesByExternalId;
     }
 

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
@@ -10,6 +10,7 @@ package org.eclipse.sw360.licenseinfo.parsers;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
@@ -153,7 +154,12 @@ public class CombinedCLIParser extends LicenseInfoParser {
         for (int i = 0; i < nodes.getLength(); i++){
             Optional<Node> externalIdOptional = findNamedAttribute(nodes.item(i), externalIdAttributeName);
             String externalId = externalIdOptional.map(Node::getNodeValue).orElse(null);
-            String contentText = findNamedSubelement(nodes.item(i), contentElementName).map(Node::getTextContent).map(String::trim).orElse(null);
+            String contentText = findNamedSubelement(nodes.item(i), contentElementName)
+                    .map(Node::getTextContent)
+                    .map(String::trim)
+                    .map(StringEscapeUtils::unescapeXml)
+                    .map(StringEscapeUtils::unescapeHtml)
+                    .orElse(null);
             if (!result.containsKey(externalId)){
                 result.put(externalId, Sets.newHashSet());
             }
@@ -172,10 +178,14 @@ public class CombinedCLIParser extends LicenseInfoParser {
                     .setLicenseText(findNamedSubelement(nodes.item(i), LICENSE_CONTENT_ELEMENT_NAME)
                             .map(Node::getTextContent)
                             .map(String::trim)
+                            .map(StringEscapeUtils::unescapeXml)
+                            .map(StringEscapeUtils::unescapeHtml)
                             .orElse(null))
                     .setAcknowledgements(findNamedSubelement(nodes.item(i), LICENSE_ACKNOWLEDGEMENTS_ELEMENT_NAME)
                             .map(Node::getTextContent)
                             .map(String::trim)
+                            .map(StringEscapeUtils::unescapeXml)
+                            .map(StringEscapeUtils::unescapeHtml)
                             .orElse(null))
                     .setLicenseName(Optional
                             .ofNullable(nodes.item(i).getAttributes().getNamedItem(LICENSENAME_ATTRIBUTE_NAME))

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParser.java
@@ -40,31 +40,5 @@ public abstract class LicenseInfoParser {
 
     public abstract boolean isApplicableTo(Attachment attachmentContent) throws TException;
 
-    protected boolean hasThisXMLRootElement(AttachmentContent content, String rootElementNamespace, String rootElementName) {
-        XMLInputFactory xmlif = XMLInputFactory.newFactory();
-        XMLStreamReader xmlStreamReader = null;
-        InputStream attachmentStream = null;
-        try {
-            attachmentStream = attachmentConnector.getAttachmentStream(content);
-            xmlStreamReader = xmlif.createXMLStreamReader(attachmentStream);
-
-            //skip to first element
-            while(xmlStreamReader.hasNext() && xmlStreamReader.next() != XMLStreamConstants.START_ELEMENT);
-            xmlStreamReader.require(XMLStreamConstants.START_ELEMENT, rootElementNamespace, rootElementName);
-            return true;
-        } catch (XMLStreamException | SW360Exception e) {
-            return false;
-        } finally {
-            if (null != xmlStreamReader){
-                try {
-                    xmlStreamReader.close();
-                } catch (XMLStreamException e) {
-                    // ignore it
-                }
-            }
-            closeQuietly(attachmentStream, LicenseInfoParser.log);
-        }
-    }
-
     public abstract List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment) throws TException;
 }

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,15 +8,28 @@
  */
 package org.eclipse.sw360.licenseinfo.parsers;
 
+import org.apache.log4j.Logger;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.apache.thrift.TException;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.eclipse.sw360.datahandler.common.CommonUtils.closeQuietly;
 
 /**
  * @author: alex.borodin@evosoft.com
  */
 public abstract class LicenseInfoParser {
+    private static final Logger log = Logger.getLogger(LicenseInfoParser.class);
     protected final AttachmentConnector attachmentConnector;
     protected AttachmentContentProvider attachmentContentProvider;
 
@@ -26,5 +39,32 @@ public abstract class LicenseInfoParser {
     }
 
     public abstract boolean isApplicableTo(Attachment attachmentContent) throws TException;
-    public abstract LicenseInfoParsingResult getLicenseInfo(Attachment attachment) throws TException;
+
+    protected boolean hasThisXMLRootElement(AttachmentContent content, String rootElementNamespace, String rootElementName) {
+        XMLInputFactory xmlif = XMLInputFactory.newFactory();
+        XMLStreamReader xmlStreamReader = null;
+        InputStream attachmentStream = null;
+        try {
+            attachmentStream = attachmentConnector.getAttachmentStream(content);
+            xmlStreamReader = xmlif.createXMLStreamReader(attachmentStream);
+
+            //skip to first element
+            while(xmlStreamReader.hasNext() && xmlStreamReader.next() != XMLStreamConstants.START_ELEMENT);
+            xmlStreamReader.require(XMLStreamConstants.START_ELEMENT, rootElementNamespace, rootElementName);
+            return true;
+        } catch (XMLStreamException | SW360Exception e) {
+            return false;
+        } finally {
+            if (null != xmlStreamReader){
+                try {
+                    xmlStreamReader.close();
+                } catch (XMLStreamException e) {
+                    // ignore it
+                }
+            }
+            closeQuietly(attachmentStream, LicenseInfoParser.log);
+        }
+    }
+
+    public abstract List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment) throws TException;
 }

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParser.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Bosch Software Innovations GmbH, 2016.
- * Copyright Siemens AG, 2016.
+ * Copyright Siemens AG, 2016-2017.
  * Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
@@ -70,7 +70,7 @@ public class SPDXParser extends LicenseInfoParser {
     }
 
     @Override
-    public LicenseInfoParsingResult getLicenseInfo(Attachment attachment) throws TException {
+    public List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment) throws TException {
         AttachmentContent attachmentContent = attachmentContentProvider.getAttachmentContent(attachment);
         LicenseInfo emptyResult = new LicenseInfo()
                 .setFilenames(Arrays.asList(attachmentContent.getFilename()));
@@ -79,12 +79,12 @@ public class SPDXParser extends LicenseInfoParser {
                 .flatMap(d -> addSpdxContentToCLI(emptyResult, d));
 
         if(licenseInfo.isPresent()){
-            return new LicenseInfoParsingResult()
+            return Collections.singletonList(new LicenseInfoParsingResult()
                     .setLicenseInfo(licenseInfo.get())
-                    .setStatus(LicenseInfoRequestStatus.SUCCESS);
+                    .setStatus(LicenseInfoRequestStatus.SUCCESS));
         }else{
-            return new LicenseInfoParsingResult()
-                    .setStatus(LicenseInfoRequestStatus.FAILURE);
+            return Collections.singletonList(new LicenseInfoParsingResult()
+                    .setStatus(LicenseInfoRequestStatus.FAILURE));
         }
     }
 

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2016.
+ * Copyright Siemens AG, 2016-2017.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  * Part of the SW360 Portal Project.
  *
@@ -101,7 +101,7 @@ public class CLIParserTest {
     public void testGetCLI() throws Exception {
         Attachment cliAttachment = new Attachment("A1", "a.xml");
         when(connector.getAttachmentStream(anyObject())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
-        LicenseInfoParsingResult res = parser.getLicenseInfo(cliAttachment);
+        LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment).stream().findFirst().orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
         assertLicenseInfoParsingResult(res);
         assertThat(res.getStatus(), is(LicenseInfoRequestStatus.SUCCESS));
         assertThat(res.getLicenseInfo(), notNullValue());
@@ -118,7 +118,7 @@ public class CLIParserTest {
     public void testGetCLIFailsOnMalformedXML() throws Exception {
         Attachment cliAttachment = new Attachment("A1", "a.xml");
         when(connector.getAttachmentStream(anyObject())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE.replaceAll("</Content>", "</Broken>"))));
-        LicenseInfoParsingResult res = parser.getLicenseInfo(cliAttachment);
+        LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment).stream().findFirst().orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
         assertLicenseInfoParsingResult(res, LicenseInfoRequestStatus.FAILURE);
         assertThat(res.getStatus(), is(LicenseInfoRequestStatus.FAILURE));
         assertThat(res.getLicenseInfo(), notNullValue());

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParserTest.java
@@ -118,7 +118,7 @@ public class CombinedCLIParserTest {
         assertThat(res.getLicenseInfo().getFilenames(), containsInAnyOrder("a.xml"));
         assertThat(res.getLicenseInfo().getLicenseNamesWithTexts().size(), is(3));
         assertThat(res.getLicenseInfo().getLicenseNamesWithTexts().stream().map(LicenseNameWithText::getLicenseText).collect(Collectors.toSet()),
-                containsInAnyOrder("License1Text", "License2Text", "License3Text"));
+                containsInAnyOrder("License1Text", "License2Text", "License3&'Text"));
         LicenseNameWithText l2 = res.getLicenseInfo().getLicenseNamesWithTexts().stream().filter(l -> l.getLicenseName().equals("License2")).findFirst().orElseThrow(AssertionError::new);
         assertThat(l2.getAcknowledgements(), is("License2Acknowledgements"));
         assertThat(res.getLicenseInfo().getCopyrights().size(), is(5));

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParserTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Siemens AG, 2017.
+ * Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.licenseinfo.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.ReaderInputStream;
+import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
+import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.eclipse.sw360.licenseinfo.TestHelper.assertLicenseInfoParsingResult;
+import static org.eclipse.sw360.licenseinfo.TestHelper.makeAttachmentContentStream;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author: alex.borodin@evosoft.com
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CombinedCLIParserTest {
+    private static final String TEST_XML_FILENAME = "CombinedCLITest.xml";
+
+    @Mock
+    private AttachmentConnector connector;
+    private CombinedCLIParser parser;
+    private AttachmentContent content;
+    private Attachment attachment;
+    @Mock
+    private ComponentDatabaseHandler componentDatabaseHandler;
+    private String cliTestfile;
+
+    @Before
+    public void setUp() throws Exception {
+        cliTestfile = IOUtils.toString(makeAttachmentContentStream(TEST_XML_FILENAME));
+        attachment = new Attachment("A1", "a.xml").setAttachmentType(AttachmentType.COMPONENT_LICENSE_INFO_COMBINED);
+        content = new AttachmentContent().setId("A1").setFilename("a.xml").setContentType("application/xml");
+        parser = spy(new CombinedCLIParser(connector, attachment -> content, componentDatabaseHandler));
+        doReturn("external-correlation-id").when(parser).getCorrelationKey();
+        Release r1 = new Release().setId("id1")
+                .setName("r1")
+                .setVersion("1.0")
+                .setVendor(new Vendor().setFullname("VendorA Fullname").setShortname("VendorA"))
+                .setExternalIds(ImmutableMap.of(parser.getCorrelationKey(), "1234"));
+        Release r2 = new Release().setId("id2")
+                .setName("r2")
+                .setVersion("2.0")
+                .setVendor(new Vendor().setFullname("VendorB Fullname").setShortname("VendorB"))
+                .setExternalIds(ImmutableMap.of(parser.getCorrelationKey(), "4321"));
+        Release r3 = new Release().setId("id3")
+                .setName("r3")
+                .setVersion("3.0")
+                .setVendor(new Vendor().setFullname("VendorC Fullname").setShortname("VendorC"));
+        Release r4 = new Release().setId("id4")
+                .setName("r4")
+                .setVersion("4.0")
+                .setVendor(new Vendor().setFullname("VendorD Fullname").setShortname("VendorD"))
+                .setExternalIds(ImmutableMap.of("some_external_id", "1234"));
+
+        when(componentDatabaseHandler.getAllReleasesIdMap()).thenReturn(ImmutableMap.of(r1.getId(), r1, r2.getId(), r2, r3.getId(), r3, r4.getId(), r4));
+    }
+
+    @Test
+    public void testIsApplicableTo() throws Exception {
+        when(connector.getAttachmentStream(content)).thenReturn(makeAttachmentContentStream(TEST_XML_FILENAME));
+        assertTrue(parser.isApplicableTo(attachment));
+    }
+
+    @Test
+    public void testIsApplicableToFailsOnIncorrectRootElement() throws Exception {
+        AttachmentContent content = new AttachmentContent().setId("A1").setFilename("a.xml").setContentType("application/xml");
+        when(connector.getAttachmentStream(content)).thenReturn(new ReaderInputStream(new StringReader("<wrong-root/>")));
+        assertFalse(parser.isApplicableTo(attachment));
+    }
+
+    @Test
+    public void testIsApplicableToFailsOnMalformedXML() throws Exception {
+        AttachmentContent content = new AttachmentContent().setId("A1").setFilename("a.xml").setContentType("application/xml");
+        when(connector.getAttachmentStream(content)).thenReturn(new ReaderInputStream(new StringReader("this is not an xml file")));
+        assertFalse(parser.isApplicableTo(attachment));
+    }
+
+    @Test
+    public void testGetCLI() throws Exception {
+        Attachment cliAttachment = new Attachment("A1", "a.xml");
+        when(connector.getAttachmentStream(anyObject())).thenReturn(new ReaderInputStream(new StringReader(cliTestfile)));
+        List<LicenseInfoParsingResult> results = parser.getLicenseInfos(cliAttachment);
+        assertThat(results.size(), is(1));
+        LicenseInfoParsingResult res = results.get(0);
+        assertLicenseInfoParsingResult(res);
+        assertThat(res.getLicenseInfo().getFilenames(), containsInAnyOrder("a.xml"));
+        assertThat(res.getLicenseInfo().getLicenseNamesWithTexts().size(), is(3));
+        assertThat(res.getLicenseInfo().getLicenseNamesWithTexts().stream().map(LicenseNameWithText::getLicenseText).collect(Collectors.toSet()),
+                containsInAnyOrder("License1Text", "License2Text", "License3Text"));
+        LicenseNameWithText l2 = res.getLicenseInfo().getLicenseNamesWithTexts().stream().filter(l -> l.getLicenseName().equals("License2")).findFirst().orElseThrow(AssertionError::new);
+        assertThat(l2.getAcknowledgements(), is("License2Acknowledgements"));
+        assertThat(res.getLicenseInfo().getCopyrights().size(), is(5));
+        assertThat(res.getLicenseInfo().getCopyrights(), containsInAnyOrder("Copyright1", "Copyright2", "Copyright3", "Copyright4", "Copyright5"));
+        assertThat(res.getVendor(), is("VendorA"));
+        assertThat(res.getName(), is("r1"));
+        assertThat(res.getVersion(), is("1.0"));
+    }
+}

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
@@ -126,7 +126,7 @@ public class SPDXParserTest {
                         .findAny()
                         .get());
 
-        LicenseInfoParsingResult result = parser.getLicenseInfo(attachment);
+        LicenseInfoParsingResult result = parser.getLicenseInfos(attachment).stream().findFirst().orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
 
         assertLicenseInfoParsingResult(result);
         assertIsResultOfExample(result.getLicenseInfo());

--- a/backend/src/src-licenseinfo/src/test/resources/CombinedCLITest.xml
+++ b/backend/src/src-licenseinfo/src/test/resources/CombinedCLITest.xml
@@ -15,7 +15,7 @@
 ]]></Acknowledgements>
     </License>
     <License type="other" name="License3" subtype="other" srcFile="some_cli_file.xml" srcComponent="1234">
-        <Content><![CDATA[License3Text
+        <Content><![CDATA[License3&amp;&apos;Text
 ]]></Content>
         <Files><![CDATA[\contrib\file3.c
 ]]></Files>

--- a/backend/src/src-licenseinfo/src/test/resources/CombinedCLITest.xml
+++ b/backend/src/src-licenseinfo/src/test/resources/CombinedCLITest.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CombinedCLI component="InternalComponent 1.0" creator="Creative Employee" date="15.03.2017" baseDoc="-" componentID="1111">
+    <License type="global" name="License1" subtype="global" srcFile="some_cli_file.xml" srcComponent="1234">
+        <Content><![CDATA[License1Text
+]]></Content>
+        <Files><![CDATA[\file1.txt
+]]></Files>
+    </License>
+    <License type="other" name="License2" subtype="other" srcFile="some_other_cli_file.xml" srcComponent="1234">
+        <Content><![CDATA[License2Text
+]]></Content>
+        <Files><![CDATA[\contrib\file2.h
+]]></Files>
+   <Acknowledgements><![CDATA[License2Acknowledgements
+]]></Acknowledgements>
+    </License>
+    <License type="other" name="License3" subtype="other" srcFile="some_cli_file.xml" srcComponent="1234">
+        <Content><![CDATA[License3Text
+]]></Content>
+        <Files><![CDATA[\contrib\file3.c
+]]></Files>
+    </License>
+    <Copyright srcComponent="1234" srcFile="some_other_cli_file.xml">
+        <Content><![CDATA[Copyright1
+]]></Content>
+        <Files><![CDATA[\contrib\file3.c
+]]></Files>
+    </Copyright>
+    <Copyright srcComponent="1234" srcFile="some_other_cli_file.xml">
+        <Content><![CDATA[Copyright2
+]]></Content>
+        <Files><![CDATA[\contrib\file3.c
+]]></Files>
+    </Copyright>
+    <Copyright srcComponent="1234" srcFile="some_other_cli_file.xml">
+        <Content><![CDATA[Copyright3
+]]></Content>
+        <Files><![CDATA[\contrib\file3.c
+\SomeClass.java
+]]></Files>
+    </Copyright>
+    <Copyright srcComponent="1234" srcFile="some_other_cli_file.xml">
+        <Content><![CDATA[Copyright4
+]]></Content>
+        <Files><![CDATA[\contrib\file3.c
+]]></Files>
+    </Copyright>
+    <Copyright srcComponent="1234" srcFile="some_other_cli_file.xml">
+        <Content><![CDATA[Copyright5
+]]></Content>
+        <Files><![CDATA[\contrib\manager.c
+\contrib\factory.c
+\contrib\problem.cpp
+]]></Files>
+    </Copyright>
+</CombinedCLI>

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -74,9 +74,6 @@ public class ProjectPermissions extends DocumentPermissions<Project> {
         return new Predicate<Project>() {
             @Override
             public boolean apply(Project input) {
-                if (input == null){
-                    return false;
-                }
                 Visibility visbility = input.getVisbility();
                 if (visbility == null) {
                     visbility = Visibility.BUISNESSUNIT_AND_MODERATORS; // the current default

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -74,6 +74,9 @@ public class ProjectPermissions extends DocumentPermissions<Project> {
         return new Predicate<Project>() {
             @Override
             public boolean apply(Project input) {
+                if (input == null){
+                    return false;
+                }
                 Visibility visbility = input.getVisbility();
                 if (visbility == null) {
                     visbility = Visibility.BUISNESSUNIT_AND_MODERATORS; // the current default


### PR DESCRIPTION
- added a parser for CombinedCLI files
- also added unescaping of license texts, copyrights, and acknowledgements to work around the improperly escaped data, where the texts are stored in CDATA sections, yet are escaped.

Combined CLI parser needs a property `combined.cli.parser.external.id.correlation.key` in sw360.properties to work. The property value is the key in `release.externalIds`, by which the parser can find the release given an external Id as a reference.