### PR TITLE
Add prefixes to duplicate column headers in spreadsheet exports

### DIFF
--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -72,7 +72,7 @@ public class ComponentExporter extends ExcelExporter<Component> {
                 .map(n -> SW360Utils.displayNameFor(n, nameToDisplayName))
                 .collect(Collectors.toList());
         if(extendedByReleases){
-            HEADERS.addAll(releaseHelper.getHeaders());
+            addSubheadersWithPrefixesAsNeeded(HEADERS, releaseHelper.getHeaders(), "release: ");
         }
     }
 

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,6 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Created on 06/02/15.
@@ -116,5 +117,14 @@ public class ExcelExporter<T> {
         font.setBoldweight(XSSFFont.BOLDWEIGHT_BOLD);
         headerCellStyle.setFont(font);
         return headerCellStyle;
+    }
+
+    protected List<String> addSubheadersWithPrefixesAsNeeded(List<String> headers, List<String> subheaders, String prefix) {
+        List<String> prefixedSubheaders = subheaders
+                .stream()
+                .map(h -> headers.contains(h) ? prefix + h : h)
+                .collect(Collectors.toList());
+        headers.addAll(prefixedSubheaders);
+        return headers;
     }
 }

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
@@ -89,7 +89,7 @@ public class ProjectExporter extends ExcelExporter<Project> {
                 .map(n -> SW360Utils.displayNameFor(n, nameToDisplayName))
                 .collect(Collectors.toList());
         if (extendedByReleases) {
-            ((ArrayList) HEADERS).addAll(releaseHelper.getHeaders());
+            addSubheadersWithPrefixesAsNeeded(HEADERS, releaseHelper.getHeaders(), "release: ");
         }
     }
 

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -49,6 +49,7 @@ public class ReleaseExporter extends ExcelExporter<Release> {
         nameToDisplayName.put(Release._Fields.MAIN_LICENSE_IDS.getFieldName(), "main license IDs");
         nameToDisplayName.put(Release._Fields.DOWNLOADURL.getFieldName(), "downloadurl");
         nameToDisplayName.put(Release._Fields.RELEASE_ID_TO_RELATIONSHIP.getFieldName(), "releases with relationship");
+        nameToDisplayName.put(Release._Fields.OPERATING_SYSTEMS.getFieldName(), "operating systems");
     }
 
     private static final List<Release._Fields> RELEASE_IGNORED_FIELDS = ImmutableList.<Release._Fields>builder()


### PR DESCRIPTION
Column headers in project spreadsheet export and component spreadsheet export are prepended by `release: ` when the export is extended by releases and a release header would otherwise create a duplicate column header

closes #354