### PR TITLE
feat(cve-search): convert old cpe format on demand

### DIFF
--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchWrapper.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchWrapper.java
@@ -31,15 +31,7 @@ public class CveSearchWrapper {
     private Heuristic heuristic;
 
     public CveSearchWrapper(CveSearchApi cveSearchApi) {
-        SearchLevels searchLevels = new SearchLevels();
-
-        // TODO: remove once decided
-        if (false) {
-            searchLevels.addBasicSearchlevels();
-        }else{
-            searchLevels.addGuessingSearchLevels(cveSearchApi, VENDOR_THRESHOLD, PRODUCT_THRESHOLD, CUTOFF);
-        }
-
+        SearchLevels searchLevels = new SearchLevels(cveSearchApi, VENDOR_THRESHOLD, PRODUCT_THRESHOLD, CUTOFF);
         heuristic = new Heuristic(searchLevels, cveSearchApi);
     }
 

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchWrapper.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchWrapper.java
@@ -21,17 +21,12 @@ import org.apache.log4j.Logger;
 
 public class CveSearchWrapper {
 
-    // TODO: finetuning of these parameters
-    private final int VENDOR_THRESHOLD  = 1;
-    private final int PRODUCT_THRESHOLD = 0;
-    private final int CUTOFF            = 6;
-
     Logger log = Logger.getLogger(CveSearchWrapper.class);
 
     private Heuristic heuristic;
 
     public CveSearchWrapper(CveSearchApi cveSearchApi) {
-        SearchLevels searchLevels = new SearchLevels(cveSearchApi, VENDOR_THRESHOLD, PRODUCT_THRESHOLD, CUTOFF);
+        SearchLevels searchLevels = new SearchLevels(cveSearchApi);
         heuristic = new Heuristic(searchLevels, cveSearchApi);
     }
 

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/heuristics/SearchLevels.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/heuristics/SearchLevels.java
@@ -18,7 +18,6 @@ import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -30,8 +29,13 @@ import static java.util.Collections.*;
 
 public class SearchLevels {
 
+    private static final String CPE_PREFIX        = "cpe:2.3:";
+    private static final String OLD_CPE_PREFIX    = "cpe:/";
     private static final String CPE_WILDCARD      = ".*";
-    private static final String CPE_NEEDLE_PREFIX = "cpe:2.3:.:";
+    private static final String CPE_NEEDLE_PREFIX = CPE_PREFIX + ".:";
+    public static final int DEFAULT_VENDOR_THRESHOLD  = 1;
+    public static final int DEFAULT_PRODUCT_THRESHOLD = 0;
+    public static final int DEFAULT_CUTOFF            = 6;
 
     private Logger log = Logger.getLogger(SearchLevels.class);
 
@@ -51,7 +55,16 @@ public class SearchLevels {
         List<NeedleWithMeta> apply(Release release) throws IOException;
     }
 
+
+    public SearchLevels(CveSearchApi cveSearchApi) {
+        setup(cveSearchApi, DEFAULT_VENDOR_THRESHOLD, DEFAULT_PRODUCT_THRESHOLD, DEFAULT_CUTOFF);
+    }
+
     public SearchLevels(CveSearchApi cveSearchApi, int vendorThreshold, int productThreshold, int cutoff) {
+        setup(cveSearchApi, vendorThreshold, productThreshold, cutoff);
+    }
+
+    private void setup(CveSearchApi cveSearchApi, int vendorThreshold, int productThreshold, int cutoff) {
         searchLevels = new ArrayList<>();
 
         // Level 1. search by full cpe
@@ -86,11 +99,22 @@ public class SearchLevels {
     }
 
     //==================================================================================================================
+    protected String cleanupCPE(String cpe) {
+        if(cpe.startsWith(OLD_CPE_PREFIX)){ // convert cpe2.2 to cpe2.3
+            cpe = cpe.replaceAll("^"+OLD_CPE_PREFIX, CPE_PREFIX)
+                    .replace("::", ":-:")
+                    .replace("~-", "~")
+                    .replace("~",  ":-:")
+                    .replace("::", ":")
+                    .replaceAll("[:-]*$", "");
+        }
+        return cpe.toLowerCase();
+    }
     private void addCPESearchLevel() {
         Predicate<Release> isPossible = r -> r.isSetCpeid() && isCpe(r.getCpeid().toLowerCase());
         searchLevels.add(r -> {
             if(isPossible.test(r)){
-                return singletonList(new NeedleWithMeta(r.getCpeid().toLowerCase(), "CPE"));
+                return singletonList(new NeedleWithMeta(cleanupCPE(r.getCpeid()), "CPE"));
             }
             return EMPTY_LIST;
         });
@@ -127,7 +151,7 @@ public class SearchLevels {
             vendorProductList = cveSearchGuesser.guessVendorAndProducts(productHaystack);
         }
 
-        String cpeNeedlePostfix = ":" + (useVersionInformation ? release.getVersion() : "") + ".*";
+        String cpeNeedlePostfix = ":" + (useVersionInformation ? release.getVersion() : "") + CPE_WILDCARD;
         Function<String,String> cpeBuilder = cpeNeedle -> CPE_NEEDLE_PREFIX + cpeNeedle + cpeNeedlePostfix;
 
         return vendorProductList.stream()
@@ -136,33 +160,9 @@ public class SearchLevels {
                 .collect(Collectors.toList());
     }
 
-    //==================================================================================================================
-    protected Function<Release,String> escapeGeneratorResult(Function<Release,String> generator) {
-        return r -> generator.apply(r)
-                .replace('/','.')
-                .replace('\\','.')
-                .replace('*','.')
-                .replace('+','.')
-                .replace('!','.')
-                .replace('?','.')
-                .replace('^','.')
-                .replace('$','.')
-                .replace('[','.')
-                .replace(']','.')
-                .replace(" ", CPE_WILDCARD)
-                .toLowerCase();
-    }
-
-    protected Function<Release, String> implodeSearchNeedleGenerators(Function<Release,String> generator, Function<Release,String> ... generators){
-        return Arrays.stream(generators)
-                .map(this::escapeGeneratorResult)
-                .reduce(generator,
-                        (g1,g2) -> r -> g1.apply(r) + CPE_WILDCARD + g2.apply(r));
-    }
-
     protected boolean isCpe(String potentialCpe){
         return (! (null == potentialCpe))
-                && potentialCpe.startsWith("cpe:")
+                && ( potentialCpe.startsWith(CPE_PREFIX) || potentialCpe.startsWith(OLD_CPE_PREFIX) )
                 && potentialCpe.length() > 10;
     }
 }

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/heuristics/SearchLevelsTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/heuristics/SearchLevelsTest.java
@@ -1,59 +1,58 @@
 package org.eclipse.sw360.cvesearch.datasource.heuristics;
 
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.junit.Before;
 import org.junit.Test;
 
 public class SearchLevelsTest {
-    @Test
-    public void implodeTestOneGenerator() {
-        assert(new SearchLevels().implodeSearchNeedleGenerators(r -> "a")
-                .apply(new Release())
-                .equals("a"));
-    }
 
-    @Test
-    public void implodeTestThreeGenerators() {
-        assert(new SearchLevels().implodeSearchNeedleGenerators(r -> "a", r -> "b", r ->"c")
-                .apply(new Release())
-                .equals("a.*b.*c"));
-    }
+    SearchLevels searchLevels;
 
-    @Test
-    public void implodeTestFunction() {
-        String name = "name";
-        assert(new SearchLevels().implodeSearchNeedleGenerators(r -> "a", r -> r.getName())
-                .apply(new Release().setName(name))
-                .equals("a.*" + name));
+    @Before
+    public void prepare() {
+        searchLevels = new SearchLevels(null);
     }
 
     @Test
     public void isCpeTestNull() {
-        assert(new SearchLevels().isCpe(null) == false);
+        assert(!searchLevels.isCpe(null));
     }
 
     @Test
     public void isCpeTestEmpty() {
-        assert(new SearchLevels().isCpe("") == false);
+        assert(!searchLevels.isCpe(""));
     }
 
     @Test
     public void isCpeTest_cpe() {
-        assert(new SearchLevels().isCpe("cpe") == false);
+        assert(!searchLevels.isCpe("cpe"));
     }
 
     @Test
     public void isCpeTestTrue() {
-        assert(new SearchLevels().isCpe("cpe:2.3:a:vendor:product:version"));
+        assert(searchLevels.isCpe("cpe:2.3:a:vendor:product:version"));
     }
 
     @Test
     public void isCpeTestOldFormat() {
-        assert(new SearchLevels().isCpe("cpe:/a:vendor:product:version"));
+        assert(searchLevels.isCpe("cpe:/a:vendor:product:version"));
     }
 
     @Test
     public void isCpeTestPattern() {
-        assert(new SearchLevels().isCpe("cpe:2.3:.*prod.*"));
+        assert(searchLevels.isCpe("cpe:2.3:.*prod.*"));
     }
 
+    @Test
+    public void cleanupNewCpeTest() {
+        String newCpe = "cpe:2.3:a:Vendor:Product:Version";
+        assert(searchLevels.cleanupCPE(newCpe).equals(newCpe.toLowerCase()));
+    }
+
+    @Test
+    public void cleanupOldCpeTest() {
+        String oldCpe = "cpe:/a:vendor:product:version:~~~~";
+        String newCpe = "cpe:2.3:a:vendor:product:version";
+        assert(searchLevels.cleanupCPE(oldCpe).equals(newCpe));
+    }
 }


### PR DESCRIPTION
a new formatted cpe is: `cpe:2.3:a:Vendor:Product:Version`
an old formatted cpe is: `cpe:/a:vendor:product:version:~~~~` 

and cleanup code: remove unused heuristics