### PR TITLE
fix(releases): fix too strict duplicate check for releases

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -758,8 +758,8 @@ public class ComponentDatabaseHandler {
         return id == null ? null : id + "_" + visitedIds.getCount(id);
     }
 
-    public List<Release> searchReleaseByName(String name) {
-        return releaseRepository.searchByName(name);
+    public List<Release> searchReleaseByNamePrefix(String name) {
+        return releaseRepository.searchByNamePrefix(name);
     }
 
     public List<Release> getReleases(Set<String> ids, User user) {

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -97,12 +97,12 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
     }
 
     @View(name = "byname", map = BY_NAME_VIEW)
-    public List<Release> searchByName(String name) {
+    public List<Release> searchByNamePrefix(String name) {
         return makeSummary(SummaryType.SHORT, queryForIdsByPrefix("byname", name));
     }
 
     public List<Release> searchByNameAndVersion(String name, String version){
-        List<Release> releasesMatchingName = searchByName(name);
+        List<Release> releasesMatchingName = queryView("byname", name);
         List<Release> releasesMatchingNameAndVersion = releasesMatchingName.stream()
                 .filter(r -> isNullOrEmpty(version) ? isNullOrEmpty(r.getVersion()) : version.equals(r.getVersion()))
                 .collect(Collectors.toList());

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -91,8 +91,8 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
-    public List<Release> searchReleaseByName(String name) throws TException {
-        return handler.searchReleaseByName(name);
+    public List<Release> searchReleaseByNamePrefix(String name) throws TException {
+        return handler.searchReleaseByNamePrefix(name);
     }
 
     @Override

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -270,11 +270,15 @@ public class ComponentDatabaseHandlerTest {
     }
 
     @Test
-    public void testSearchReleaseByName() throws Exception {
-        List<Release> releases = handler.searchReleaseByName("component1");
-
+    public void testSearchReleaseByNamePrefix() throws Exception {
+        List<Release> releases = handler.searchReleaseByNamePrefix("component1");
         assertThat(getReleaseIds(releases), containsInAnyOrder("R1A", "R1B"));
+    }
 
+    @Test
+    public void testSearchReleaseByNamePrefix2() throws Exception {
+        List<Release> releases = handler.searchReleaseByNamePrefix("compo");
+        assertThat(getReleaseIds(releases), containsInAnyOrder("R1A", "R1B", "R2A", "R2B", "R2C"));
     }
 
     @Test
@@ -1006,7 +1010,21 @@ public class ComponentDatabaseHandlerTest {
 
         final Map<String, List<String>> duplicateReleases = handler.getDuplicateReleases();
 
+        assertThat(newReleaseId, isEmptyOrNullString());
         assertThat(duplicateReleases.size(), is(0));
+    }
+
+    @Test
+    public void testDuplicateCheckDoesntMatchByPrefix() throws Exception {
+
+        String originalReleaseId = "R1A";
+        final Release tmp = handler.getRelease(originalReleaseId, user1);
+        tmp.unsetId();
+        tmp.unsetRevision();
+        tmp.setName(tmp.getName().substring(0, 4));
+        String newReleaseId = handler.addRelease(tmp, email1).getId();
+
+        assertThat(newReleaseId, not(isEmptyOrNullString()));
     }
 
     @Test

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -327,7 +327,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                     searchResult = Collections.emptyList();
                 }
             } else {
-                searchResult = componentClient.searchReleaseByName(searchText);
+                searchResult = componentClient.searchReleaseByNamePrefix(searchText);
             }
         } catch (TException e) {
             log.error("Error searching projects", e);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -438,7 +438,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                     searchResult = Collections.emptyList();
                 }
             } else {
-                searchResult = componentClient.searchReleaseByName(searchText);
+                searchResult = componentClient.searchReleaseByNamePrefix(searchText);
             }
         } catch (TException e) {
             log.error("Error searching projects", e);

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -321,9 +321,9 @@ service ComponentService {
     list<Component> refineSearch(1: string text, 2: map<string ,  set<string > > subQueryRestrictions);
 
     /**
-     * get short summary of release by release name
+     * get short summary of release by release name prefix
      **/
-    list<Release> searchReleaseByName(1: string name);
+    list<Release> searchReleaseByNamePrefix(1: string name);
 
     /**
      * information for home portlet


### PR DESCRIPTION
- fix(releases): fix too strict duplicate check for releases that matches prefixes of existing release names
- rename confusingly named method in thrift api to match its function

closes #317