### PR TITLE
chore(db migration): add dockerized script

### DIFF
--- a/scripts/migrations/dockerized-migration-runner.Dockerfile
+++ b/scripts/migrations/dockerized-migration-runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright Bosch Software Innovations GmbH, 2017.
+# Part of the SW360 Portal Project.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+FROM debian:jessie
+MAINTAINER admin@sw360.org
+ENV DEBIAN_FRONTEND noninteractive
+
+ENV _update="apt-get update"
+ENV _install="apt-get install -y --no-install-recommends"
+ENV _cleanup="eval apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*"
+
+RUN set -x \
+ && $_update && $_install python python-couchdb \
+ && $_cleanup
+
+RUN mkdir -p /migrations
+WORKDIR /migrations
+ADD ./ /migrations

--- a/scripts/migrations/dockerized-migration-runner.sh
+++ b/scripts/migrations/dockerized-migration-runner.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright Bosch Software Innovations GmbH, 2017.
+# Part of the SW360 Portal Project.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+# call as:
+# ./dockerized-migration-runner.sh migrationScript [migrationScript [...]]
+# e.g.:
+# ./dockerized-migration-runner.sh 003_rename_release_contacts_to_contributors.py 004_move_release_ecc_fields_to_release_information.py
+
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# build docker image for migration
+docker build -t sw360/migration-runner \
+       --rm=true --force-rm=true \
+       -f ./dockerized-migration-runner.Dockerfile \
+       .
+
+for scriptpath in "$@"; do
+    scriptname="$(basename $scriptpath)"
+    if [ ! -e "$scriptname" ]; then
+        echo "migration script \"$scriptname\" not found"
+        continue
+    fi
+
+    # run docker image
+    docker run -it --net=host sw360/migration-runner \
+           "./$scriptname"
+done


### PR DESCRIPTION
This PR adds a tiny Dockerfile together with a script which allows the usage of the migration scripts within an isolated environment. The container uses `--net=host` to access the couchdb running on the host.

--

call as:
```
./dockerized-migration-runner.sh migrationScript [migrationScript [...]]
```
e.g.:
```
./dockerized-migration-runner.sh 003_rename_release_contacts_to_contributors.py 004_move_release_ecc_fields_to_release_information.py
```