### PR TITLE
chore(mvn): Allow to deploy backend via webapps, i.e. the tomcat hot deploy mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,19 @@ For deployment run the command
 ```
 mvn install -Pdeploy
 ```
-which copies the war files to the liferay auto deploy folder, which is often
-found at `/opt/sw360/deploy`.
-The Target path
-- is either calculated from the environmental variable `LIFERAY_PATH` as
-  `${env.LIFERAY_PATH}/deploy` or
-- can be set directly via
-  - `mvn install -Pdeploy -Ddeploy.dir=/DIR/TO/PLACE/WAR/FILES/IN"` or
-  - `rake deploy DEPLOY_DIR=/DIR/TO/PLACE/WAR/FILES/IN`, which wraps the
-  compilation within docker, if `DOCKERIZE=false` is not set 
+which copies the war files to the liferay auto deploy folder (if `LIFERAY_PATH` is set).
+Otherwise one has to specify the absolute path to the deploy folder in the following way:
+```
+mvn install -Pdeploy \
+    -Pdeploy.dir=/ABSOLUTE/PATH/TO/DEPLOY/FOLDER
+```
+It is even better to also pass the path to the webapps folder, thus allowing maven to deploy the backend services directly via the native tomcat hot deploy mechanism.
+This is done in the following way:
+```
+mvn install -Pdeploy \
+    -Pdeploy.dir=/ABSOLUTE/PATH/TO/DEPLOY/FOLDER \
+    -Pwebapps.dir=/ABSOLUTE/PATH/TO/WEBAPPS/FOLDER
+```
   
 #### Packaging
 The packaging mechanisms are able to produce **.deb**, **.rpm** and **.tar.gz**

--- a/backend/svc/pom.xml
+++ b/backend/svc/pom.xml
@@ -76,7 +76,7 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-war-plugin</artifactId>
               <configuration>
-                <outputDirectory>${deploy.dir}</outputDirectory>
+                <outputDirectory>${webapps.dir}</outputDirectory>
               </configuration>
             </plugin>
           </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,9 @@
         <deploy.dir>
             ${env.LIFERAY_PATH}/deploy
         </deploy.dir>
+        <webapps.dir>
+            ${deploy.dir}
+        </webapps.dir>
         <liferay.maven.plugin.version>${liferay.version}</liferay.maven.plugin.version>
 
         <!-- some mem optimization here -->


### PR DESCRIPTION
using the following command, one is able to deploy
- the frontend via liferay and its hot deploy mechanisms
- the backend via tomcats native hot deploy mechanisms
```
$ mvn install -P deploy \
    -Ddeploy.dir=/ABSOLUTE/PATH/TO/deploy/ \
    -Dwebapps.dir=/ABSOLUTE/PATH/TO/webapps/
```

it is still possible to deploy everythin via the liferay deploy
mechanism using
```
$ mvn install -P deploy \
    -Ddeploy.dir=/ABSOLUTE/PATH/TO/deploy/
```

to use relative paths one has to use something like:
```
$ mvn install -P deploy \
    -Ddeploy.dir=$(realpath PATH/TO/deploy/) \
    -Dwebapps.dir=$(realpath PATH/TO/webapps/)
```