### PR TITLE
fix(licenseinfo): currently copyrights in SPDX files are not parsed correctly

### DIFF
--- a/backend/src/src-licenseinfo/pom.xml
+++ b/backend/src/src-licenseinfo/pom.xml
@@ -17,6 +17,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.tngtech.java</groupId>
+            <artifactId>junit-dataprovider</artifactId>
+            <version>1.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.sw360</groupId>
             <artifactId>src-attachments</artifactId>
             <version>1.8.0-SNAPSHOT</version>

--- a/backend/src/src-licenseinfo/pom.xml
+++ b/backend/src/src-licenseinfo/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.spdx</groupId>
             <artifactId>spdx-tools</artifactId>
-            <version>2.0.4</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
@@ -31,10 +31,7 @@ import javax.xml.stream.XMLStreamReader;
 import javax.xml.xpath.*;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -55,6 +52,11 @@ public abstract class AbstractCLIParser extends LicenseInfoParser {
 
     public AbstractCLIParser(AttachmentConnector attachmentConnector, AttachmentContentProvider attachmentContentProvider) {
         super(attachmentConnector, attachmentContentProvider);
+    }
+
+    @Override
+    public List<String> getApplicableFileExtensions() {
+        return Collections.singletonList(XML_FILE_EXTENSION);
     }
 
     protected static String normalizeEscapedXhtml(Node node) {

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParser.java
@@ -8,28 +8,18 @@
  */
 package org.eclipse.sw360.licenseinfo.parsers;
 
-import org.apache.log4j.Logger;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
-import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.apache.thrift.TException;
 
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-import java.io.InputStream;
 import java.util.List;
 
-import static org.eclipse.sw360.datahandler.common.CommonUtils.closeQuietly;
 
 /**
  * @author: alex.borodin@evosoft.com
  */
 public abstract class LicenseInfoParser {
-    private static final Logger log = Logger.getLogger(LicenseInfoParser.class);
     protected final AttachmentConnector attachmentConnector;
     protected AttachmentContentProvider attachmentContentProvider;
 
@@ -38,7 +28,17 @@ public abstract class LicenseInfoParser {
         this.attachmentContentProvider = attachmentContentProvider;
     }
 
-    public abstract boolean isApplicableTo(Attachment attachmentContent) throws TException;
+    public abstract List<String> getApplicableFileExtensions();
+
+    public boolean isApplicableTo(Attachment attachmentContent) throws TException {
+        List<String> applicableFileExtensions = getApplicableFileExtensions();
+        if(applicableFileExtensions.size() == 0){
+            return true;
+        }
+        String lowerFileName = attachmentContent.getFilename().toLowerCase();
+        return applicableFileExtensions.stream()
+                .anyMatch(extension -> lowerFileName.endsWith(extension.toLowerCase()));
+    }
 
     public abstract List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment) throws TException;
 }

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Bosch Software Innovations GmbH, 2017.
+ * Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.licenseinfo.parsers;
+
+import org.apache.log4j.Logger;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.spdx.rdfparser.InvalidSPDXAnalysisException;
+import org.spdx.rdfparser.license.*;
+import org.spdx.rdfparser.model.SpdxDocument;
+import org.spdx.rdfparser.model.SpdxFile;
+import org.spdx.rdfparser.model.SpdxItem;
+import org.spdx.rdfparser.model.SpdxPackage;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
+
+public class SPDXParserTools {
+
+    private static final Logger log = Logger.getLogger(SPDXParserTools.class);
+
+    private static String extractLicenseName(AnyLicenseInfo licenseConcluded) {
+        return licenseConcluded.getResource().getLocalName();
+    }
+
+    private static String extractLicenseName(ExtractedLicenseInfo extractedLicenseInfo){
+        return ! isNullEmptyOrWhitespace(extractedLicenseInfo.getName()) ? extractedLicenseInfo.getName() : extractedLicenseInfo.getLicenseId();
+    }
+
+
+    protected static Stream<LicenseNameWithText> getAllLicenseTextsFromInfo(AnyLicenseInfo spdxLicenseInfo) {
+        log.trace("Seen the spdxLicenseInfo=" + spdxLicenseInfo.toString() + "]");
+        if (spdxLicenseInfo instanceof LicenseSet) {
+
+            LicenseSet LicenseSet = (LicenseSet) spdxLicenseInfo;
+            return Arrays.stream(LicenseSet.getMembers())
+                    .flatMap(SPDXParserTools::getAllLicenseTextsFromInfo);
+
+        } else if (spdxLicenseInfo instanceof ExtractedLicenseInfo) {
+
+            ExtractedLicenseInfo extractedLicenseInfo = (ExtractedLicenseInfo) spdxLicenseInfo;
+            return Stream.of(new LicenseNameWithText()
+                    .setLicenseName(extractLicenseName(extractedLicenseInfo))
+                    .setLicenseText(extractedLicenseInfo.getExtractedText()));
+
+        } else if (spdxLicenseInfo instanceof License) {
+
+            License license = (License) spdxLicenseInfo;
+            return Stream.of(new LicenseNameWithText()
+                    .setLicenseName(extractLicenseName(license))
+                    .setLicenseText(license.getLicenseText()));
+
+        } else if (spdxLicenseInfo instanceof OrLaterOperator) {
+
+            OrLaterOperator orLaterOperator = (OrLaterOperator) spdxLicenseInfo;
+            return getAllLicenseTextsFromInfo(orLaterOperator.getLicense())
+                    .map(lnwt -> lnwt.setLicenseName(lnwt.getLicenseName() + " or later"));
+
+        } else if (spdxLicenseInfo instanceof WithExceptionOperator) {
+
+            WithExceptionOperator withExceptionOperator = (WithExceptionOperator) spdxLicenseInfo;
+            String licenseExceptionText = withExceptionOperator.getException()
+                    .getLicenseExceptionText();
+            return getAllLicenseTextsFromInfo(withExceptionOperator.getLicense())
+                    .map(licenseNWT -> licenseNWT
+                            .setLicenseText(licenseNWT.getLicenseText() + "\n\n" + licenseExceptionText)
+                            .setLicenseName(licenseNWT.getLicenseName() + " with " + withExceptionOperator.getException().getName()));
+
+        }
+        log.debug("the spdxLicenseInfo=[" + spdxLicenseInfo.toString() + "] did not contain any license information");
+
+        return Stream.empty();
+    }
+
+    protected static Stream<LicenseNameWithText> getAllLicenseTexts(SpdxItem spdxItem, boolean useLicenseInfoFromFiles) {
+        Stream<LicenseNameWithText> licenseTexts = getAllLicenseTextsFromInfo(spdxItem.getLicenseConcluded());
+
+        if (useLicenseInfoFromFiles){
+            licenseTexts = Stream.concat(licenseTexts,
+                    Arrays.stream(spdxItem.getLicenseInfoFromFiles())
+                            .flatMap(SPDXParserTools::getAllLicenseTextsFromInfo));
+        }
+
+        if (spdxItem instanceof SpdxPackage) {
+            SpdxPackage spdxPackage = (SpdxPackage) spdxItem;
+            try {
+                licenseTexts = Stream.concat(licenseTexts,
+                        getAllLicenseTextsFromInfo(spdxPackage.getLicenseDeclared()));
+
+                for (SpdxFile spdxFile: spdxPackage.getFiles()){
+                    licenseTexts = Stream.concat(licenseTexts,
+                            getAllLicenseTexts(spdxFile, useLicenseInfoFromFiles));
+                }
+            } catch (InvalidSPDXAnalysisException e) {
+                log.error("Failed to analyse spdx package: " + spdxPackage.getName(), e);
+                throw new UncheckedInvalidSPDXAnalysisException(e);
+            }
+        }
+
+        return licenseTexts;
+    }
+
+    protected static Stream<String> getAllCopyrights(SpdxItem spdxItem) {
+        Stream<String> copyrights = Stream.of(spdxItem.getCopyrightText().trim());
+        if (spdxItem instanceof SpdxPackage){
+            SpdxPackage spdxPackage = (SpdxPackage) spdxItem;
+            try {
+                copyrights = Stream.concat(copyrights,
+                        Arrays.stream(spdxPackage.getFiles())
+                                .flatMap(spdxFile -> getAllCopyrights(spdxFile)));
+            } catch (InvalidSPDXAnalysisException e) {
+                log.error("Failed to get files of package: " + spdxPackage.getName(), e);
+                throw new UncheckedInvalidSPDXAnalysisException(e);
+            }
+        }
+        return copyrights;
+    }
+
+
+    protected static LicenseInfoParsingResult getLicenseInfoFromSpdx(AttachmentContent attachmentContent, SpdxDocument doc) {
+        LicenseInfo licenseInfo = new LicenseInfo().setFilenames(Arrays.asList(attachmentContent.getFilename()));
+        licenseInfo.setLicenseNamesWithTexts(new HashSet<>());
+        licenseInfo.setCopyrights(new HashSet<>());
+
+        try {
+            for (SpdxItem spdxItem : doc.getDocumentDescribes()) {
+                licenseInfo.getLicenseNamesWithTexts()
+                        .addAll(getAllLicenseTexts(spdxItem, true)
+                                .collect(Collectors.toSet()));
+                licenseInfo.getCopyrights()
+                        .addAll(getAllCopyrights(spdxItem)
+                                .collect(Collectors.toSet()));
+            }
+        } catch (UncheckedInvalidSPDXAnalysisException e) {
+            return new LicenseInfoParsingResult()
+                    .setStatus(LicenseInfoRequestStatus.FAILURE)
+                    .setMessage(e.getInvalidSPDXAnalysisExceptionCause().getMessage());
+        } catch (InvalidSPDXAnalysisException e) {
+            return new LicenseInfoParsingResult()
+                    .setStatus(LicenseInfoRequestStatus.FAILURE)
+                    .setMessage(e.getMessage());
+        }
+
+        return new LicenseInfoParsingResult()
+                .setLicenseInfo(licenseInfo)
+                .setStatus(LicenseInfoRequestStatus.SUCCESS);
+    }
+
+
+    private static class UncheckedInvalidSPDXAnalysisException extends RuntimeException {
+        UncheckedInvalidSPDXAnalysisException(InvalidSPDXAnalysisException te) {
+            super(te);
+        }
+
+        InvalidSPDXAnalysisException getInvalidSPDXAnalysisExceptionCause() {
+            return (InvalidSPDXAnalysisException) getCause();
+        }
+    }
+}

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParserTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Bosch Software Innovations GmbH, 2017.
+ * Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.licenseinfo.parsers;
+
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
+import org.eclipse.sw360.datahandler.common.UncheckedSW360Exception;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.eclipse.sw360.licenseinfo.TestHelper.makeAttachment;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class LicenseInfoParserTest {
+
+    @Test
+    public void testIsApplicableTo() throws Exception {
+        try {
+            LicenseInfoParser parser = new LicenseInfoParser(null, null) {
+                @Override
+                public List<String> getApplicableFileExtensions() {
+                    return Arrays.asList(".ext1",".ext2");
+                }
+
+                @Override
+                public List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment) throws TException {
+                    return null;
+                }
+            };
+            Arrays.stream(AttachmentType.values())
+                    .filter(SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES::contains)
+                    .forEach(attachmentType -> parser.getApplicableFileExtensions().stream()
+                            .forEach(extension -> {
+                                String filename = "filename" + extension;
+                                Attachment attachment = makeAttachment(filename, attachmentType);
+                                try {
+                                    assertThat(parser.isApplicableTo(attachment), is(true));
+                                } catch (TException e) {
+                                    e.printStackTrace();
+                                }
+                            }));
+        }catch (UncheckedSW360Exception se){
+            throw se.getSW360ExceptionCause();
+        }
+    }
+}

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
@@ -17,16 +17,23 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 import org.spdx.rdfparser.model.SpdxDocument;
 import org.spdx.rdfparser.SPDXDocumentFactory;
 
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.List;
+
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
 
 import static org.eclipse.sw360.licenseinfo.TestHelper.*;
 import static org.eclipse.sw360.licenseinfo.parsers.SPDXParser.FILETYPE_SPDX_INTERNAL;
