### PR TITLE
Replace compatibility bool with ternary value

### DIFF
--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -440,8 +440,10 @@ public class LicenseDatabaseHandler {
         license.unsetShortname();
         license.setLicenseTypeDatabaseId(inputLicense.getLicenseTypeDatabaseId());
         license.unsetLicenseType();
-        license.setGPLv2Compat(inputLicense.GPLv2Compat);
-        license.setGPLv3Compat(inputLicense.GPLv3Compat);
+        license.setGPLv2Compat(Optional.ofNullable(inputLicense.getGPLv2Compat())
+                .orElse(Ternary.UNDEFINED));
+        license.setGPLv3Compat(Optional.ofNullable(inputLicense.getGPLv3Compat())
+                .orElse(Ternary.UNDEFINED));
         license.setExternalLicenseLink(inputLicense.getExternalLicenseLink());
 
         return license;

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/licenses/LicensesPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/licenses/LicensesPortlet.java
@@ -13,10 +13,13 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
 import com.liferay.portal.kernel.servlet.SessionMessages;
+import org.apache.commons.lang.enums.EnumUtils;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.ThriftEnumUtils;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.Ternary;
 import org.eclipse.sw360.datahandler.thrift.licenses.*;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
@@ -273,10 +276,8 @@ public class LicensesPortlet extends Sw360Portlet {
         String text = request.getParameter(License._Fields.TEXT.name());
         String fullname = request.getParameter(License._Fields.FULLNAME.name());
         String shortname = request.getParameter(License._Fields.SHORTNAME.name());
-        boolean gpl2compatibility =
-                (request.getParameter(License._Fields.GPLV2_COMPAT.toString()) == null) ? false : true;
-        boolean gpl3compatibility =
-                (request.getParameter(License._Fields.GPLV3_COMPAT.toString()) == null) ? false : true;
+        Ternary gpl2compatibility = Ternary.findByValue(Integer.parseInt(request.getParameter(License._Fields.GPLV2_COMPAT.toString())));
+        Ternary gpl3compatibility = Ternary.findByValue(Integer.parseInt(request.getParameter(License._Fields.GPLV3_COMPAT.toString())));
         String licenseTypeString =
                 request.getParameter(License._Fields.LICENSE_TYPE.toString() + LicenseType._Fields.LICENSE_TYPE.toString());
         license.setText(CommonUtils.nullToEmptyString(text));

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailSummary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailSummary.jspf
@@ -13,8 +13,8 @@
   <tr><td>Shortname:</td><td><sw360:out value="${licenseDetail.shortname}"/></td></tr>
   <tr><td>Type:</td><td><sw360:out value="${licenseDetail.licenseType.licenseType}"/></td></tr>
   <%--need nested ifs for the yes no because the values can be undefined--%>
-  <tr><td>GPL-2.0 compatibility:</td><td><sw360:DisplayBoolean value="${licenseDetail.GPLv2Compat}" defined="${licenseDetail.setGPLv2Compat}"/></td></tr>
-  <tr><td>GPL-3.0 compatibility:</td><td><sw360:DisplayBoolean value="${licenseDetail.GPLv3Compat}" defined="${licenseDetail.setGPLv3Compat}"/></td></tr>
+  <tr><td>GPL-2.0 compatibility:</td><td><sw360:DisplayEnum value="${licenseDetail.GPLv2Compat}"/></td></tr>
+  <tr><td>GPL-3.0 compatibility:</td><td><sw360:DisplayEnum value="${licenseDetail.GPLv3Compat}"/></td></tr>
   <tr><td>External link for more information:</td><td>
 
     <core_rt:choose>

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/editDetailSummary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/editDetailSummary.jspf
@@ -1,5 +1,6 @@
 <%@ page import="org.eclipse.sw360.datahandler.thrift.licenses.LicenseType" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.licenses.License" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.Ternary" %>
 <%--
   ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
   ~
@@ -50,21 +51,23 @@
   <tr>
     <td width="33%">
       <label class="checkboxlabel" for="gpl2">
-        <input id="gpl2" type="checkbox"
-               name="<portlet:namespace/><%=License._Fields.GPLV2_COMPAT%>"
-               value="<sw360:out value="${licenseDetail.GPLv2Compat}"/>"
-                <core_rt:if test="${licenseDetail.GPLv2Compat == 'true'}"> checked="checked" </core_rt:if>
-        />
-        GPL-2.0 compatibility</label>
+        GPL-2.0 compatibility:
+         <select class="toplabelledInput" id="gpl2"
+                name="<portlet:namespace/><%=License._Fields.GPLV2_COMPAT%>"
+                style="min-width: 162px; min-height: 28px;">
+          <sw360:DisplayEnumOptions type="<%=Ternary.class%>" selected="${licenseDetail.GPLv2Compat}"/>
+        </select>
+      </label>
     </td>
     <td width="33%">
       <label class="checkboxlabel" for="gpl3">
-        <input id="gpl3" type="checkbox"
-               name="<portlet:namespace/><%=License._Fields.GPLV3_COMPAT%>"
-               value="<sw360:out value="${licenseDetail.GPLv3Compat}"/>"
-                <core_rt:if test="${licenseDetail.GPLv3Compat == 'true'}"> checked="checked" </core_rt:if>
-        />
-        GPL-3.0 compatibility</label>
+        GPL-3.0 compatibility:
+        <select class="toplabelledInput" id="gpl3"
+                name="<portlet:namespace/><%=License._Fields.GPLV3_COMPAT%>"
+                style="min-width: 162px; min-height: 28px;">
+          <sw360:DisplayEnumOptions type="<%=Ternary.class%>" selected="${licenseDetail.GPLv3Compat}"/>
+        </select>
+      </label>
     </td>
 
     <td width="33%"></td>

--- a/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/ConvertRecord.java
+++ b/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/ConvertRecord.java
@@ -12,12 +12,16 @@ package org.eclipse.sw360.commonIO;
 import com.google.common.base.Function;
 import com.google.common.base.Strings;
 import com.google.common.collect.*;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.thrift.licenses.*;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.licenses.*;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.common.ThriftEnumUtils;
+import org.eclipse.sw360.datahandler.thrift.Ternary;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -361,13 +365,13 @@ public class ConvertRecord {
 
             String gplv2CompatString = record.get(3);
             if (!Strings.isNullOrEmpty(gplv2CompatString) && !"NULL".equals(gplv2CompatString)) {
-                boolean gplv2Compat = parseBoolean(gplv2CompatString);
+                Ternary gplv2Compat = ThriftEnumUtils.stringToEnum(gplv2CompatString, Ternary.class);
                 license.setGPLv2Compat(gplv2Compat);
             }
 
             String gplv3CompatString = record.get(4);
             if (!Strings.isNullOrEmpty(gplv3CompatString) && !"NULL".equals(gplv3CompatString)) {
-                boolean gplv3Compat = parseBoolean(gplv3CompatString);
+                Ternary gplv3Compat = ThriftEnumUtils.stringToEnum(gplv3CompatString, Ternary.class);
                 license.setGPLv3Compat(gplv3Compat);
             }
 
@@ -420,8 +424,8 @@ public class ConvertRecord {
                     out.add(CommonUtils.nullToEmptyString(license.getFullname()));
                     out.add(license.isSetLicenseType() ? ((Integer) license.getLicenseType().getLicenseTypeId()).toString() :
                             CommonUtils.nullToEmptyString(license.getLicenseTypeDatabaseId()));
-                    out.add(license.isSetGPLv2Compat() ? ((Boolean) license.isGPLv2Compat()).toString() : "");
-                    out.add(license.isSetGPLv3Compat() ? ((Boolean) license.isGPLv3Compat()).toString() : "");
+                    out.add(license.isSetGPLv2Compat() ? (license.getGPLv2Compat()).toString() : "");
+                    out.add(license.isSetGPLv3Compat() ? (license.getGPLv3Compat()).toString() : "");
                     out.add(CommonUtils.nullToEmptyString(license.getReviewdate()));
                     out.add(CommonUtils.nullToEmptyString(license.getText()));
                     out.add(CommonUtils.nullToEmptyString(license.getExternalLicenseLink()));

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.datahandler.common;
 
 
 import com.google.common.collect.ImmutableMap;
+import org.eclipse.sw360.datahandler.thrift.Ternary;
 import org.eclipse.sw360.datahandler.thrift.VerificationState;
 import org.eclipse.sw360.datahandler.thrift.ModerationState;
 import org.eclipse.sw360.datahandler.thrift.Visibility;
@@ -52,6 +53,10 @@ public class ThriftEnumUtils {
             .put(ComponentType.FREESOFTWARE, "Freeware")
             .build();
 
+    private static final ImmutableMap<Ternary,String> Map_TERNARY_STRING = ImmutableMap.of(
+            Ternary.UNDEFINED, "undefined",
+            Ternary.NO, "no",
+            Ternary.YES, "yes");
 
     private static final ImmutableMap<ProjectType, String> MAP_PROJECT_TYPE_STRING = ImmutableMap.of(
             ProjectType.CUSTOMER, "Customer Project" ,
@@ -202,6 +207,7 @@ public class ThriftEnumUtils {
     public static final ImmutableMap<Class<? extends TEnum>, Map<? extends TEnum, String>>
             MAP_ENUMTYPE_MAP = ImmutableMap.<Class<? extends TEnum>, Map<? extends TEnum, String>>builder()
             .put(ComponentType.class, MAP_COMPONENT_TYPE_STRING)
+            .put(Ternary.class, Map_TERNARY_STRING)
             .put(ProjectType.class, MAP_PROJECT_TYPE_STRING)
             .put(AttachmentType.class, MAP_ATTACHMENT_TYPE_STRING)
             .put(ClearingState.class, MAP_CLEARING_STATUS_STRING)

--- a/libraries/lib-datahandler/src/main/thrift/licenses.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenses.thrift
@@ -19,6 +19,7 @@ typedef sw360.RequestStatus RequestStatus
 typedef sw360.DocumentState DocumentState
 typedef sw360.CustomProperties CustomProperties
 typedef sw360.RequestSummary RequestSummary
+typedef sw360.Ternary Ternary
 
 struct Obligation {
 	1: optional string id,
@@ -86,9 +87,13 @@ struct License {
      9: optional map<string, string> externalIds,
 
     // Additional informations
-	10: optional bool GPLv2Compat,
-	11: optional bool GPLv3Compat,
+	// 10: optional bool GPLv2Compat,
+	// 11: optional bool GPLv3Compat,
 	12: optional string reviewdate,
+
+	15: optional Ternary GPLv2Compat = sw360.Ternary.UNDEFINED,
+	16: optional Ternary GPLv3Compat = sw360.Ternary.UNDEFINED,
+
     20: optional list<Todo> todos,
     21: optional set<string> todoDatabaseIds,
 	22: optional list<Risk> risks,

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -252,5 +252,5 @@ service ProjectService {
     /**
     * get the same list of projects back, but with filled release clearing state summaries
      */
-    list<Project> fillClearingStateSummary(list<Project> projects, User user);
+    list<Project> fillClearingStateSummary(1: list<Project> projects, 2: User user);
 }

--- a/libraries/lib-datahandler/src/main/thrift/schedule.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/schedule.thrift
@@ -47,9 +47,9 @@ service ScheduleService {
 
     RequestStatusWithBoolean isAnyServiceScheduled(1: User user);
 
-    i32 getFirstRunOffset(string serviceName);
+    i32 getFirstRunOffset(1: string serviceName);
 
-    string getNextSync(string serviceName);
+    string getNextSync(1: string serviceName);
 
-    i32 getInterval(string serviceName);
+    i32 getInterval(1: string serviceName);
 }

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -11,6 +11,12 @@
 namespace java org.eclipse.sw360.datahandler.thrift
 namespace php sw360.thrift
 
+enum Ternary {
+    UNDEFINED = 0,
+    NO = 1,
+    YES = 2,
+}
+
 enum RequestStatus {
     SUCCESS = 0,
     SENT_TO_MODERATOR = 1,

--- a/scripts/migrations/005_convert_compatibility_fields_to_ternary.py
+++ b/scripts/migrations/005_convert_compatibility_fields_to_ternary.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+# -----------------------------------------------------------------------------
+# Copyright (c) Bosch Software Innovations GmbH 2017.
+# Part of the SW360 Portal Project.
+#
+# All rights reserved.   This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# This is a manual database migration script. It is assumed that a
+# dedicated framework for automatic migration will be written in the
+# future. When that happens, this script should be refactored to conform
+# to the framework's prerequisites to be run by the framework. For
+# example, server address and db name should be parametrized, the code
+# reorganized into a single class or function, etc.
+#
+# -----------------------------------------------------------------------------
+
+import couchdb
+
+COUCHSERVER = "http://localhost:5984/"
+DBNAME = 'sw360db'
+
+couch=couchdb.Server(COUCHSERVER)
+db = couch[DBNAME]
+
+# -----------------------------------------------------------------------------
+# helper functions
+def convertToTernary(compatibilityBool):
+    if isinstance(compatibilityBool, bool):
+        if compatibilityBool:
+            return "YES"
+        else:
+            return "UNDEFINED"
+    return compatibilityBool
+
+def convertLicenseToTernary(license):
+    for field in ['GPLv2Compat','GPLv3Compat']:
+        if field in license:
+            license[field] = convertToTernary(license[field])
+        else:
+            license[field] = "UNDEFINED"
+    if 'issetBitfield' in license:
+        del license['issetBitfield']
+    return license
+
+# -----------------------------------------------------------------------------
+# migrate licenses
+licenses_by_id_fun = '''function(doc){
+    if (doc.type=="license"){
+        emit(doc._id, doc)
+    }
+}'''
+
+licenses = db.query(licenses_by_id_fun)
+
+print 'On raw licenses: converting boolean compatibility flags to ternary.'
+for license_row in licenses:
+    db.save(convertLicenseToTernary(license_row.value))
+print 'Done.'
+
+# -----------------------------------------------------------------------------
+# migrate moderations related to licenses
+moderations_with_license_stuff_fun = '''function(doc){
+    if (doc.type=="moderation" && (doc.licenseAdditions || doc.licenseDeletions)){
+        emit(doc._id, doc)
+    }
+}'''
+
+moderations_with_license_stuff = db.query(moderations_with_license_stuff_fun)
+
+print 'In moderations: converting boolean compatibility flags to ternary.'
+for moderation_row in moderations_with_license_stuff:
+    moderation = moderation_row.value
+    for field in ['licenseAdditions','licenseDeletions']:
+        moderation[field] = map(convertLicenseToTernary, moderation[field])
+    db.save(moderation)
+print 'Done.'

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -19,7 +19,9 @@ To migrate it is recommended to do this in the following order:
 ### 1.4.0 -> 1.5.0
 ### 1.5.0 -> 1.6.0
 - `004_move_release_ecc_fields_to_release_information.py`
-### 1.6.0 -> ?
+### 1.6.0 -> 1.7.0
+### 1.7.0 -> ?
+- `005_convert_compatibility_fields_to_ternary.py`
 
 ## Run the scripts for a database not running on localhost
 tbd.


### PR DESCRIPTION
This PR replaces the types of two fileds `GPLv2Compatibility` and `GPLv3Compatibility` with a ternary value. This allows to express `"YES"`, `"NO"` and `"UNKNOWN"`.

The corresponding migration script maps the old values in the following way:
- `True` becomes `YES`
- `No` becomes `UNKNOWN`