### PR TITLE
feat(ui): added custom role map to project, component and release

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ProjectModerator.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ProjectModerator.java
@@ -18,9 +18,6 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Moderation for the project service
  *

--- a/backend/src-common/src/test/java/org/eclipse/sw360/components/summary/ProjectSummaryTest.java
+++ b/backend/src-common/src/test/java/org/eclipse/sw360/components/summary/ProjectSummaryTest.java
@@ -73,6 +73,9 @@ public class ProjectSummaryTest {
                 case CLEARING_STATE:
                     project.clearingState = ProjectClearingState.OPEN;
                     break;
+                case ROLES:
+                    project.roles = Collections.emptyMap();
+                    break;
                 default: //most fields are string
                     project.setFieldValue(renderedField, "asd");
                     break;

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ComponentModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ComponentModerationRequestGenerator.java
@@ -9,13 +9,8 @@
 
 package org.eclipse.sw360.moderation.db;
 
-import com.google.common.collect.Sets;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
-import org.apache.log4j.Logger;
-import org.apache.thrift.protocol.TType;
-
-import java.util.Set;
 
 /**
  * Class for comparing a document with its counterpart in the database
@@ -61,6 +56,9 @@ public class ComponentModerationRequestGenerator extends ModerationRequestGenera
                         break;
                     case ATTACHMENTS:
                         dealWithAttachments(Component._Fields.ATTACHMENTS);
+                        break;
+                    case ROLES:
+                        dealWithCustomMap(Component._Fields.ROLES);
                         break;
                     default:
                         dealWithBaseTypes(field, Component.metaDataMap.get(field));

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ProjectModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ProjectModerationRequestGenerator.java
@@ -9,14 +9,9 @@
 
 package org.eclipse.sw360.moderation.db;
 
-import com.google.common.collect.Sets;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Class for comparing a document with its counterpart in the database
@@ -63,6 +58,9 @@ public class ProjectModerationRequestGenerator extends ModerationRequestGenerato
                         break;
                     case RELEASE_ID_TO_USAGE:
                         dealWithStringMap(Project._Fields.RELEASE_ID_TO_USAGE);
+                        break;
+                    case ROLES:
+                        dealWithCustomMap(Project._Fields.ROLES);
                         break;
                     default:
                         dealWithBaseTypes(field, Project.metaDataMap.get(field));

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ReleaseModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ReleaseModerationRequestGenerator.java
@@ -67,6 +67,9 @@ public class ReleaseModerationRequestGenerator extends ModerationRequestGenerato
                     case REPOSITORY:
                         dealWithRepository();
                         break;
+                    case ROLES:
+                        dealWithCustomMap(Release._Fields.ROLES);
+                        break;
                     default:
                         dealWithBaseTypes(field, Release.metaDataMap.get(field));
                 }

--- a/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/tags/DisplayMapOfEmailStringSets.java
+++ b/frontend/sw360-portlet/src/main/java/com/siemens/sw360/portal/tags/DisplayMapOfEmailStringSets.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2016.
+ * Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package com.siemens.sw360.portal.tags;
+
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This displays a map map<string, set<string>>
+ *
+ */
+public class DisplayMapOfEmailStringSets extends SimpleTagSupport {
+
+    private Map<String, Set<String>> value;
+    private Map<String, Set<String>> autoFillValue;
+
+    public void setValue(Map<String,Set<String>> value) {
+        this.value = value;
+    }
+    public void setAutoFillValue(Map<String, Set<String>> autoFillValue) {
+        this.autoFillValue = autoFillValue;
+    }
+
+    public void doTag() throws JspException, IOException {
+        Map<String, Set<String>> fullValue;
+
+        if (value == null) {
+            fullValue = autoFillValue;
+        } else {
+            fullValue = value;
+        }
+
+        if (null != fullValue && ! fullValue.isEmpty()) {
+            getJspContext().getOut().print(getMapOfEmailSetsAsString(fullValue));
+        }
+    }
+
+    private static String getMapOfEmailSetsAsString(Map<String, Set<String>> mapOfSets){
+        if (mapOfSets == null || mapOfSets.size() == 0){
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("<ul class=\"mapDisplayRootItem\">");
+        mapOfSets.entrySet().stream()
+                .filter(e -> ! CommonUtils.allAreEmptyOrNull(e.getValue()))
+                .forEach(e -> sb.append(
+                "<li><span class=\"mapDisplayChildItemLeft\">"
+                        + e.getKey()
+                        + ":"
+                        + "</span> <span class=\"mapDisplayChildItemRight\">"
+                        + getEmailSetAsString(e.getValue())
+                        + "</span></li>"
+        ));
+        sb.append("</ul>");
+        return sb.toString();
+    }
+
+    private static String getEmailSetAsString(Set<String> emailStrings){
+        Set<String> mailtToLinks = emailStrings.stream()
+                .map(s-> "<a href=\"mailto:"+s+"\">"+s+"</a>")
+                .collect(Collectors.toSet());
+        return CommonUtils.COMMA_JOINER.join(mailtToLinks);
+    }
+}

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -87,6 +87,7 @@ public class PortalConstants {
     public static final String TYPE_MASK = "typeMask";
     public static final String COMPONENT_TYPE_LIST = "componentTypeList";
     public static final String COMPONENT_CATEGORIES;
+    public static final String COMPONENT_ROLES;
 
     //! Specialized keys for releases
     public static final String RELEASE_ID = "releaseId";
@@ -96,6 +97,7 @@ public class PortalConstants {
     public static final String PAGENAME_RELEASE_DETAIL = "detailRelease";
     public static final String PAGENAME_EDIT_RELEASE = "editRelease";
     public static final String PAGENAME_DUPLICATE_RELEASE = "duplicateRelease";
+    public static final String RELEASE_ROLES;
 
     //! Specialized keys for vendors
     public static final String VENDOR = "vendor";
@@ -127,6 +129,7 @@ public class PortalConstants {
     public static final String PROJECT_NOT_FOUND = "projectNotFound";
     public static final String PAGENAME_LICENSE_INFO = "generateLicenseInfo";
     public static final String PAGENAME_SOURCE_CODE_BUNDLE = "generateSourceCodeBundle";
+    public static final String PROJECT_ROLES;
 
     public static final String FOSSOLOGY_FINGER_PRINTS = "fingerPrints";
     public static final String USER_LIST = "userList";
@@ -318,6 +321,11 @@ public class PortalConstants {
     public static final String UPDATE_VULNERABILITIES__NEW_IDS = "updateVulnerabilities_newIds";
     public static final String UPDATE_VULNERABILITIES__UPDATED_IDS = "updateVulnerabilities_updatedIds";
 
+    //custom map keywords
+    public static final String CUSTOM_MAP = "customMap";
+    public static final String CUSTOM_MAP_KEY = "customMapKey";
+    public static final String CUSTOM_MAP_VALUE = "customMapValue";
+
     //! request status
     public static final String REQUEST_STATUS = "request_status";
 
@@ -332,6 +340,9 @@ public class PortalConstants {
         PROJECT_TYPE = props.getProperty("project.type","[ \"Customer Project\", \"Internal Project\", \"Product\", \"Service\"]");
         LICENSE_IDENTIFIERS = props.getProperty("license.identifiers", "[]");
         COMPONENT_CATEGORIES = props.getProperty("component.categories", "[ \"framework\", \"SDK\", \"big-data\", \"build-management\", \"cloud\", \"content\", \"database\", \"graphics\", \"http\", \"javaee\", \"library\", \"mail\", \"mobile\", \"security\", \"testing\", \"virtual-machine\", \"web-framework\", \"xml\"]");
+        PROJECT_ROLES = props.getProperty("custommap.project.roles", "[ \"pre-sales consultant\", \"primary contact\"]");
+        COMPONENT_ROLES = props.getProperty("custommap.component.roles", "[ \"committer\", \"contributor\", \"expert\"]");
+        RELEASE_ROLES = props.getProperty("custommap.release.roles", "[ \"expert\"]");
     }
 
     private PortalConstants() {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -340,9 +340,9 @@ public class PortalConstants {
         PROJECT_TYPE = props.getProperty("project.type","[ \"Customer Project\", \"Internal Project\", \"Product\", \"Service\"]");
         LICENSE_IDENTIFIERS = props.getProperty("license.identifiers", "[]");
         COMPONENT_CATEGORIES = props.getProperty("component.categories", "[ \"framework\", \"SDK\", \"big-data\", \"build-management\", \"cloud\", \"content\", \"database\", \"graphics\", \"http\", \"javaee\", \"library\", \"mail\", \"mobile\", \"security\", \"testing\", \"virtual-machine\", \"web-framework\", \"xml\"]");
-        PROJECT_ROLES = props.getProperty("custommap.project.roles", "[ \"pre-sales consultant\", \"primary contact\"]");
-        COMPONENT_ROLES = props.getProperty("custommap.component.roles", "[ \"committer\", \"contributor\", \"expert\"]");
-        RELEASE_ROLES = props.getProperty("custommap.release.roles", "[ \"expert\"]");
+        PROJECT_ROLES = props.getProperty("custommap.project.roles", "[ \"Stakeholder\", \"Analyst\", \"Contributor\", \"Accountant\", \"End user\", \"Quality manager\", \"Test manager\", \"Technical writer\", \"Key user\" ]");
+        COMPONENT_ROLES = props.getProperty("custommap.component.roles", "[ \"Committer\", \"Contributor\", \"Expert\"]");
+        RELEASE_ROLES = props.getProperty("custommap.release.roles", "[ \"Committer\", \"Contributor\", \"Expert\"]");
     }
 
     private PortalConstants() {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
@@ -39,6 +39,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyList;
 import static java.lang.Integer.parseInt;
 
@@ -314,5 +315,27 @@ public class PortletUtils {
             }
         }
         return VerificationState.NOT_CHECKED;
+    }
+
+    public static Map<String,Set<String>> getCustomMapFromRequest(PortletRequest request) {
+        Map<String, Set<String>> customMap = new HashMap<>();
+        Enumeration<String> parameterNames = request.getParameterNames();
+        List<String> keyAndValueParameterIds = Collections.list(parameterNames).stream()
+                .filter(p -> p.startsWith(PortalConstants.CUSTOM_MAP_KEY))
+                .map(s -> s.replace(PortalConstants.CUSTOM_MAP_KEY, ""))
+                .collect(Collectors.toList());
+        for(String parameterId : keyAndValueParameterIds) {
+            String key = request.getParameter(PortalConstants.CUSTOM_MAP_KEY +parameterId);
+            if(isNullEmptyOrWhitespace(key)){
+                log.error("Empty map key found");
+            } else {
+                String value = request.getParameter(PortalConstants.CUSTOM_MAP_VALUE + parameterId);
+                if(!customMap.containsKey(key)){
+                    customMap.put(key, new HashSet<>());
+                }
+                customMap.get(key).add(value);
+            }
+        }
+        return customMap;
     }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -379,6 +379,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                 addEditDocumentMessage(request, permissions, documentState);
                 Set<String> releaseIds = SW360Utils.getReleaseIds(component.getReleases());
                 setUsingDocs(request, user, client, releaseIds);
+                request.setAttribute(CUSTOM_MAP, component.isSetRoles() ? component.roles : Collections.emptyMap());
             } catch (TException e) {
                 log.error("Error fetching component from backend!", e);
                 setSW360SessionError(request, ErrorMessages.ERROR_GETTING_COMPONENT);
@@ -390,6 +391,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                 setUsingDocs(request, user, null, component.getReleaseIds());
                 setAttachmentsInRequest(request, component.getAttachments());
                 SessionMessages.add(request, "request_processed", "New Component");
+                request.setAttribute(CUSTOM_MAP, Collections.emptyMap());
             }
         }
     }
@@ -419,6 +421,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                 Map<RequestedAction, Boolean> permissions = release.getPermissions();
                 DocumentState documentState = release.getDocumentState();
                 setUsingDocs(request, releaseId, user, client);
+                request.setAttribute(CUSTOM_MAP, release.isSetRoles() ? release.roles : Collections.emptyMap());
                 addEditDocumentMessage(request, permissions, documentState);
 
                 if (isNullOrEmpty(id)) {
@@ -435,6 +438,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                     putDirectlyLinkedReleaseRelationsInRequest(request, release.getReleaseIdToRelationship());
                     setAttachmentsInRequest(request, release.getAttachments());
                     setUsingDocs(request, null, user, client);
+                    request.setAttribute(CUSTOM_MAP, Collections.emptyMap());
                     SessionMessages.add(request, "request_processed", "New Release");
                 }
             }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortletUtils.java
@@ -74,6 +74,8 @@ public abstract class ComponentPortletUtils {
                 case CLEARING_STATE:
                     // skip setting CLEARING_STATE. it is supposed to be set only programmatically, never from user input.
                     break;
+                case ROLES:
+                    release.setRoles(PortletUtils.getCustomMapFromRequest(request));
                 default:
                     setFieldValue(request, release, field);
             }
@@ -125,6 +127,8 @@ public abstract class ComponentPortletUtils {
                 case ATTACHMENTS:
                     component.setAttachments(PortletUtils.updateAttachmentsFromRequest(request, component.getAttachments()));
                     break;
+                case ROLES:
+                    component.setRoles(PortletUtils.getCustomMapFromRequest(request));
 
 
                 default:

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -803,6 +803,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 return;
             }
 
+            request.setAttribute(CUSTOM_MAP, project.isSetRoles() ? project.roles : Collections.emptyMap());
             request.setAttribute(USING_PROJECTS, usingProjects);
             Map<RequestedAction, Boolean> permissions = project.getPermissions();
             DocumentState documentState = project.getDocumentState();
@@ -821,6 +822,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                     log.error("Could not put empty linked projects or linked releases in projects view.", e);
                 }
                 request.setAttribute(USING_PROJECTS, Collections.emptySet());
+                request.setAttribute(CUSTOM_MAP, Collections.emptyMap());
 
                 SessionMessages.add(request, "request_processed", "New Project");
             }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtils.java
