### PR TITLE
Add attachment permissions

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
@@ -8,7 +8,6 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Sets;
 import org.eclipse.sw360.components.summary.ProjectSummary;
 import org.eclipse.sw360.components.summary.SummaryType;
@@ -245,7 +244,7 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
          *  this is to refactor if say an enum value gets renamed...
          * **/
         final List<Project> all = getAll();
-        return FluentIterable.from(all).filter(ProjectPermissions.isVisible(user)).toSet();
+        return all.stream().filter(ProjectPermissions.isVisible(user)::apply).collect(Collectors.toSet());
     }
 
     public List<Project> searchByName(String name, User user) {

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/handler/FossologyFileHandler.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/handler/FossologyFileHandler.java
@@ -76,7 +76,7 @@ public class FossologyFileHandler {
         if (!release.isSetFossologyId()) {
             /* send the attachment as a new upload */
             AttachmentContent attachmentContent = filledAttachment.getAttachmentContent();
-            return sendToFossologyNewUpload(releaseId, user, clearingTeam, attachmentContent, componentClient);
+            return sendToFossologyNewUpload(release, user, clearingTeam, attachmentContent, componentClient);
         } else {
             if (!checkSourceAttachment(release, filledAttachment)) {
                 return RequestStatus.FAILURE; // TODO summary
@@ -96,13 +96,12 @@ public class FossologyFileHandler {
         return check;
     }
 
-    private RequestStatus sendToFossologyNewUpload(String releaseId, User user, String clearingTeam, AttachmentContent attachmentContent, ComponentService.Iface componentService) throws TException {
-        InputStream stream = attachmentConnector.getAttachmentStream(attachmentContent);
+    private RequestStatus sendToFossologyNewUpload(Release release, User user, String clearingTeam, AttachmentContent attachmentContent, ComponentService.Iface componentService) throws TException {
+        InputStream stream = attachmentConnector.getAttachmentStream(attachmentContent, user, release);
         try {
             int fossologyUploadId = fossologyUploader.uploadToFossology(stream, attachmentContent, clearingTeam);
             if (fossologyUploadId > 0) {
                 //to avoid race conditions, get the object again
-                Release release = assertNotNull(componentService.getReleaseById(releaseId, user));
                 setFossologyStatus(release, clearingTeam, FossologyStatus.SENT, Integer.toString(fossologyUploadId), attachmentContent.getId());
                 updateReleaseClearingState(release, FossologyStatus.SENT);
                 updateRelease(release, user, componentService);

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/handler/FossologyFileHandlerTest.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/handler/FossologyFileHandlerTest.java
@@ -27,6 +27,7 @@ import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.fossology.ssh.FossologyUploader;
 import org.apache.thrift.TException;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -174,7 +175,7 @@ public class FossologyFileHandlerTest {
         final InputStream inputStream = mock(InputStream.class);
         when(release.isSetFossologyId()).thenReturn(false);
         when(release.getClearingState()).thenReturn(ClearingState.NEW_CLEARING);
-        when(attachmentConnector.getAttachmentStream(attachmentContent)).thenReturn(inputStream);
+        when(attachmentConnector.getAttachmentStream(attachmentContent, user, release)).thenReturn(inputStream);
         when(fossologyUploader.uploadToFossology(inputStream, attachmentContent, clearingTeam)).thenReturn(1);
 
         doNothing().when(fossologyFileHandler)
@@ -191,8 +192,8 @@ public class FossologyFileHandlerTest {
                 .setFossologyStatus(eq(release), anyString(), eq(FossologyStatus.SENT), eq("" + 1), eq(id));
 
         // unimportant verifies
-        verify(componentService, times(2)).getReleaseById(releaseId, user);
-        verify(attachmentConnector).getAttachmentStream(attachmentContent);
+        verify(componentService, times(1)).getReleaseById(releaseId, user);
+        verify(attachmentConnector).getAttachmentStream(attachmentContent, user, release);
         verify(fossologyUploader).uploadToFossology(inputStream, attachmentContent, clearingTeam);
     }
 
@@ -215,7 +216,7 @@ public class FossologyFileHandlerTest {
 
         final InputStream inputStream = mock(InputStream.class);
         when(release.isSetFossologyId()).thenReturn(false);
-        when(attachmentConnector.getAttachmentStream(attachmentContent)).thenReturn(inputStream);
+        when(attachmentConnector.getAttachmentStream(attachmentContent, user, release)).thenReturn(inputStream);
         when(fossologyUploader.uploadToFossology(inputStream, attachmentContent, clearingTeam)).thenReturn(-1);
 
         assertThat(fossologyFileHandler.sendToFossology(releaseId, user, clearingTeam), is(RequestStatus.FAILURE));
@@ -224,7 +225,7 @@ public class FossologyFileHandlerTest {
 
         // unimportant verifies
         verify(componentService, atLeastOnce()).getReleaseById(releaseId, user);
-        verify(attachmentConnector).getAttachmentStream(attachmentContent);
+        verify(attachmentConnector).getAttachmentStream(attachmentContent, user, release);
         verify(fossologyUploader).uploadToFossology(inputStream, attachmentContent, clearingTeam);
     }
 

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -88,7 +88,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
         };
     }
 
-    private List<LicenseInfoParsingResult> getLicenseInfosForRelease(Release release, String selectedAttachmentContentId) throws TException{
+    private List<LicenseInfoParsingResult> getLicenseInfosForRelease(Release release, String selectedAttachmentContentId, User user) throws TException{
         if(release == null){
             return Collections.singletonList(noSourceParsingResult());
         }
@@ -107,7 +107,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
         try {
             List<LicenseInfoParser> applicableParsers = Arrays.stream(parsers).filter(p -> {
                 try {
-                    return p.isApplicableTo(attachment);
+                    return p.isApplicableTo(attachment, user, release);
                 } catch (TException e) {
                     throw new UncheckedTException(e);
                 }
@@ -123,7 +123,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
                 }
                 List<LicenseInfoParsingResult> results = applicableParsers.stream().map(parser -> {
                     try {
-                        return parser.getLicenseInfos(attachment);
+                        return parser.getLicenseInfos(attachment, user, release);
                     } catch (TException e) {
                         throw new UncheckedTException(e);
                     }
@@ -217,7 +217,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
                             .filter(Objects::nonNull)
                             .map(attId -> {
                                 try {
-                                    return getLicenseInfosForRelease(entry.getKey(), attId);
+                                    return getLicenseInfosForRelease(entry.getKey(), attId, user);
                                 } catch (TException e) {
                                     throw new UncheckedTException(e);
                                 }

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
@@ -11,10 +11,12 @@ package org.eclipse.sw360.licenseinfo.parsers;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -79,12 +81,12 @@ public abstract class AbstractCLIParser extends LicenseInfoParser {
         return StreamSupport.stream(iterable.spliterator(), false);
     }
 
-    protected boolean hasThisXMLRootElement(AttachmentContent content, String rootElementNamespace, String rootElementName) {
+    protected <T> boolean hasThisXMLRootElement(AttachmentContent content, String rootElementNamespace, String rootElementName, User user, T context) throws TException {
         XMLInputFactory xmlif = XMLInputFactory.newFactory();
         XMLStreamReader xmlStreamReader = null;
         InputStream attachmentStream = null;
         try {
-            attachmentStream = attachmentConnector.getAttachmentStream(content);
+            attachmentStream = attachmentConnector.getAttachmentStream(content, user, context);
             xmlStreamReader = xmlif.createXMLStreamReader(attachmentStream);
 
             //skip to first element

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
@@ -19,6 +19,7 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -51,24 +52,24 @@ public class CLIParser extends AbstractCLIParser {
     }
 
     @Override
-    public boolean isApplicableTo(Attachment attachment) throws TException {
+    public <T> boolean isApplicableTo(Attachment attachment, User user, T context) throws TException {
         AttachmentContent attachmentContent = attachmentContentProvider.getAttachmentContent(attachment);
-        return attachmentContent.getFilename().endsWith(XML_FILE_EXTENSION) && hasCLIRootElement(attachmentContent);
+        return attachmentContent.getFilename().endsWith(XML_FILE_EXTENSION) && hasCLIRootElement(attachmentContent, user, context);
     }
 
-    private boolean hasCLIRootElement(AttachmentContent content) {
-        return hasThisXMLRootElement(content, CLI_ROOT_ELEMENT_NAMESPACE, CLI_ROOT_ELEMENT_NAME);
+    private <T> boolean hasCLIRootElement(AttachmentContent content, User user, T context) throws TException {
+        return hasThisXMLRootElement(content, CLI_ROOT_ELEMENT_NAMESPACE, CLI_ROOT_ELEMENT_NAME, user, context);
     }
 
     @Override
-    public List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment) throws TException {
+    public <T> List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment, User user, T context) throws TException {
         AttachmentContent attachmentContent = attachmentContentProvider.getAttachmentContent(attachment);
         LicenseInfo licenseInfo = new LicenseInfo().setFilenames(Arrays.asList(attachmentContent.getFilename()));
         LicenseInfoParsingResult result = new LicenseInfoParsingResult().setLicenseInfo(licenseInfo);
         InputStream attachmentStream = null;
 
         try {
-            attachmentStream = attachmentConnector.getAttachmentStream(attachmentContent);
+            attachmentStream = attachmentConnector.getAttachmentStream(attachmentContent, user, context);
             Document doc = getDocument(attachmentStream);
 
             Set<String> copyrights = getCopyrights(doc);

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
@@ -24,6 +24,7 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -74,24 +75,24 @@ public class CombinedCLIParser extends AbstractCLIParser{
     }
 
     @Override
-    public boolean isApplicableTo(Attachment attachment) throws TException {
+    public <T> boolean isApplicableTo(Attachment attachment, User user, T context) throws TException {
         AttachmentContent attachmentContent = attachmentContentProvider.getAttachmentContent(attachment);
-        return attachmentContent.getFilename().endsWith(XML_FILE_EXTENSION) && hasCombinedCLIRootElement(attachmentContent);
+        return attachmentContent.getFilename().endsWith(XML_FILE_EXTENSION) && hasCombinedCLIRootElement(attachmentContent, user, context);
     }
 
-    private boolean hasCombinedCLIRootElement(AttachmentContent content) {
-        return hasThisXMLRootElement(content, COMBINED_CLI_ROOT_ELEMENT_NAMESPACE, COMBINED_CLI_ROOT_ELEMENT_NAME);
+    private <T> boolean hasCombinedCLIRootElement(AttachmentContent content, User user, T context) throws TException {
+        return hasThisXMLRootElement(content, COMBINED_CLI_ROOT_ELEMENT_NAMESPACE, COMBINED_CLI_ROOT_ELEMENT_NAME, user, context);
     }
 
     @Override
-    public List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment) throws TException {
+    public <T> List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment, User user, T context) throws TException {
         AttachmentContent attachmentContent = attachmentContentProvider.getAttachmentContent(attachment);
         InputStream attachmentStream = null;
         List<LicenseInfoParsingResult> parsingResults = new ArrayList<>();
         Map<String, Release> releasesByExternalId = prepareReleasesByExternalId(getCorrelationKey());
 
         try {
-            attachmentStream = attachmentConnector.getAttachmentStream(attachmentContent);
+            attachmentStream = attachmentConnector.getAttachmentStream(attachmentContent, user, context);
             Document doc = getDocument(attachmentStream);
 
             Map<String, Set<String>> copyrightSetsByExternalId = getCopyrightSetsByExternalIdsMap(doc);

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParser.java
@@ -12,9 +12,9 @@ import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 
 import java.util.List;
-
 
 /**
  * @author: alex.borodin@evosoft.com
@@ -30,7 +30,7 @@ public abstract class LicenseInfoParser {
 
     public abstract List<String> getApplicableFileExtensions();
 
-    public boolean isApplicableTo(Attachment attachmentContent) throws TException {
+    public <T> boolean isApplicableTo(Attachment attachmentContent, User user, T context) throws TException {
         List<String> applicableFileExtensions = getApplicableFileExtensions();
         if(applicableFileExtensions.size() == 0){
             return true;
@@ -40,5 +40,5 @@ public abstract class LicenseInfoParser {
                 .anyMatch(extension -> lowerFileName.endsWith(extension.toLowerCase()));
     }
 
-    public abstract List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment) throws TException;
+    public abstract <T> List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment, User user, T context) throws TException;
 }

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/TestHelper.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/TestHelper.java
@@ -10,6 +10,7 @@
 package org.eclipse.sw360.licenseinfo;
 
 import org.apache.commons.io.input.ReaderInputStream;
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
@@ -29,6 +30,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 /**
@@ -76,20 +79,20 @@ public class TestHelper {
             return store.get(attachmentContentId);
         }
 
-        public AttachmentContentStore put(String filename, String fileContent) throws SW360Exception {
+        public AttachmentContentStore put(String filename, String fileContent) throws TException {
             AttachmentContent attachmentContent = makeAttachmentContent(filename);
             store.put(attachmentContent.getId(), attachmentContent);
-            when(connectorMock.getAttachmentStream(attachmentContent)).thenReturn(new ReaderInputStream(new StringReader(fileContent)));
+            when(connectorMock.getAttachmentStream(eq(attachmentContent), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader(fileContent)));
             return this;
         }
 
-        public AttachmentContentStore put(String filename) throws SW360Exception {
+        public AttachmentContentStore put(String filename) throws TException {
             return put(makeAttachmentContent(filename));
         }
 
-        public AttachmentContentStore put(AttachmentContent attachmentContent) throws SW360Exception {
+        public AttachmentContentStore put(AttachmentContent attachmentContent) throws TException {
             store.put(attachmentContent.getId(), attachmentContent);
-            when(connectorMock.getAttachmentStream(attachmentContent)).thenReturn(makeAttachmentContentStream(attachmentContent.getFilename()));
+            when(connectorMock.getAttachmentStream(eq(attachmentContent), anyObject(), anyObject())).thenReturn(makeAttachmentContentStream(attachmentContent.getFilename()));
             return this;
         }
     }

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
@@ -18,6 +18,8 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +35,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 /**
@@ -79,29 +82,29 @@ public class CLIParserTest {
 
     @Test
     public void testIsApplicableTo() throws Exception {
-        when(connector.getAttachmentStream(content)).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
-        assertTrue(parser.isApplicableTo(attachment));
+        when(connector.getAttachmentStream(eq(content), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
+        assertTrue(parser.isApplicableTo(attachment, new User(), new Project()));
     }
 
     @Test
     public void testIsApplicableToFailsOnIncorrectRootElement() throws Exception {
         AttachmentContent content = new AttachmentContent().setId("A1").setFilename("a.xml").setContentType("application/xml");
-        when(connector.getAttachmentStream(content)).thenReturn(new ReaderInputStream(new StringReader("<wrong-root/>")));
-        assertFalse(parser.isApplicableTo(attachment));
+        when(connector.getAttachmentStream(eq(content), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader("<wrong-root/>")));
+        assertFalse(parser.isApplicableTo(attachment, new User(), new Project()));
     }
 
     @Test
     public void testIsApplicableToFailsOnMalformedXML() throws Exception {
         AttachmentContent content = new AttachmentContent().setId("A1").setFilename("a.xml").setContentType("application/xml");
-        when(connector.getAttachmentStream(content)).thenReturn(new ReaderInputStream(new StringReader("this is not an xml file")));
-        assertFalse(parser.isApplicableTo(attachment));
+        when(connector.getAttachmentStream(eq(content), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader("this is not an xml file")));
+        assertFalse(parser.isApplicableTo(attachment, new User(), new Project()));
     }
 
     @Test
     public void testGetCLI() throws Exception {
         Attachment cliAttachment = new Attachment("A1", "a.xml");
-        when(connector.getAttachmentStream(anyObject())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
-        LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment).stream().findFirst().orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
+        when(connector.getAttachmentStream(anyObject(), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
+        LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment, new User(), new Project()).stream().findFirst().orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
         assertLicenseInfoParsingResult(res);
         assertThat(res.getStatus(), is(LicenseInfoRequestStatus.SUCCESS));
         assertThat(res.getLicenseInfo(), notNullValue());
@@ -117,8 +120,8 @@ public class CLIParserTest {
     @Test
     public void testGetCLIFailsOnMalformedXML() throws Exception {
         Attachment cliAttachment = new Attachment("A1", "a.xml");
-        when(connector.getAttachmentStream(anyObject())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE.replaceAll("</Content>", "</Broken>"))));
-        LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment).stream().findFirst().orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
+        when(connector.getAttachmentStream(anyObject(), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE.replaceAll("</Content>", "</Broken>"))));
+        LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment, new User(), new Project()).stream().findFirst().orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
         assertLicenseInfoParsingResult(res, LicenseInfoRequestStatus.FAILURE);
         assertThat(res.getStatus(), is(LicenseInfoRequestStatus.FAILURE));
         assertThat(res.getLicenseInfo(), notNullValue());

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParserTest.java
@@ -20,6 +20,8 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.junit.Before;
 import org.junit.Test;
@@ -89,29 +91,29 @@ public class CombinedCLIParserTest {
 
     @Test
     public void testIsApplicableTo() throws Exception {
-        when(connector.getAttachmentStream(content)).thenReturn(makeAttachmentContentStream(TEST_XML_FILENAME));
-        assertTrue(parser.isApplicableTo(attachment));
+        when(connector.getAttachmentStream(content, new User(), new Project())).thenReturn(makeAttachmentContentStream(TEST_XML_FILENAME));
+        assertTrue(parser.isApplicableTo(attachment, new User(), new Project()));
     }
 
     @Test
     public void testIsApplicableToFailsOnIncorrectRootElement() throws Exception {
         AttachmentContent content = new AttachmentContent().setId("A1").setFilename("a.xml").setContentType("application/xml");
-        when(connector.getAttachmentStream(content)).thenReturn(new ReaderInputStream(new StringReader("<wrong-root/>")));
-        assertFalse(parser.isApplicableTo(attachment));
+        when(connector.getAttachmentStream(content, new User(), new Project())).thenReturn(new ReaderInputStream(new StringReader("<wrong-root/>")));
+        assertFalse(parser.isApplicableTo(attachment, new User(), new Project()));
     }
 
     @Test
     public void testIsApplicableToFailsOnMalformedXML() throws Exception {
         AttachmentContent content = new AttachmentContent().setId("A1").setFilename("a.xml").setContentType("application/xml");
-        when(connector.getAttachmentStream(content)).thenReturn(new ReaderInputStream(new StringReader("this is not an xml file")));
-        assertFalse(parser.isApplicableTo(attachment));
+        when(connector.getAttachmentStream(content, new User(), new Project())).thenReturn(new ReaderInputStream(new StringReader("this is not an xml file")));
+        assertFalse(parser.isApplicableTo(attachment, new User(), new Project()));
     }
 
     @Test
     public void testGetCLI() throws Exception {
         Attachment cliAttachment = new Attachment("A1", "a.xml");
-        when(connector.getAttachmentStream(anyObject())).thenReturn(new ReaderInputStream(new StringReader(cliTestfile)));
-        List<LicenseInfoParsingResult> results = parser.getLicenseInfos(cliAttachment);
+        when(connector.getAttachmentStream(anyObject(), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader(cliTestfile)));
+        List<LicenseInfoParsingResult> results = parser.getLicenseInfos(cliAttachment, new User(), new Project());
         assertThat(results.size(), is(1));
         LicenseInfoParsingResult res = results.get(0);
         assertLicenseInfoParsingResult(res);

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParserTest.java
@@ -13,12 +13,16 @@ import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.UncheckedSW360Exception;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.Visibility;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.eclipse.sw360.licenseinfo.TestHelper.makeAttachment;
@@ -26,6 +30,8 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 public class LicenseInfoParserTest {
+
+    private User dummyUser = new User().setEmail("dummy@some.domain");
 
     @Test
     public void testIsApplicableTo() throws Exception {
@@ -37,7 +43,7 @@ public class LicenseInfoParserTest {
                 }
 
                 @Override
-                public List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment) throws TException {
+                public <T> List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment, User user, T context) throws TException {
                     return null;
                 }
             };
@@ -48,7 +54,12 @@ public class LicenseInfoParserTest {
                                 String filename = "filename" + extension;
                                 Attachment attachment = makeAttachment(filename, attachmentType);
                                 try {
-                                    assertThat(parser.isApplicableTo(attachment), is(true));
+                                    assertThat(parser.isApplicableTo(attachment, dummyUser,
+                                            new Project()
+                                                    .setVisbility(Visibility.ME_AND_MODERATORS)
+                                                    .setCreatedBy(dummyUser.getEmail())
+                                                    .setAttachments(Collections.singleton(new Attachment().setAttachmentContentId(attachment.getAttachmentContentId())))
+                                            ), is(true));
                                 } catch (TException e) {
                                     e.printStackTrace();
                                 }

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
@@ -12,12 +12,17 @@ package org.eclipse.sw360.licenseinfo.parsers;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.UncheckedSW360Exception;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
+import org.eclipse.sw360.datahandler.thrift.Visibility;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +33,7 @@ import org.spdx.rdfparser.SPDXDocumentFactory;
 
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -45,6 +51,8 @@ import static org.junit.Assert.*;
  */
 @RunWith(DataProviderRunner.class)
 public class SPDXParserTest {
+
+    private User dummyUser = new User().setEmail("dummy@some.domain");
 
     private SPDXParser parser;
 
@@ -136,7 +144,12 @@ public class SPDXParserTest {
                         .findAny()
                         .get());
 
-        LicenseInfoParsingResult result = parser.getLicenseInfos(attachment).stream()
+        LicenseInfoParsingResult result = parser.getLicenseInfos(attachment, dummyUser,
+                                            new Project()
+                                                    .setVisbility(Visibility.ME_AND_MODERATORS)
+                                                    .setCreatedBy(dummyUser.getEmail())
+                                                    .setAttachments(Collections.singleton(new Attachment().setAttachmentContentId(attachment.getAttachmentContentId()))))
+                .stream()
                 .findFirst()
                 .orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
 

--- a/backend/utils/src/main/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloader.java
+++ b/backend/utils/src/main/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloader.java
@@ -64,7 +64,7 @@ public class RemoteAttachmentDownloader {
 
             InputStream content = null;
             try {
-                content = attachmentConnector.getAttachmentStream(attachmentContent);
+                content = attachmentConnector.unsafeGetAttachmentStream(attachmentContent);
                 if (content == null) {
                     log.error("null content retrieving attachment " + attachmentContentId);
                     continue;

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -109,6 +109,8 @@ public class PortalConstants {
     public static final String ADDED_ATTACHMENTS = "added_attachments";
     public static final String REMOVED_ATTACHMENTS = "removed_attachments";
     public static final String ATTACHMENT_ID = "attachmentId";
+    public static final String CONTEXT_TYPE = "context_type";
+    public static final String CONTEXT_ID = "context_id";
 
     //! Specialized keys for projects
     public static final String PROJECT_ID = "projectid";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -599,13 +599,13 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         User user = UserCacheHolder.getUserFromRequest(request);
         String id = request.getParameter(PROJECT_ID);
         request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_PROJECT);
+        request.setAttribute(DOCUMENT_ID, id);
         if (id != null) {
             try {
                 ProjectService.Iface client = thriftClients.makeProjectClient();
                 Project project = client.getProjectById(id, user);
                 project = getWithFilledClearingStateSummary(project, user);
                 request.setAttribute(PROJECT, project);
-                request.setAttribute(DOCUMENT_ID, id);
                 setAttachmentsInRequest(request, project.getAttachments());
                 Map<String, ProjectRelationship> fakeRelations = new HashMap<>();
                 fakeRelations.put(id, ProjectRelationship.UNKNOWN);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/TagUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/TagUtils.java
@@ -10,6 +10,7 @@ import org.apache.thrift.meta_data.FieldMetaData;
 import org.apache.thrift.protocol.TType;
 import org.eclipse.sw360.portal.tags.urlutils.UrlWriter;
 
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
@@ -226,16 +227,18 @@ public class TagUtils {
         return fieldDisplay;
     }
 
-    public static void addDownloadLink(PageContext pageContext, JspWriter jspWriter, String name, String ids)
+    public static void addDownloadLink(PageContext pageContext, JspWriter jspWriter, String name, String id, String contextType, String contextId)
             throws IOException, JspException {
-        addDownloadLink(pageContext, jspWriter, name, Collections.singleton(ids));
+        addDownloadLink(pageContext, jspWriter, name, Collections.singleton(id), contextType, contextId);
     }
-    public static void addDownloadLink(PageContext pageContext, JspWriter jspWriter, String name, Collection<String> ids)
+    public static void addDownloadLink(PageContext pageContext, JspWriter jspWriter, String name, Collection<String> ids, String contextType, String contextId)
             throws IOException, JspException {
         name = escapeHtml(" " + name);
         jspWriter.write("<a href='");
         UrlWriter urlWriter = resourceUrl(pageContext)
-                .withParam(PortalConstants.ACTION, PortalConstants.ATTACHMENT_DOWNLOAD);
+                .withParam(PortalConstants.ACTION, PortalConstants.ATTACHMENT_DOWNLOAD)
+                .withParam(PortalConstants.CONTEXT_TYPE, contextType)
+                .withParam(PortalConstants.CONTEXT_ID, contextId);
         for(String id : ids){
             urlWriter.withParam(PortalConstants.ATTACHMENT_ID, id);
         }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayDownloadAttachment.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayDownloadAttachment.java
@@ -30,6 +30,8 @@ import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
  */
 public class DisplayDownloadAttachment extends ContextAwareTag {
     protected Collection<String> ids = Collections.emptySet();
+    private String contextType;
+    private String contextId;
     private String name = "";
     private Logger log = Logger.getLogger(DisplayDownloadAttachment.class);
 
@@ -37,7 +39,7 @@ public class DisplayDownloadAttachment extends ContextAwareTag {
     public int doStartTag() throws JspException {
         try {
             JspWriter jspWriter = pageContext.getOut();
-            addDownloadLink(pageContext, jspWriter, name, ids);
+            addDownloadLink(pageContext, jspWriter, name, ids, contextType, contextId);
         } catch (Exception e) {
             throw new JspException(e);
         }
@@ -70,6 +72,15 @@ public class DisplayDownloadAttachment extends ContextAwareTag {
             }
         }
     }
+
+    public void setContextType(String contextType) {
+        this.contextType = contextType;
+    }
+
+    public void setContextId(String contextId) {
+        this.contextId = contextId;
+    }
+
 
     public void setName(String name) {
         this.name = escapeHtml(" " + name);

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
@@ -507,6 +507,18 @@
             <type>java.util.Set</type>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
+        <attribute>
+            <name>contextType</name>
+            <required>true</required>
+            <type>java.lang.String</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>contextId</name>
+            <required>true</required>
+            <type>java.lang.String</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
 
         <attribute>
             <name>idPrefix</name>
@@ -829,6 +841,18 @@
             <rtexprvalue>true</rtexprvalue>
         </attribute>
         <attribute>
+            <name>contextType</name>
+            <required>true</required>
+            <type>java.lang.String</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>contextId</name>
+            <required>true</required>
+            <type>java.lang.String</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
             <name>name</name>
             <required>false</required>
             <type>java.lang.String</type>
@@ -855,6 +879,18 @@
         <attribute>
             <name>name</name>
             <required>false</required>
+            <type>java.lang.String</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>contextType</name>
+            <required>true</required>
+            <type>java.lang.String</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>contextId</name>
+            <required>true</required>
             <type>java.lang.String</type>
             <rtexprvalue>true</rtexprvalue>
         </attribute>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/clearingStatus.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/clearingStatus.jspf
@@ -52,7 +52,7 @@
             "0": "${release.name}",
             "1": "<a href='<portlet:renderURL ><portlet:param name="<%=PortalConstants.COMPONENT_ID%>" value="${component.id}"/><portlet:param name="<%=PortalConstants.RELEASE_ID%>" value="${release.id}"/><portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.PAGENAME_RELEASE_DETAIL%>"/></portlet:renderURL>' target='_self'>" + "${release.version}" + "</a>",
             "2": "<span id='clearingState${release.id}'><sw360:DisplayEnum value="${release.clearingState}"/></span>",
-            "3": "<sw360:DisplayDownloadReport attachments="${release.attachments}" attachmentEntryVar="entry"><sw360:DisplayDownloadAttachment id="${entry.key}" name="${entry.value}"/></sw360:DisplayDownloadReport>",
+            "3": "<sw360:DisplayDownloadReport attachments="${release.attachments}" attachmentEntryVar="entry"><sw360:DisplayDownloadAttachment id="${entry.key}" name="${entry.value}"  contextType="${release.type}" contextId="${release.id}" /></sw360:DisplayDownloadReport>",
             "4": "<span id='mainlineState${release.id}'><sw360:DisplayEnum value="${release.mainlineState}"/></span>",
             <core_rt:if test="${inComponentDetailsContext}">
             "5": "<span id='fossologySending${release.id}'></span><span id='releaseAction${release.id}'><img src='<%=request.getContextPath()%>/images/fossology-logo-24.gif' onclick='openSelectClearingDialog(\"fossologySending${release.id}\",\"${release.id}\")' alt='SelectClearing' title='send to Fossology'></span>"

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/components/merge.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/components/merge.jsp
@@ -46,7 +46,13 @@
 <sw360:DisplayComponentChanges actual="${actual_component}" additions="${moderationRequest.componentAdditions}" deletions="${moderationRequest.componentDeletions}" idPrefix="basicFields" tableClasses="table info_table" />
 
 <h3>Attachments</h3>
-<sw360:CompareAttachments actual="${actual_component.attachments}" additions="${moderationRequest.componentAdditions.attachments}"  deletions="${moderationRequest.componentDeletions.attachments}" idPrefix="attachments" tableClasses="table info_table" />
+<sw360:CompareAttachments actual="${actual_component.attachments}"
+                          additions="${moderationRequest.componentAdditions.attachments}"
+                          deletions="${moderationRequest.componentDeletions.attachments}"
+                          idPrefix="attachments"
+                          tableClasses="table info_table"
+                          contextType="${component.type}"
+                          contextId="${component.id}"/>
 
 <h2>Current Component</h2>
 <core_rt:set var="inComponentDetailsContext" value="false" scope="request"/>

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/projects/merge.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/projects/merge.jsp
@@ -40,8 +40,13 @@
 <sw360:DisplayProjectChanges actual="${actual_project}" additions="${moderationRequest.projectAdditions}" deletions="${moderationRequest.projectDeletions}" idPrefix="basicFields" tableClasses="table info_table"/>
 
 <h3>Attachments</h3>
-<sw360:CompareAttachments actual="${actual_project.attachments}" additions="${moderationRequest.projectAdditions.attachments}" deletions="${moderationRequest.projectDeletions.attachments}" idPrefix="attachments" tableClasses="table info_table" />
-
+<sw360:CompareAttachments actual="${actual_project.attachments}"
+                          additions="${moderationRequest.projectAdditions.attachments}"
+                          deletions="${moderationRequest.projectDeletions.attachments}"
+                          idPrefix="attachments"
+                          tableClasses="table info_table"
+                          contextType="${project.type}"
+                          contextId="${project.id}"/>
 
 <h2>Current Project</h2>
 <core_rt:set var="inProjectDetailsContext" value="false" scope="request"/>

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/releases/merge.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/releases/merge.jsp
@@ -63,7 +63,13 @@
 <sw360:DisplayReleaseChanges actual="${actual_release}" additions="${moderationRequest.releaseAdditions}" deletions="${moderationRequest.releaseDeletions}" idPrefix="basicFields" tableClasses="table info_table"/>
 
 <h3>Attachments</h3>
-<sw360:CompareAttachments actual="${actual_release.attachments}" additions="${moderationRequest.releaseAdditions.attachments}" deletions="${moderationRequest.releaseDeletions.attachments}" idPrefix="attachments" tableClasses="table info_table" />
+<sw360:CompareAttachments actual="${actual_release.attachments}"
+                          additions="${moderationRequest.releaseAdditions.attachments}"
+                          deletions="${moderationRequest.releaseDeletions.attachments}"
+                          idPrefix="attachments"
+                          tableClasses="table info_table"
+                          contextType="${component.type}"
+                          contextId="${component.id}"/>
 
 <h2>Current Release</h2>
 <core_rt:set var="inReleaseDetailsContext" value="false" scope="request"/>

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/attachmentsAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/attachmentsAjax.jsp
@@ -9,6 +9,7 @@
 <%@ page import="org.eclipse.sw360.datahandler.common.SW360Constants" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus" %>
 <%@include file="/html/init.jsp" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
 <portlet:defineObjects/>
 <liferay-theme:defineObjects/>
@@ -17,85 +18,91 @@
 
 <%@ page import="org.eclipse.sw360.datahandler.thrift.components.Release" %>
 
-<jsp:useBean id="attachments" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.attachments.Attachment>"
-             scope="request"/>
 <jsp:useBean id="documentType" type="java.lang.String" scope="request"/>
+<c:catch var="attributeNotFoundException">
+  <jsp:useBean id="attachments" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.attachments.Attachment>"
+               scope="request"/>
+  <jsp:useBean id="documentID" class="java.lang.String" scope="request" />
+</c:catch>
+<core_rt:if test="${empty attributeNotFoundException}">
+    <core_rt:if test="${attachments.size()>0}">
+        <tr id="noAttachmentsRow" style="display: none">
+            <td colspan="5">No attachments yet.</td>
+        </tr>
+    </core_rt:if>
+    <core_rt:if test="${attachments.size()==0}">
+        <tr id="noAttachmentsRow">
+            <td colspan="5">No attachments yet.</td>
+        </tr>
+    </core_rt:if>
 
-<core_rt:if test="${attachments.size()>0}">
-    <tr id="noAttachmentsRow" style="display: none">
-        <td colspan="5">No attachments yet.</td>
-    </tr>
+    <core_rt:forEach items="${attachments}" var="attachment" varStatus="loop">
+        <tr id="componentattachmentrow${loop.count}" class="tr_clone">
+            <td colspan="5">
+                <table style="width:100%">
+                    <tr>
+                        <td>
+                            <input type="hidden" value="${attachment.attachmentContentId}"
+                                   name="<portlet:namespace/><%=Release._Fields.ATTACHMENTS%><%=Attachment._Fields.ATTACHMENT_CONTENT_ID%>">
+                            <label class="textlabel stackedLabel" for="comp_file${loop.count}">File name</label>
+                            <input class="toplabelledInput" id="comp_file${loop.count}" style="margin-left: 10px;"
+                                   name="<portlet:namespace/><%=Release._Fields.ATTACHMENTS%><%=Attachment._Fields.FILENAME%>"
+                                   type="text"
+                                   value="<sw360:out value="${attachment.filename}"/>" readonly/>
+                        </td>
+                        <td>
+                            <label class="textlabel stackedLabel" for="comp_filetype${loop.count}">Attachment type</label>
+                            <select class="toplabelledInput" id="comp_filetype${loop.count}"
+                                    name="<portlet:namespace/><%=Release._Fields.ATTACHMENTS%><%=Attachment._Fields.ATTACHMENT_TYPE%>"
+                                    style="min-width: 162px; min-height: 28px;">
+                                <sw360:DisplayEnumOptions
+                                        options="<%=SW360Constants.allowedAttachmentTypes(documentType)%>"
+                                        selected="${attachment.attachmentType}"/>
+                            </select>
+                        </td>
+                        <td>
+                            <label class="textlabel stackedLabel" for="comp_filecomment${loop.count}">Comments</label>
+                            <input class="toplabelledInput" id="comp_filecomment${loop.count}"
+                                   name="<portlet:namespace/><%=Release._Fields.ATTACHMENTS%><%=Attachment._Fields.CREATED_COMMENT%>"
+                                   type="text" placeholder="Enter comments"
+                                   value="<sw360:out value="${attachment.createdComment}"/>"
+                            />
+                        </td>
+                        <td class="downloader">
+                            <sw360:DisplayDownloadAttachment id="${attachment.attachmentContentId}"
+                                                             name="${attachment.filename}"
+                                                             contextType="${documentType}"
+                                                             contextId="${documentID}"/>
+                        </td>
+                        <td class="deletor">
+                            <img src="<%=request.getContextPath()%>/images/Trash.png"
+                                 onclick="deleteAttachment('componentattachmentrow${loop.count}','${attachment.attachmentContentId}')"
+                                 alt="Delete">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label class="textlabel stackedLabel" for="approval_status${loop.count}">Approval Status</label>
+                            <select class="toplabelledInput" id="approval_status${loop.count}"
+                                    name="<portlet:namespace/><%=Release._Fields.ATTACHMENTS%><%=Attachment._Fields.CHECK_STATUS%>"
+                                    style="min-width: 162px; min-height: 28px;">
+                                <sw360:DisplayEnumOptions type="<%=CheckStatus.class%>"
+                                                          selected="${attachment.checkStatus}"/>
+                            </select>
+                        </td>
+                        <td>
+                            <label class="textlabel stackedLabel" for="comp_checkedcomment${loop.count}">Approval
+                                Comments</label>
+                            <input class="toplabelledInput" id="comp_checkedcomment${loop.count}"
+                                   name="<portlet:namespace/><%=Release._Fields.ATTACHMENTS%><%=Attachment._Fields.CHECKED_COMMENT%>"
+                                   type="text" placeholder="Enter comments"
+                                   value="<sw360:out value="${attachment.checkedComment}"/>"
+                            />
+                        </td>
+                        <td colspan="3"></td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </core_rt:forEach>
 </core_rt:if>
-<core_rt:if test="${attachments.size()==0}">
-    <tr id="noAttachmentsRow">
-        <td colspan="5">No attachments yet.</td>
-    </tr>
-</core_rt:if>
-
-<core_rt:forEach items="${attachments}" var="attachment" varStatus="loop">
-    <tr id="componentattachmentrow${loop.count}" class="tr_clone">
-        <td colspan="5">
-            <table style="width:100%">
-                <tr>
-                    <td>
-                        <input type="hidden" value="${attachment.attachmentContentId}"
-                               name="<portlet:namespace/><%=Release._Fields.ATTACHMENTS%><%=Attachment._Fields.ATTACHMENT_CONTENT_ID%>">
-                        <label class="textlabel stackedLabel" for="comp_file${loop.count}">File name</label>
-                        <input class="toplabelledInput" id="comp_file${loop.count}" style="margin-left: 10px;"
-                               name="<portlet:namespace/><%=Release._Fields.ATTACHMENTS%><%=Attachment._Fields.FILENAME%>"
-                               type="text"
-                               value="<sw360:out value="${attachment.filename}"/>" readonly/>
-                    </td>
-                    <td>
-                        <label class="textlabel stackedLabel" for="comp_filetype${loop.count}">Attachment type</label>
-                        <select class="toplabelledInput" id="comp_filetype${loop.count}"
-                                name="<portlet:namespace/><%=Release._Fields.ATTACHMENTS%><%=Attachment._Fields.ATTACHMENT_TYPE%>"
-                                style="min-width: 162px; min-height: 28px;">
-                            <sw360:DisplayEnumOptions
-                                    options="<%=SW360Constants.allowedAttachmentTypes(documentType)%>"
-                                    selected="${attachment.attachmentType}"/>
-                        </select>
-                    </td>
-                    <td>
-                        <label class="textlabel stackedLabel" for="comp_filecomment${loop.count}">Comments</label>
-                        <input class="toplabelledInput" id="comp_filecomment${loop.count}"
-                               name="<portlet:namespace/><%=Release._Fields.ATTACHMENTS%><%=Attachment._Fields.CREATED_COMMENT%>"
-                               type="text" placeholder="Enter comments"
-                               value="<sw360:out value="${attachment.createdComment}"/>"
-                        />
-                    </td>
-                    <td class="downloader">
-                        <sw360:DisplayDownloadAttachment id="${attachment.attachmentContentId}"
-                                                         name="${attachment.filename}"/>
-                    </td>
-                    <td class="deletor">
-                        <img src="<%=request.getContextPath()%>/images/Trash.png"
-                             onclick="deleteAttachment('componentattachmentrow${loop.count}','${attachment.attachmentContentId}')"
-                             alt="Delete">
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <label class="textlabel stackedLabel" for="approval_status${loop.count}">Approval Status</label>
-                        <select class="toplabelledInput" id="approval_status${loop.count}"
-                                name="<portlet:namespace/><%=Release._Fields.ATTACHMENTS%><%=Attachment._Fields.CHECK_STATUS%>"
-                                style="min-width: 162px; min-height: 28px;">
-                            <sw360:DisplayEnumOptions type="<%=CheckStatus.class%>"
-                                                      selected="${attachment.checkStatus}"/>
-                        </select>
-                    </td>
-                    <td>
-                        <label class="textlabel stackedLabel" for="comp_checkedcomment${loop.count}">Approval
-                            Comments</label>
-                        <input class="toplabelledInput" id="comp_checkedcomment${loop.count}"
-                               name="<portlet:namespace/><%=Release._Fields.ATTACHMENTS%><%=Attachment._Fields.CHECKED_COMMENT%>"
-                               type="text" placeholder="Enter comments"
-                               value="<sw360:out value="${attachment.checkedComment}"/>"
-                        />
-                    </td>
-                    <td colspan="3"></td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</core_rt:forEach>

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsDetail.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsDetail.jsp
@@ -6,23 +6,30 @@
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v10.html
   --%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@include file="/html/init.jsp" %>
 
 
-<%@ taglib prefix="sw360" uri="/WEB-INF/customTags.tld" %>
 
 <portlet:defineObjects/>
 <liferay-theme:defineObjects/>
 
-<jsp:useBean id="attachments" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.attachments.Attachment>" scope="request"/>
-<jsp:useBean id="documentType" type="java.lang.String" scope="request"/>
+<c:catch var="attributeNotFoundException">
+    <jsp:useBean id="attachments" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.attachments.Attachment>" scope="request"/>
+    <jsp:useBean id="documentType" type="java.lang.String" scope="request"/>
+    <jsp:useBean id="documentID" class="java.lang.String" scope="request"/>
+</c:catch>
+<core_rt:if test="${empty attributeNotFoundException}">
 <table class="table info_table " id="attachmentDetail" title="Attachment Information">
     <thead>
     <tr>
         <th colspan="8" class="headlabel">
             Attachments
             <core_rt:if test="${not empty attachments}">
-                <sw360:DisplayDownloadAttachmentBundle ids="${attachments}" name="${AttachmentBundle.zip}"/>
+                <sw360:DisplayDownloadAttachmentBundle ids="${attachments}"
+                                                       name="${AttachmentBundle.zip}"
+                                                       contextType="${documentType}"
+                                                       contextId="${documentID}"/>
             </core_rt:if>
         </th>
     </tr>
@@ -32,7 +39,10 @@
         <core_rt:forEach items="${attachments}" var="attachment" varStatus="loop">
             <tr id="attachmentRow1${loop.count}">
                 <td colspan="8" class="attachmentTitle">
-                    <sw360:DisplayDownloadAttachment id="${attachment.attachmentContentId}" name="${attachment.filename}"/>
+                    <sw360:DisplayDownloadAttachment id="${attachment.attachmentContentId}"
+                                                     name="${attachment.filename}"
+                                                     contextType="${documentType}"
+                                                     contextId="${documentID}"/>
                     "<sw360:out value="${attachment.filename}"/>"
                 </td>
             </tr>
@@ -88,3 +98,4 @@
     </core_rt:if>
     </tbody>
 </table>
+</core_rt:if>

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ComponentPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ComponentPermissions.java
@@ -16,7 +16,9 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.toSingletonSet;
 
 /**
@@ -29,12 +31,16 @@ public class ComponentPermissions extends DocumentPermissions<Component> {
 
     private final Set<String> createdBy;
     private final Set<String> moderators;
+    private final Set<String> attachmentContentIds;
 
     protected ComponentPermissions(Component document, User user) {
         super(document, user);
         //Should depend on permissions of contained releases
         this.createdBy = toSingletonSet(document.createdBy);
-        moderators = Sets.union(toSingletonSet(document.createdBy), CommonUtils.nullToEmptySet(document.moderators));
+        moderators = Sets.union(toSingletonSet(document.createdBy), nullToEmptySet(document.moderators));
+        attachmentContentIds = nullToEmptySet(document.getAttachments()).stream()
+                .map(a -> a.getAttachmentContentId())
+                .collect(Collectors.toSet());
     }
 
     @Override
@@ -55,6 +61,11 @@ public class ComponentPermissions extends DocumentPermissions<Component> {
     @Override
     protected Set<String> getModerators() {
         return moderators;
+    }
+
+    @Override
+    protected Set<String> getAttachmentContentIds() {
+        return attachmentContentIds;
     }
 
 }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissions.java
@@ -10,15 +10,18 @@ package org.eclipse.sw360.datahandler.permissions;
 
 import com.google.common.collect.ImmutableSet;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static org.eclipse.sw360.datahandler.thrift.users.RequestedAction.*;
 import static org.eclipse.sw360.datahandler.thrift.users.UserGroup.ADMIN;
 
@@ -48,6 +51,10 @@ public abstract class DocumentPermissions<T> {
 
     protected boolean isUserInEquivalentToOwnerGroup(){
         return true;
+    }
+
+    protected Set<String> getAttachmentContentIds() {
+        return Collections.emptySet();
     }
 
     protected boolean isContributor() {
@@ -105,4 +112,12 @@ public abstract class DocumentPermissions<T> {
                 .collect(Collectors.toList());
     }
 
+    public boolean isAllowedToDownload(AttachmentContent attachment){
+        return isAllowedToDownload(attachment.getId());
+    }
+
+    public boolean isAllowedToDownload(String attachmentContentId){
+        return nullToEmptySet(getAttachmentContentIds()).contains(attachmentContentId) &&
+                isActionAllowed(RequestedAction.READ);
+    }
 }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ReleasePermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ReleasePermissions.java
@@ -17,7 +17,9 @@ import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.toSingletonSet;
 
 /**
@@ -30,12 +32,16 @@ public class ReleasePermissions extends DocumentPermissions<Release> {
 
     private final Set<String> moderators;
     private final Set<String> contributors;
+    private final Set<String> attachmentContentIds;
 
     protected ReleasePermissions(Release document, User user) {
         super(document, user);
 
-        moderators = Sets.union(toSingletonSet(document.createdBy), CommonUtils.nullToEmptySet(document.moderators));
-        contributors = Sets.union(moderators, CommonUtils.nullToEmptySet(document.contributors));
+        moderators = Sets.union(toSingletonSet(document.createdBy), nullToEmptySet(document.moderators));
+        contributors = Sets.union(moderators, nullToEmptySet(document.contributors));
+        attachmentContentIds = nullToEmptySet(document.getAttachments()).stream()
+                .map(a -> a.getAttachmentContentId())
+                .collect(Collectors.toSet());
 
     }
 
@@ -61,5 +67,10 @@ public class ReleasePermissions extends DocumentPermissions<Release> {
     @Override
     protected Set<String> getModerators() {
         return moderators;
+    }
+
+    @Override
+    protected Set<String> getAttachmentContentIds() {
+        return attachmentContentIds;
     }
 }


### PR DESCRIPTION
To download an attachment one has to say **in which context (release, project, ...) one wants to download the attachment**. Then the application checks if
- the attachment is connected to the context object and
- the user has read permissions to the context object.

The context consists of a type (i.e. a String) and an ID.

--

The word "context" is not perfect, if someone has a better idea please add a comment.