### PR TITLE
fix(spdx): `getAllLicenseTexts` was not called due to merge failure

### DIFF
--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
@@ -65,7 +65,7 @@ public class SPDXParserTest {
         assertThat(result.getFilenames().size(), is(1));
         assertThat(result.getFilenames().get(0), is(spdxExampleFile));
 
-        assertThat(result.getLicenseNamesWithTextsSize(), is(5));
+        assertThat(result.getLicenseNamesWithTextsSize(), is(7));
         assertThat(result.getLicenseNamesWithTexts()
                 .stream()
                 .map(lt -> lt.getLicenseText())


### PR DESCRIPTION
The generated reports does not include all license information due to a merge failure.