### PR TITLE
ui(projectedit): add buttons also to bottom of edit page

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
@@ -96,8 +96,17 @@
         <jsp:include page="/html/utils/includes/searchReleases.jsp" />
         <jsp:include page="/html/utils/includes/searchAndSelect.jsp" />
         <jsp:include page="/html/utils/includes/searchUsers.jsp" />
+
+        <core_rt:if test="${not addMode}" >
+            <input type="button" id="formSubmit2" value="Update Project" class="addButton">
+        </core_rt:if>
+        <core_rt:if test="${addMode}" >
+            <input type="button" id="formSubmit2" value="Add Project" class="addButton">
+        </core_rt:if>
+        <input type="button" value="Cancel" onclick="cancel()" class="cancelButton">
     </div>
 </core_rt:if>
+
 <script>
     function cancel() {
         deleteAttachmentsOnCancel();
@@ -137,7 +146,7 @@
             invalidHandler: invalidHandlerShowErrorTab
         });
 
-        $('#formSubmit').click(
+        $('#formSubmit, #formSubmit2').click(
                 function() {
                     $('#projectEditForm').submit();
                 }


### PR DESCRIPTION
This adds an additional pair of buttons to the end of the edit page.

![screenshot](https://cloud.githubusercontent.com/assets/1187050/25224533/f251634a-25be-11e7-8de7-eda674f21947.png)