@@ -29,6 +29,7 @@ import com.liferay.portlet.expando.model.ExpandoColumn;
 import com.liferay.portlet.expando.model.ExpandoColumnConstants;
 import com.liferay.portlet.expando.model.ExpandoTableConstants;
 import com.liferay.portlet.expando.service.ExpandoColumnLocalServiceUtil;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
@@ -67,17 +68,24 @@ public class ProjectPortletUtils {
         for (Project._Fields field : Project._Fields.values()) {
             switch (field) {
                 case LINKED_PROJECTS:
-                    if (!project.isSetLinkedProjects()) project.setLinkedProjects(new HashMap<String, ProjectRelationship>());
+                    if (!project.isSetLinkedProjects()) {
+                        project.setLinkedProjects(new HashMap<String, ProjectRelationship>());
+                    }
                     updateLinkedProjectsFromRequest(request, project.linkedProjects);
                     break;
                 case RELEASE_ID_TO_USAGE:
-                    if (!project.isSetReleaseIdToUsage()) project.setReleaseIdToUsage(new HashMap<String,String>());
+                    if (!project.isSetReleaseIdToUsage()) {
+                        project.setReleaseIdToUsage(new HashMap<String,String>());
+                    }
                     updateLinkedReleasesFromRequest(request, project.releaseIdToUsage);
                     break;
 
                 case ATTACHMENTS:
                     project.setAttachments(PortletUtils.updateAttachmentsFromRequest(request, project.getAttachments()));
                     break;
+
+                case ROLES:
+                    project.setRoles(PortletUtils.getCustomMapFromRequest(request));
                 default:
                     setFieldValue(request, project, field);
             }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/CompareAttachments.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/CompareAttachments.java
@@ -137,12 +137,12 @@ public class CompareAttachments extends ContextAwareTag {
             FieldMetaData fieldMetaData = Attachment.metaDataMap.get(field);
             Object fieldValue = attachment.getFieldValue(field);
             if(field.equals(Attachment._Fields.FILENAME)){
-                jspWriter.append(String.format("<td>%s", getDisplayString(fieldMetaData, fieldValue)));
+                jspWriter.append(String.format("<td>%s", getDisplayString(fieldMetaData.valueMetaData.type, fieldValue)));
                 jspWriter.write("<br/>");
                 addDownloadLink(pageContext, jspWriter, attachment.getFilename(), attachment.getAttachmentContentId());
                 jspWriter.append("</td>");
             } else {
-                jspWriter.append(String.format("<td>%s</td>", getDisplayString(fieldMetaData, fieldValue)));
+                jspWriter.append(String.format("<td>%s</td>", getDisplayString(fieldMetaData.valueMetaData.type, fieldValue)));
             }
         }
         jspWriter.append("</tr>");

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/CompareTodos.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/CompareTodos.java
@@ -169,7 +169,7 @@ public class CompareTodos extends NameSpaceAwareTag {
                                 .map(Obligation::getName)
                                 .collect(Collectors.toList());
             }
-            display.append(String.format("<td>%s</td>", getDisplayString(fieldMetaData, fieldValue)));
+            display.append(String.format("<td>%s</td>", getDisplayString(fieldMetaData.valueMetaData.type, fieldValue)));
 
         }
         display.append("</tr>");

--- a/frontend/sw360-portlet/src/main/resources/sw360.properties
+++ b/frontend/sw360-portlet/src/main/resources/sw360.properties
@@ -32,3 +32,8 @@ license.identifiers=[ "Glide", "Abstyles", "AFL-1.1", "AFL-1.2", "AFL-2.0", "AFL
 
 # values just used for UI, not forcing DB writes
 component.categories= [ "framework", "SDK", "big-data", "build-management", "cloud", "content", "database", "graphics", "http", "javaee", "library", "mail", "mobile", "network-client", "network-server", "osgi", "security", "testing", "virtual-machine", "web-framework", "xml"]
+
+# values just used for UI, not forcing DB writes
+custommap.project.roles=pre-sales consultant,primary contact
+custommap.component.roles=committer,contributor,expert
+custommap.release.roles=expert

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
@@ -80,6 +80,23 @@
         </attribute>
     </tag>
     <tag>
+        <name>DisplayMapOfEmailSets</name>
+        <tag-class>com.siemens.sw360.portal.tags.DisplayMapOfEmailStringSets</tag-class>
+        <body-content>empty</body-content>
+        <attribute>
+            <name>value</name>
+            <required>true</required>
+            <type>java.util.Map</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>autoFillValue</name>
+            <required>false</required>
+            <type>java.util.Map</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+    </tag>
+    <tag>
         <name>DisplayEnum</name>
         <tag-class>org.eclipse.sw360.portal.tags.DisplayEnum</tag-class>
         <body-content>empty</body-content>

--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -413,12 +413,13 @@ input[readonly].clickable {
 
 .mapDisplayRootItem {
     list-style-type: none;
-    padding:0;
-    margin:0;
+    padding-left:0 !important;
+    margin:0 !important;
 }
 
 .mapDisplayChildItemLeft {
     font-weight:bold;
+    margin: 0;
 }
 
 .highlightedRed {

--- a/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
@@ -102,6 +102,11 @@
                     <div class="tab-content span10">
                         <div id="tab-ReleaseInformation" class="tab-pane">
                             <%@include file="/html/components/includes/releases/editReleaseInformation.jspf" %>
+                            <core_rt:set var="keys" value="<%=PortalConstants.RELEASE_ROLES%>"/>
+                            <core_rt:set var="mapTitle" value="Additional Roles"/>
+                            <core_rt:set var="inputType" value="email"/>
+                            <core_rt:set var="inputSubtitle" value="Enter mail address"/>
+                            <%@include file="/html/utils/includes/mapEdit.jspf" %>
                             <%@include file="/html/components/includes/releases/editReleaseRepository.jspf" %>
                         </div>
                         <div id="tab-ReleaseLinks">

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/editBasicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/editBasicInfo.jspf
@@ -106,3 +106,8 @@
         </td>
     </tr>
 </table>
+<core_rt:set var="keys" value="<%=PortalConstants.COMPONENT_ROLES%>"/>
+<core_rt:set var="mapTitle" value="Additional Roles"/>
+<core_rt:set var="inputType" value="email"/>
+<core_rt:set var="inputSubtitle" value="Enter mail address"/>
+<%@include file="/html/utils/includes/mapEdit.jspf" %>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/summary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/summary.jspf
@@ -108,4 +108,8 @@
         <td>Subscribers:</td>
         <td><sw360:DisplayUserEmailCollection value="${component.subscribers}"/></td>
     </tr>
+    <tr>
+        <td>Additional Roles:</td>
+        <td><sw360:DisplayMapOfEmailSets value="${component.roles}"/></td>
+    </tr>
 </table>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/summaryRelease.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/summaryRelease.jspf
@@ -45,6 +45,10 @@
             <td><sw360:DisplayUserEmailCollection value="${release.subscribers}"/></td>
         </tr>
         <tr>
+            <td>Additional Roles:</td>
+            <td><sw360:DisplayMapOfEmailSets value="${release.roles}"/></td>
+        </tr>
+        <tr>
             <td>Download URL:</td>
             <td><sw360:DisplayLink target="${release.downloadurl}"/></td>
         </tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/basicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/basicInfo.jspf
@@ -157,6 +157,14 @@
 
 </table>
 
+
+<core_rt:set var="keys" value="<%=PortalConstants.PROJECT_ROLES%>"/>
+<core_rt:set var="mapTitle" value="Additional Roles"/>
+<core_rt:set var="inputType" value="email"/>
+<core_rt:set var="inputSubtitle" value="Enter mail address"/>
+<%@include file="/html/utils/includes/mapEdit.jspf" %>
+
+
 <table class="table info_table" id="ProjectClearingInfo" title="Clearing">
     <thead>
     <tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/summary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/summary.jspf
@@ -98,4 +98,8 @@
         <td>Security Responsibles:</td>
         <td><sw360:DisplayUserEmailCollection value="${project.securityResponsibles}"/></td>
     </tr>
+    <tr>
+        <td>Additional Roles:</td>
+        <td><sw360:DisplayMapOfEmailSets value="${project.roles}"/></td>
+    </tr>
 </table>

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/mapEditBody.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/mapEditBody.jsp
@@ -1,0 +1,72 @@
+<%@ page import="java.util.ArrayList" %>
+<%--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2016.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  --%>
+
+<%@include file="/html/init.jsp" %>
+<script src="<%=request.getContextPath()%>/js/external/jquery.validate.min.js" type="text/javascript"></script>
+<script src="<%=request.getContextPath()%>/js/external/additional-methods.min.js" type="text/javascript"></script>
+
+<jsp:useBean id="customMap" type="java.util.Map<java.lang.String, java.util.Set<java.lang.String>>"  scope="request"/>
+<core_rt:forEach items="<%=customMap.entrySet()%>" var="mapEntry" varStatus="loop1">
+    <core_rt:forEach items="${mapEntry.value}" var="setItem" varStatus="loop2">
+        <tr id="mapEditTableRow${loop1.count}_${loop2.count}" >
+            <td width="46%">
+                <select class="toplabelledInput" id="<%=PortalConstants.CUSTOM_MAP_KEY%>${loop1.count}_${loop2.count}"
+                        name="<portlet:namespace/><%=PortalConstants.CUSTOM_MAP_KEY%>${loop1.count}_${loop2.count}"
+                        style="min-width: 162px; min-height: 28px;">
+
+                    <core_rt:forEach items="${keys}" var="key">
+                        <option value="${key}" class="textlabel stackedLabel" <core_rt:if
+                                test='${mapEntry.key == key}'>selected="selected"</core_rt:if>> ${key} </option>
+                    </core_rt:forEach>
+                </select>
+            </td>
+            <td width="46%">
+                <input id="<%=PortalConstants.CUSTOM_MAP_VALUE%>${loop1.count}_${loop2.count}" name="<portlet:namespace/><%=PortalConstants.CUSTOM_MAP_VALUE%>${loop1.count}_${loop2.count}" type="email" class="toplabelledInput" placeholder="${inputSubtitle}" title="${inputSubtitle}"
+                       value="<sw360:out value='${setItem}'/>"/>
+            </td>
+
+            <td class="deletor">
+                <img src="<%=request.getContextPath()%>/images/Trash.png"
+                     onclick="deleteMapItem('mapEditTableRow${loop1.count}_${loop2.count}')"
+                     alt="Delete">
+            </td>
+        </tr>
+    </core_rt:forEach>
+</core_rt:forEach>
+<script>
+    function deleteMapItem(rowId) {
+        function deleteMapItemInternal() {
+            $('#' + rowId).remove();
+        };
+
+        deleteConfirmed("Do you really want to remove this item?", deleteMapItemInternal);
+    }
+
+    function addRowToMapEditTable() {
+        var randomRowId = "mapItemRow" + Date.now();
+        var newRowAsString =
+                '<tr id="' + randomRowId + '" >'+
+                '<td width="46%">'+
+                '<select class="toplabelledInput" id="<%=PortalConstants.CUSTOM_MAP_KEY%>'+randomRowId+'" name="<portlet:namespace/><%=PortalConstants.CUSTOM_MAP_KEY%>'+randomRowId+'" style="min-width: 162px; min-height: 28px;">' +
+                <core_rt:forEach items="${keys}" var="key">
+                '<option value="${key}" class="textlabel stackedLabel"> ${key} </option>'+
+                </core_rt:forEach>
+                '</select>'+
+                '</td>'+
+                '<td width="46%">'+
+                '<input id="<%=PortalConstants.CUSTOM_MAP_VALUE%>'+randomRowId+'" name="<portlet:namespace/><%=PortalConstants.CUSTOM_MAP_VALUE%>'+randomRowId+'" type="email" class="toplabelledInput" placeholder="${inputSubtitle}" title="${inputSubtitle}" />'+
+                '</td>'+
+                '<td class="deletor">'+
+                '<img src="<%=request.getContextPath()%>/images/Trash.png" onclick="deleteMapItem(\''+ randomRowId +'\')" alt="Delete">' +
+                '</td>'+
+                '</tr>';
+        $('#mapEditTable tr:last').after(newRowAsString);
+    }
+</script>

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/mapEdit.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/mapEdit.jspf
@@ -1,0 +1,23 @@
+<%--
+  ~ Copyright (c) Bosch Software Innovations GmbH 2016.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  --%>
+
+<table class="table info_table" id="mapEditTable">
+    <thead>
+    <tr>
+        <th colspan="3" class="headlabel">${mapTitle}</th>
+    </tr>
+    </thead>
+    <tbody>
+    <%@include file="/html/utils/ajax/mapEditBody.jsp" %>
+    </tbody>
+</table>
+
+<input type="button" class="addButton" onclick="addRowToMapEditTable();" value="Click to add row to ${mapTitle} "/>
+<br/>
+<br/>

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -200,6 +200,7 @@ struct Release {
     32: optional set<string> contributors, // contributors to the release
     34: optional set<string> moderators, // people who can modify the data
     36: optional set<string> subscribers, // List of subscribers
+    37: optional map<string,set<string>> roles, //customized roles with set of mail addresses
 
     40: optional Vendor vendor,
     41: optional string vendorId,
@@ -254,6 +255,7 @@ struct Component {
     26: optional string componentOwner,
     27: optional string ownerAccountingUnit,
     28: optional string ownerGroup,
+    29: optional map<string,set<string>> roles, //customized roles with set of mail addresses
 
     // Linked objects
     32: optional list<Release> releases,

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -85,6 +85,7 @@ struct Project {
 //    26: optional set<string> comoderators, //deleted
     27: optional set<string> contributors = [],
     28: optional Visibility visbility = sw360.Visibility.BUISNESSUNIT_AND_MODERATORS,
+    29: optional map<string,set<string>> roles, //customized roles with set of mail addresses
     129: optional set<string> securityResponsibles = [],
     130: optional string projectOwner,
     131: optional string ownerAccountingUnit,

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/CommonUtilsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/CommonUtilsTest.java
@@ -8,11 +8,16 @@
  */
 package org.eclipse.sw360.datahandler.common;
 
+import org.apache.log4j.Logger;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.junit.Test;
 
-import static org.eclipse.sw360.datahandler.common.CommonUtils.formatTime;
-import static org.eclipse.sw360.datahandler.common.CommonUtils.getTargetNameOfUrl;
-import static org.eclipse.sw360.datahandler.common.CommonUtils.isValidUrl;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.eclipse.sw360.datahandler.common.CommonUtils.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -121,4 +126,50 @@ public class CommonUtilsTest {
         assertThat(formatTime(86400), is("24:00:00"));
     }
 
+    @Test
+    public void testIsMapFieldMapOfStringSets_EmptyMaps() throws Exception {
+        Map<String, Set<String>> roleMap = new HashMap<>();
+        Project project = new Project().setName("pname").setRoles(roleMap);
+        boolean b = isMapFieldMapOfStringSets(Project._Fields.ROLES, project, project, project, Logger.getLogger(CommonUtilsTest.class));
+        assertThat(b, is(false));
+    }
+    @Test
+    public void testIsMapFieldMapOfStringSets_EmptySets() throws Exception {
+        Map<String, Set<String>> roleMap = new HashMap<>();
+        roleMap.put("role1", new HashSet<>());
+        roleMap.put("role2", new HashSet<>());
+        Project project = new Project().setName("pname").setRoles(roleMap);
+        boolean b = isMapFieldMapOfStringSets(Project._Fields.ROLES, project, project, project, Logger.getLogger(CommonUtilsTest.class));
+        assertThat(b, is(false));
+    }
+    @Test
+    public void testIsMapFieldMapOfStringSets_NoSet() throws Exception {
+        Map<String, String> releaseIdToUsage = new HashMap<>();
+        releaseIdToUsage.put("r1", "u1");
+        releaseIdToUsage.put("r2", "u2");
+        Project project = new Project().setName("pname").setReleaseIdToUsage(releaseIdToUsage);
+        boolean b = isMapFieldMapOfStringSets(Project._Fields.RELEASE_ID_TO_USAGE, project, project, project, Logger.getLogger(CommonUtilsTest.class));
+        assertThat(b, is(false));
+    }
+    @Test
+    public void testIsMapFieldMapOfStringSets_StringSets() throws Exception {
+        Map<String, Set<String>> roleMap = new HashMap<>();
+        roleMap.put("expert", toSingletonSet("expert@company.com"));
+        Project project = new Project().setName("pname").setRoles(roleMap);
+        boolean b = isMapFieldMapOfStringSets(Project._Fields.ROLES, project, project, project, Logger.getLogger(CommonUtilsTest.class));
+        assertThat(b, is(true));
+    }
+    @Test
+    public void testIsMapFieldMapOfStringSets_SingleStringSets() throws Exception {
+        Map<String, Set<String>> roleMap = new HashMap<>();
+        Project project = new Project().setName("pname").setRoles(roleMap);
+        Map<String, Set<String>> roleMap2 = new HashMap<>();
+        roleMap.put("expert", new HashSet<>());
+        Project project2 = new Project().setName("pname").setRoles(roleMap2);
+        Map<String, Set<String>> roleMap3 = new HashMap<>();
+        roleMap.put("expert", toSingletonSet("expert@company.com"));
+        Project project3 = new Project().setName("pname").setRoles(roleMap3);
+        boolean b = isMapFieldMapOfStringSets(Project._Fields.ROLES, project, project2, project3, Logger.getLogger(CommonUtilsTest.class));
+        assertThat(b, is(true));
+    }
 }


### PR DESCRIPTION
This PR adds the following features:
* displayed in details-view (as mailto-link) and edit view
* keys can be configured in sw360-portlet: sw360.properties
* edit-view: user can choose key out of drop down list and must enter valid email address per row
* Moderation request generation for role-property
* Diff display of properties of type map of set to set of strings
* merge for properties of type map of set to set of strings