### PR TITLE
Remove backticks from JS code to eliminate Liferay's minifier errors

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/tags/TrimLineBreaks.tag
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/tags/TrimLineBreaks.tag
@@ -1,0 +1,12 @@
+<%--
+  ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~ This tag file MUST NOT have any line breaks outside of this multiline comment.
+  ~ It is surely possible to implement it in Java to avoid having this weird restriction,
+  ~ but this way was perceived as quickest by me at the time.
+  --%><%@ attribute name="input" type="java.lang.String" required="true" %><%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%><%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %><c:set var="newline" value='<%="\n"%>' />${fn:replace(input, newline, '')}

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/vulnerabilities.jspf
@@ -4,7 +4,7 @@
 <%@ page import="org.eclipse.sw360.datahandler.thrift.VerificationState" %>
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%--
-  ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
   ~ With modifications from Bosch Software Innovations GmbH, 2016.
   ~
   ~ All rights reserved. This program and the accompanying materials
@@ -67,7 +67,7 @@
                     '<select class="toplabelledInput" ' +
                     'id="verificationChangeSelectFor${vulnerability.externalId}" ' +
                     'name="<portlet:namespace/><%=VerificationState.class%>" ' +
-                    'onchange="changeVerification(this, `${vulnerability.externalId}`,`${vulnerabilityVerifications.get(vulnerability.externalId).get(vulnerability.intReleaseId).ordinal()}`, `${vulnerability.intReleaseId}`)" ' +
+                    'onchange="changeVerification(this, \'${vulnerability.externalId}\',\'${vulnerabilityVerifications.get(vulnerability.externalId).get(vulnerability.intReleaseId).ordinal()}\', \'${vulnerability.intReleaseId}\')" ' +
                     'title="<sw360:out value='${vulnerabilityVerificationTooltips.get(vulnerability.externalId).get(vulnerability.intReleaseId)}'/>"'+
                     'style="min-width: 90px; min-height: 28px;">' +
                     <sw360:DisplayEnumOptions type="<%=VerificationState.class%>" selected="${vulnerabilityVerifications.get(vulnerability.externalId).get(vulnerability.intReleaseId)}" inQuotes="true"/> +

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/vulnerabilities.jspf
@@ -3,7 +3,7 @@
 <%@ page import="org.eclipse.sw360.datahandler.thrift.VerificationState" %>
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%--
-  ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
   ~ With modifications from Bosch Software Innovations GmbH, 2016.
   ~
   ~ All rights reserved. This program and the accompanying materials
@@ -70,7 +70,7 @@
                 '<select class="toplabelledInput" ' +
                 'id="verificationChangeSelectFor<sw360:out value='${vulnerability.externalId}'/>" ' +
                 'name="<portlet:namespace/><%=VerificationState.class%>" ' +
-                'onchange="changeVerification(this, `<sw360:out value='${vulnerability.externalId}'/>`,`${vulnerabilityVerifications.get(vulnerability.externalId).get(releaseId).ordinal()}`)" ' +
+                'onchange="changeVerification(this, \'<sw360:out value='${vulnerability.externalId}'/>\',\'${vulnerabilityVerifications.get(vulnerability.externalId).get(releaseId).ordinal()}\')" ' +
                 'title="<sw360:out value='${vulnerabilityVerificationTooltips.get(vulnerability.externalId).get(releaseId)}'/>"'+
                 'style="min-width: 90px; min-height: 28px;">' +
                 <sw360:DisplayEnumOptions type="<%=VerificationState.class%>" selected="${vulnerabilityVerifications.get(vulnerability.externalId).get(releaseId)}" inQuotes="true"/> +

--- a/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
   ~ All rights reserved. This program and the accompanying materials
@@ -248,11 +248,12 @@
         var result = [];
 
         <core_rt:forEach items="${componentList}" var="component">
+        <core_rt:set var="licenseCollectionTagOutput"><tags:DisplayLicenseCollection licenseIds="${component.mainLicenseIds}" scopeGroupId="${pageContext.getAttribute('scopeGroupId')}"/></core_rt:set>
         result.push({
             "DT_RowId": "${component.id}",
             "0": '<sw360:DisplayCollection value="${component.vendorNames}"/>',
             "1": "<a href='" + createDetailURLfromComponentId("${component.id}") + "' target='_self'><sw360:out value="${component.name}"/></a>",
-            "2": `<tags:DisplayLicenseCollection licenseIds="${component.mainLicenseIds}" scopeGroupId="${pageContext.getAttribute('scopeGroupId')}"/>`,
+            "2": "<tags:TrimLineBreaks input="${licenseCollectionTagOutput}"/>",
             "3": '<sw360:DisplayEnum value="${component.componentType}"/>',
             "4": "<a href='<portlet:renderURL ><portlet:param name="<%=PortalConstants.COMPONENT_ID%>" value="${component.id}"/><portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.PAGENAME_EDIT%>"/></portlet:renderURL>'><img src='<%=request.getContextPath()%>/images/edit.png' alt='Edit' title='Edit'> </a>"
             + "<img src='<%=request.getContextPath()%>/images/Trash.png' onclick=\"deleteComponent('${component.id}', '<b>${component.name}</b>',${component.releaseIdsSize},${component.attachmentsSize})\"  alt='Delete' title='Delete'>"

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/vulnerabilities.jspf
@@ -4,7 +4,7 @@
 <%@ page import="org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityRatingForProject" %>
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%--
-  ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
   ~ With modifications from Bosch Software Innovations GmbH, 2016.
   ~
   ~ All rights reserved. This program and the accompanying materials
@@ -70,7 +70,7 @@
                 '<select class="toplabelledInput" '+
                     'id="ratingChangeSelectFor${vulnerability.externalId}" '+
                     'name="<portlet:namespace/><%=VulnerabilityRatingForProject.class%>" '+
-                    'onchange="changeRating(this, `${vulnerability.externalId}`,`${vulnerabilityRatings.get(vulnerability.externalId).get(vulnerability.intReleaseId).ordinal()}`, `${vulnerability.intReleaseId}`)" '+
+                    'onchange="changeRating(this, \'${vulnerability.externalId}\',\'${vulnerabilityRatings.get(vulnerability.externalId).get(vulnerability.intReleaseId).ordinal()}\', \'${vulnerability.intReleaseId}\')" '+
                     'title="<sw360:out value='${vulnerabilityCheckstatusTooltips.get(vulnerability.externalId).get(vulnerability.intReleaseId)}'/>"'+
                     'style="min-width: 90px; min-height: 28px;">'+
                    <sw360:DisplayEnumOptions type="<%=VulnerabilityRatingForProject.class%>" selected="${vulnerabilityRatings.get(vulnerability.externalId).get(vulnerability.intReleaseId)}" inQuotes="true"/> +


### PR DESCRIPTION
Remove backticks from JS code to eliminate Liferay's minifier errors