### PR TITLE
Issues With Project Duplication

### DIFF
--- a/frontend/sw360-portlet/pom.xml
+++ b/frontend/sw360-portlet/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
@@ -69,7 +69,7 @@
                                 </property>
                                 <property>
                                     <name>sw360Version</name>
-                                    <value>${version}</value>
+                                    <value>${project.version}</value>
                                 </property>
                                 <property>
                                     <name>gitBranch</name>

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -48,6 +48,7 @@ import static java.lang.Integer.parseInt;
  * @author cedric.bodet@tngtech.com
  * @author Johannes.Najjar@tngtech.com
  * @author birgit.heydenreich@tngtech.com
+ * @author alex.borodin@evosoft.com
  */
 public class PortletUtils {
 
@@ -253,6 +254,7 @@ public class PortletUtils {
 
         //project specifics
         newProject.unsetAttachments();
+        newProject.setClearingState(ProjectClearingState.OPEN);
 
         return newProject;
     }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -839,8 +839,8 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 Project newProject = PortletUtils.cloneProject(emailFromRequest, department, client.getProjectById(id, user));
                 setAttachmentsInRequest(request, newProject.getAttachments());
                 request.setAttribute(PROJECT, newProject);
-                putLinkedProjectsInRequest(request, newProject.getLinkedProjects());
-                putLinkedReleasesInRequest(request, newProject.getReleaseIdToUsage());
+                putDirectlyLinkedProjectsInRequest(request, newProject.getLinkedProjects());
+                putDirectlyLinkedReleasesInRequest(request, newProject.getReleaseIdToUsage());
                 request.setAttribute(USING_PROJECTS, Collections.emptySet());
             } else {
                 Project project = new Project();
@@ -848,8 +848,8 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 setAttachmentsInRequest(request, project.getAttachments());
 
                 request.setAttribute(PROJECT, project);
-                putLinkedProjectsInRequest(request, Collections.emptyMap());
-                putLinkedReleasesInRequest(request, Collections.emptyMap());
+                putDirectlyLinkedProjectsInRequest(request, Collections.emptyMap());
+                putDirectlyLinkedReleasesInRequest(request, Collections.emptyMap());
 
                 request.setAttribute(USING_PROJECTS, Collections.emptySet());
             }


### PR DESCRIPTION
- fixed broken linked projects and linked releases of a duplicated project. 
- reset clearing state of a duplicated project to OPEN.
- fixed a minor Maven warning.

closes #356 
closes #357