@@ -36,7 +43,7 @@ import static org.junit.Assert.*;
 /**
  * @author: maximilian.huber@tngtech.com
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(DataProviderRunner.class)
 public class SPDXParserTest {
 
     private SPDXParser parser;
@@ -47,61 +54,93 @@ public class SPDXParserTest {
     private AttachmentConnector connector;
 
     public static final String spdxExampleFile = "SPDXRdfExample-v2.0.rdf";
-    private static String baseUri;
+    public static final String spdx11ExampleFile = "SPDXRdfExample-v1.1.rdf";
+    public static final String spdx12ExampleFile = "SPDXRdfExample-v1.2.rdf";
+
+    @DataProvider
+    public static Object[][] dataProviderAdd() {
+        // @formatter:off
+        return new Object[][] {
+                { spdxExampleFile,
+                        Arrays.asList("Apache-2.0", "LGPL-2.0", "LicenseRef-1", "GPL-2.0", "CyberNeko License", "LicenseRef-2"),
+                        4,
+                        "Copyright 2008-2010 John Smith" },
+                { spdx11ExampleFile,
+                        Arrays.asList("LicenseRef-4", "LicenseRef-1", "Apache-2.0", "LicenseRef-2", "Apache-1.0", "MPL-1.1", "CyberNeko License"),
+                        2,
+                        "Hewlett-Packard Development Company, LP" },
+                { spdx12ExampleFile,
+                        Arrays.asList("LicenseRef-4", "LicenseRef-1", "Apache-2.0", "LicenseRef-2", "Apache-1.0", "MPL-1.1", "CyberNeko License"),
+                        3,
+                        "Hewlett-Packard Development Company, LP" },
+        };
+        // @formatter:on
+    }
 
     @Before
     public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
         attachmentContentStore = new AttachmentContentStore(connector);
 
         parser = new SPDXParser(connector, attachmentContentStore.getAttachmentContentProvider());
 
         attachmentContentStore.put(spdxExampleFile);
+        attachmentContentStore.put(spdx11ExampleFile);
+        attachmentContentStore.put(spdx12ExampleFile);
     }
 
-    private void assertIsResultOfExample(LicenseInfo result){
+    private void assertIsResultOfExample(LicenseInfo result, String exampleFile, List<String> expectedLicenses, int numberOfCoyprights, String exampleCopyright){
         assertLicenseInfo(result);
 
         assertThat(result.getFilenames().size(), is(1));
-        assertThat(result.getFilenames().get(0), is(spdxExampleFile));
+        assertThat(result.getFilenames().get(0), is(exampleFile));
 
-        assertThat(result.getLicenseNamesWithTextsSize(), is(6));
+        assertThat(result.getLicenseNamesWithTextsSize(), is(expectedLicenses.size()));
+        expectedLicenses.stream()
+                .forEach(licenseId -> assertThat(result.getLicenseNamesWithTexts().stream()
+                        .map(LicenseNameWithText::getLicenseName)
+                        .anyMatch(licenseId::equals), is(true)));
         assertThat(result.getLicenseNamesWithTexts().stream()
-                .map(lt -> lt.getLicenseText())
-                .anyMatch(t -> t.contains("Free Software Foundation")),
+                        .map(lt -> lt.getLicenseText())
+                        .anyMatch(t -> t.contains("The CyberNeko Software License, Version 1.0")),
                 is(true));
 
-        assertThat(result.getCopyrightsSize(), is(4));
+        assertThat(result.getCopyrightsSize(), is(numberOfCoyprights));
         assertThat(result.getCopyrights().stream()
-                        .anyMatch(c -> c.contains("Copyright 2008-2010 John Smith")),
+                        .anyMatch(c -> c.contains(exampleCopyright)),
                 is(true));
     }
 
     @Test
-    public void testAddSPDXContentToCLI() throws Exception {
+    @UseDataProvider("dataProviderAdd")
+    public void testAddSPDXContentToCLI(String exampleFile, List<String> expectedLicenses, int numberOfCoyprights, String exampleCopyright) throws Exception {
         AttachmentContent attachmentContent = new AttachmentContent()
-                .setFilename(spdxExampleFile);
+                .setFilename(exampleFile);
 
-        InputStream input = makeAttachmentContentStream(spdxExampleFile);
+        InputStream input = makeAttachmentContentStream(exampleFile);
         SpdxDocument spdxDocument = SPDXDocumentFactory.createSpdxDocument(input,
-                parser.getUriOfAttachment(attachmentContentStore.get(spdxExampleFile)),
+                parser.getUriOfAttachment(attachmentContentStore.get(exampleFile)),
                 FILETYPE_SPDX_INTERNAL);
 
         LicenseInfoParsingResult result = SPDXParserTools.getLicenseInfoFromSpdx(attachmentContent, spdxDocument);
-        assertIsResultOfExample(result.getLicenseInfo());
+        assertIsResultOfExample(result.getLicenseInfo(), exampleFile, expectedLicenses, numberOfCoyprights, exampleCopyright);
     }
 
     @Test
-    public void testGetLicenseInfo() throws Exception {
+    @UseDataProvider("dataProviderAdd")
+    public void testGetLicenseInfo(String exampleFile, List<String> expectedLicenses, int numberOfCoyprights, String exampleCopyright) throws Exception {
 
-        Attachment attachment = makeAttachment(spdxExampleFile,
+        Attachment attachment = makeAttachment(exampleFile,
                 Arrays.stream(AttachmentType.values())
                         .filter(at -> SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES.contains(at))
                         .findAny()
                         .get());
 
-        LicenseInfoParsingResult result = parser.getLicenseInfos(attachment).stream().findFirst().orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
+        LicenseInfoParsingResult result = parser.getLicenseInfos(attachment).stream()
+                .findFirst()
+                .orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
 
         assertLicenseInfoParsingResult(result);
-        assertIsResultOfExample(result.getLicenseInfo());
+        assertIsResultOfExample(result.getLicenseInfo(), exampleFile, expectedLicenses, numberOfCoyprights, exampleCopyright);
     }
 }

--- a/backend/src/src-licenseinfo/src/test/resources/SPDXRdfExample-v1.1.rdf
+++ b/backend/src/src-licenseinfo/src/test/resources/SPDXRdfExample-v1.1.rdf
@@ -1,0 +1,259 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://usefulinc.com/ns/doap#"
+    xmlns="http://spdx.org/rdf/terms#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <SpdxDocument rdf:about="http://www.spdx.org/tools#SPDXANALYSIS">
+    <creationInfo>
+      <CreationInfo>
+        <created>2010-02-03T00:00:00Z</created>
+        <rdfs:comment>This is an example of an SPDX spreadsheet format</rdfs:comment>
+        <creator>Tool: SourceAuditor-V1.2</creator>
+        <creator>Organization: Source Auditor Inc.</creator>
+        <creator>Person: Gary O'Neall</creator>
+      </CreationInfo>
+    </creationInfo>
+    <specVersion>SPDX-1.1</specVersion>
+    <referencesFile>
+      <File rdf:nodeID="A0">
+        <licenseConcluded>
+          <ExtractedLicensingInfo rdf:nodeID="A1">
+            <extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+            <licenseId>LicenseRef-1</licenseId>
+          </ExtractedLicensingInfo>
+        </licenseConcluded>
+        <artifactOf>
+          <j.0:Project>
+            <j.0:homepage>http://www.openjena.org/</j.0:homepage>
+            <j.0:name>Jena</j.0:name>
+          </j.0:Project>
+        </artifactOf>
+        <licenseComments>This license is used by Jena</licenseComments>
+        <fileName>Jenna-2.6.3/jena-2.6.3-sources.jar</fileName>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+        <copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+        <licenseInfoInFile rdf:nodeID="A1"/>
+        <rdfs:comment>This file belongs to Jena</rdfs:comment>
+        <checksum>
+          <Checksum>
+            <checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </File>
+    </referencesFile>
+    <reviewed>
+      <Review>
+        <rdfs:comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <reviewDate>2010-02-10T00:00:00Z</reviewDate>
+        <reviewer>Person: Joe Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A1"/>
+    <reviewed>
+      <Review>
+        <rdfs:comment>Another example reviewer.</rdfs:comment>
+        <reviewDate>2011-03-13T00:00:00Z</reviewDate>
+        <reviewer>Person: Suzanne Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <referencesFile>
+      <File rdf:nodeID="A2">
+        <copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseComments></licenseComments>
+        <licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <fileName>src/org/spdx/parser/DOAPProject.java</fileName>
+      </File>
+    </referencesFile>
+    <describesPackage>
+      <Package rdf:about="http://www.spdx.org/tools#SPDXANALYSIS?package">
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+        <downloadLocation>http://www.spdx.org/tools</downloadLocation>
+        <supplier>Organization:Linux Foundation</supplier>
+        <hasFile rdf:nodeID="A0"/>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <packageVerificationCode>
+          <PackageVerificationCode>
+            <packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFile>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFile>
+          </PackageVerificationCode>
+        </packageVerificationCode>
+        <licenseConcluded>
+          <ConjunctiveLicenseSet>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A3">
+                <extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+                <licenseId>LicenseRef-2</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A4">
+                <extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+                <licenseId>LicenseRef-4</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A5">
+                <rdfs:seeAlso>http://justasample.url.com</rdfs:seeAlso>
+                <rdfs:seeAlso>http://people.apache.org/~andyc/neko/LICENSE</rdfs:seeAlso>
+                <licenseName>CyberNeko License</licenseName>
+                <rdfs:comment>This is tye CyperNeko License</rdfs:comment>
+                <extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+                <licenseId>LicenseRef-3</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+          </ConjunctiveLicenseSet>
+        </licenseConcluded>
+        <sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <packageFileName>spdxtranslator-1.0.zip</packageFileName>
+        <description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+        <licenseInfoFromFiles rdf:nodeID="A4"/>
+        <name>SPDX Translator</name>
+        <versionInfo>Version 0.9.2</versionInfo>
+        <licenseInfoFromFiles rdf:nodeID="A1"/>
+        <hasFile rdf:nodeID="A2"/>
+        <licenseInfoFromFiles rdf:nodeID="A3"/>
+        <copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseDeclared>
+          <ConjunctiveLicenseSet>
+            <member rdf:nodeID="A3"/>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:nodeID="A4"/>
+            <member rdf:nodeID="A5"/>
+          </ConjunctiveLicenseSet>
+        </licenseDeclared>
+        <licenseInfoFromFiles rdf:nodeID="A5"/>
+        <originator>Organization:SPDX</originator>
+        <licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+        <summary>SPDX Translator utility</summary>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+      </Package>
+    </describesPackage>
+    <rdfs:comment>This is a sample spreadsheet</rdfs:comment>
+    <hasExtractedLicensingInfo rdf:nodeID="A4"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A5"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A3"/>
+  </SpdxDocument>
+</rdf:RDF>

--- a/backend/src/src-licenseinfo/src/test/resources/SPDXRdfExample-v1.2.rdf
+++ b/backend/src/src-licenseinfo/src/test/resources/SPDXRdfExample-v1.2.rdf
@@ -1,0 +1,307 @@
+﻿<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:doap="http://usefulinc.com/ns/doap#"
+    xmlns:spdx="http://spdx.org/rdf/terms#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <spdx:SpdxDocument rdf:about="http://git.spdx.org/?p=spdx-tools.git;a=summary#SPDXANALYSIS">
+    <spdx:hasExtractedLicensingInfo>
+      <spdx:ExtractedLicensingInfo rdf:nodeID="A0">
+        <spdx:extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </spdx:extractedText>
+        <spdx:licenseId>LicenseRef-2</spdx:licenseId>
+      </spdx:ExtractedLicensingInfo>
+    </spdx:hasExtractedLicensingInfo>
+    <spdx:referencesFile>
+      <spdx:File rdf:nodeID="A1">
+        <spdx:checksum>
+          <spdx:Checksum rdf:nodeID="A2">
+            <spdx:checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</spdx:checksumValue>
+            <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </spdx:Checksum>
+        </spdx:checksum>
+        <spdx:fileDependency>
+          <spdx:File rdf:nodeID="A3">
+            <spdx:fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+            <spdx:artifactOf>
+              <doap:Project>
+                <doap:homepage>http://www.openjena.org/</doap:homepage>
+                <doap:name>Jena</doap:name>
+              </doap:Project>
+            </spdx:artifactOf>
+            <spdx:licenseInfoInFile>
+              <spdx:ExtractedLicensingInfo rdf:nodeID="A4">
+                <spdx:extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</spdx:extractedText>
+                <spdx:licenseId>LicenseRef-1</spdx:licenseId>
+              </spdx:ExtractedLicensingInfo>
+            </spdx:licenseInfoInFile>
+            <spdx:fileName>lib-source/jena-2.6.3-sources.jar</spdx:fileName>
+            <spdx:licenseComments>This license is used by Jena</spdx:licenseComments>
+            <rdfs:comment>This file belongs to Jena</rdfs:comment>
+            <spdx:fileContributor>Apache Software Foundation</spdx:fileContributor>
+            <spdx:checksum>
+              <spdx:Checksum>
+                <spdx:checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</spdx:checksumValue>
+                <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+              </spdx:Checksum>
+            </spdx:checksum>
+            <spdx:fileContributor>Hewlett Packard Inc.</spdx:fileContributor>
+            <spdx:licenseConcluded rdf:nodeID="A4"/>
+            <spdx:fileDependency>
+              <spdx:File rdf:nodeID="A5">
+                <spdx:licenseComments></spdx:licenseComments>
+                <spdx:copyrightText>Copyright 2001-2011 The Apache Software Foundation</spdx:copyrightText>
+                <spdx:fileContributor>Apache Software Foundation</spdx:fileContributor>
+                <spdx:fileName>lib-source/commons-lang3-3.1-sources.jar</spdx:fileName>
+                <spdx:fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+                <spdx:checksum>
+                  <spdx:Checksum>
+                    <spdx:checksumValue>c2b4e1c67a2d28fced849ee1bb76e7391b93f125</spdx:checksumValue>
+                    <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                  </spdx:Checksum>
+                </spdx:checksum>
+                <spdx:artifactOf>
+                  <doap:Project>
+                    <doap:homepage>http://commons.apache.org/proper/commons-lang/</doap:homepage>
+                    <doap:name>Apache Commons Lang</doap:name>
+                  </doap:Project>
+                </spdx:artifactOf>
+                <spdx:licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+                <rdfs:comment>This file is used by Jena</rdfs:comment>
+                <spdx:noticeText>Apache Commons Lang
+Copyright 2001-2011 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software from the Spring Framework,
+under the Apache License 2.0 (see: StringUtils.containsWhitespace())</spdx:noticeText>
+                <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+              </spdx:File>
+            </spdx:fileDependency>
+            <spdx:copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</spdx:copyrightText>
+          </spdx:File>
+        </spdx:fileDependency>
+        <spdx:licenseComments></spdx:licenseComments>
+        <spdx:licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <spdx:fileContributor>SPDX Technical Team Members</spdx:fileContributor>
+        <spdx:copyrightText>Copyright 2010, 2011 Source Auditor Inc.</spdx:copyrightText>
+        <spdx:fileName>src/org/spdx/parser/DOAPProject.java</spdx:fileName>
+        <spdx:fileContributor>Source Auditor Inc.</spdx:fileContributor>
+        <spdx:fileContributor>Black Duck Software In.c</spdx:fileContributor>
+        <spdx:fileContributor>Open Logic Inc.</spdx:fileContributor>
+        <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <spdx:fileDependency rdf:nodeID="A5"/>
+        <spdx:fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+        <spdx:fileContributor>Protecode Inc.</spdx:fileContributor>
+      </spdx:File>
+    </spdx:referencesFile>
+    <spdx:creationInfo>
+      <spdx:CreationInfo>
+        <spdx:licenseListVersion>1.19</spdx:licenseListVersion>
+        <spdx:created>2010-02-03T00:00:00Z</spdx:created>
+        <rdfs:comment>This is an example of an SPDX spreadsheet format</rdfs:comment>
+        <spdx:creator>Tool: SourceAuditor-V1.2</spdx:creator>
+        <spdx:creator>Organization: Source Auditor Inc.</spdx:creator>
+        <spdx:creator>Person: Gary O'Neall</spdx:creator>
+      </spdx:CreationInfo>
+    </spdx:creationInfo>
+    <spdx:referencesFile rdf:nodeID="A3"/>
+    <rdfs:comment>This is a sample spreadsheet</rdfs:comment>
+    <spdx:referencesFile rdf:nodeID="A5"/>
+    <spdx:hasExtractedLicensingInfo>
+      <spdx:ExtractedLicensingInfo rdf:nodeID="A6">
+        <spdx:extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </spdx:extractedText>
+        <spdx:licenseId>LicenseRef-4</spdx:licenseId>
+      </spdx:ExtractedLicensingInfo>
+    </spdx:hasExtractedLicensingInfo>
+    <spdx:reviewed>
+      <spdx:Review>
+        <rdfs:comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <spdx:reviewDate>2010-02-10T00:00:00Z</spdx:reviewDate>
+        <spdx:reviewer>Person: Joe Reviewer</spdx:reviewer>
+      </spdx:Review>
+    </spdx:reviewed>
+    <spdx:specVersion>SPDX-1.2</spdx:specVersion>
+    <spdx:dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+    <spdx:reviewed>
+      <spdx:Review>
+        <rdfs:comment>Another example reviewer.</rdfs:comment>
+        <spdx:reviewDate>2011-03-13T00:00:00Z</spdx:reviewDate>
+        <spdx:reviewer>Person: Suzanne Reviewer</spdx:reviewer>
+      </spdx:Review>
+    </spdx:reviewed>
+    <spdx:hasExtractedLicensingInfo>
+      <spdx:ExtractedLicensingInfo rdf:nodeID="A7">
+        <rdfs:seeAlso>http://justasample.url.com</rdfs:seeAlso>
+        <rdfs:seeAlso>http://people.apache.org/~andyc/neko/LICENSE</rdfs:seeAlso>
+        <spdx:licenseName>CyberNeko License</spdx:licenseName>
+        <rdfs:comment>This is tye CyperNeko License</rdfs:comment>
+        <spdx:extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</spdx:extractedText>
+        <spdx:licenseId>LicenseRef-3</spdx:licenseId>
+      </spdx:ExtractedLicensingInfo>
+    </spdx:hasExtractedLicensingInfo>
+    <spdx:describesPackage>
+      <spdx:Package rdf:about="http://git.spdx.org/?p=spdx-tools.git;a=summary#SPDXANALYSIS?package">
+        <spdx:sourceInfo>Version 1.0 of the SPDX Translator application</spdx:sourceInfo>
+        <spdx:description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</spdx:description>
+        <spdx:versionInfo>Version1.2.0</spdx:versionInfo>
+        <spdx:licenseInfoFromFiles rdf:nodeID="A4"/>
+        <spdx:packageVerificationCode>
+          <spdx:PackageVerificationCode>
+            <spdx:packageVerificationCodeValue>c8ff32b6fe1200abadcdddda79d677f538c3cec3</spdx:packageVerificationCodeValue>
+            <spdx:packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.txt</spdx:packageVerificationCodeExcludedFile>
+            <spdx:packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.rdf</spdx:packageVerificationCodeExcludedFile>
+          </spdx:PackageVerificationCode>
+        </spdx:packageVerificationCode>
+        <spdx:licenseInfoFromFiles rdf:nodeID="A7"/>
+        <spdx:licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+        <spdx:originator>Organization:SPDX</spdx:originator>
+        <spdx:licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</spdx:licenseComments>
+        <spdx:licenseInfoFromFiles rdf:nodeID="A6"/>
+        <spdx:summary>SPDX Translator utility</spdx:summary>
+        <spdx:licenseDeclared>
+          <spdx:ConjunctiveLicenseSet>
+            <spdx:member rdf:nodeID="A0"/>
+            <spdx:member rdf:nodeID="A4"/>
+            <spdx:member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <spdx:member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <spdx:member rdf:nodeID="A6"/>
+            <spdx:member rdf:nodeID="A7"/>
+          </spdx:ConjunctiveLicenseSet>
+        </spdx:licenseDeclared>
+        <spdx:name>SPDX Translator</spdx:name>
+        <spdx:licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <spdx:licenseInfoFromFiles rdf:nodeID="A0"/>
+        <doap:homepage>http://www.spdx.org/tools</doap:homepage>
+        <spdx:hasFile rdf:nodeID="A5"/>
+        <spdx:hasFile rdf:nodeID="A3"/>
+        <spdx:packageFileName>spdxtranslator-1.2.zip</spdx:packageFileName>
+        <spdx:checksum rdf:nodeID="A2"/>
+        <spdx:copyrightText> Copyright 2010, 2011 Source Auditor Inc.</spdx:copyrightText>
+        <spdx:hasFile rdf:nodeID="A1"/>
+        <spdx:licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+        <spdx:supplier>Organization:Linux Foundation</spdx:supplier>
+        <spdx:downloadLocation>http://git.spdx.org/?p=spdx-tools.git;a=summary</spdx:downloadLocation>
+        <spdx:licenseConcluded>
+          <spdx:ConjunctiveLicenseSet>
+            <spdx:member rdf:nodeID="A0"/>
+            <spdx:member rdf:nodeID="A4"/>
+            <spdx:member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <spdx:member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <spdx:member rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+            <spdx:member rdf:nodeID="A6"/>
+            <spdx:member rdf:nodeID="A7"/>
+          </spdx:ConjunctiveLicenseSet>
+        </spdx:licenseConcluded>
+      </spdx:Package>
+    </spdx:describesPackage>
+    <spdx:hasExtractedLicensingInfo rdf:nodeID="A4"/>
+  </spdx:SpdxDocument>
+  <doap:Project>
+    <doap:homepage>http://commons.apache.org/proper/commons-lang/</doap:homepage>
+    <doap:name>Apache Commons Lang</doap:name>
+  </doap:Project>
+  <doap:Project>
+    <doap:homepage>http://www.openjena.org/</doap:homepage>
+    <doap:name>Jena</doap:name>
+  </doap:Project>
+</rdf:RDF>


### PR DESCRIPTION
This pull request fixes a problem in the SPDX parsing and also refactors the SPDX-parser. This is done in preparation for adding support for TagValue-SPDX files. Sadly there is a bug in the current implementation of spdx-tools, which stop the code from working. It will be contributed as soon as it works.

In addition are tests added, which check whether the old SPDX-formats (1.1 and 1.2) can be parsed.

This PR adds a new dependency: com.tngtech.java.junit-dataprovider, which simplifies the implementation of parametrized tests. It is under Apache2