### PR TITLE
chore(mvn): update dependency versions in poms

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
+            <version>2.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
-            <version>1.4</version>
+            <version>1.4.7</version>
         </dependency>
     </dependencies>
 

--- a/backend/src/src-attachments/pom.xml
+++ b/backend/src/src-attachments/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/backend/src/src-cvesearch/pom.xml
+++ b/backend/src/src-cvesearch/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.6.2</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.sw360</groupId>

--- a/backend/src/src-fossology/pom.xml
+++ b/backend/src/src-fossology/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.51</version>
+            <version>0.1.54</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/backend/src/src-licenseinfo/pom.xml
+++ b/backend/src/src-licenseinfo/pom.xml
@@ -13,13 +13,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.tngtech.java</groupId>
             <artifactId>junit-dataprovider</artifactId>
-            <version>1.10.0</version>
+            <version>1.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity</artifactId>
-            <version>1.6.2</version>
+            <version>1.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
@@ -45,12 +45,12 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>3.9</version>
+            <version>3.16</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>3.9</version>
+            <version>3.16</version>
         </dependency>
         <dependency>
             <groupId>net.sf.saxon</groupId>

--- a/backend/utils/pom.xml
+++ b/backend/utils/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
+            <version>1.4</version>
         </dependency>
     </dependencies>
 

--- a/frontend/sw360-portlet/pom.xml
+++ b/frontend/sw360-portlet/pom.xml
@@ -147,7 +147,6 @@
             <groupId>jstl</groupId>
             <artifactId>jstl</artifactId>
             <version>1.2</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -156,7 +155,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
-            <version>1.0</version>
+            <version>1.4</version>
         </dependency>
 
         <dependency>

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectImportPortletTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectImportPortletTest.java
@@ -33,21 +33,10 @@ public class ProjectImportPortletTest extends TestCase {
     private final String newURL = "newURL";
 
     @Mock
-    private ResourceRequest request;
-
-    @Mock
-    private ResourceResponse response;
-
-    @Mock
     private PortletSession session;
 
     @Mock
     private JSONObject responseData;
-
-    @Before
-    public void before() {
-        when(request.getPortletSession()).thenReturn(session);
-    }
 
     @Test
     public void testUpdateInputSourceWithoutUrl() throws Exception {

--- a/libraries/exporters/pom.xml
+++ b/libraries/exporters/pom.xml
@@ -69,17 +69,17 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>13.0</version>
+            <version>15.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.1</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.1</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>3.9</version>
+            <version>3.16</version>
         </dependency>
 
         <dependency>

--- a/libraries/lib-datahandler/pom.xml
+++ b/libraries/lib-datahandler/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>13.0</version>
+            <version>15.0</version>
         </dependency>
         <dependency>
             <groupId>org.ektorp</groupId>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.3.3</version>
+            <version>4.4.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,20 +32,20 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <liferay.version>6.2.1</liferay.version>
+        <liferay.version>6.2.2</liferay.version>
         <ektorp.version>1.4.4</ektorp.version>
         <thrift.version>0.9.3</thrift.version>
-        <guava.version>18.0</guava.version>
-        <spring.version>4.1.5.RELEASE</spring.version>
+        <guava.version>21.0</guava.version>
+        <spring.version>4.3.8.RELEASE</spring.version>
 
-        <slf4j.version>1.7.7</slf4j.version>
-        <logback.version>1.1.2</logback.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <logback.version>1.2.3</logback.version>
         <log4j.version>1.2.17</log4j.version>
-        <junit-dataprovider.version>1.10.0</junit-dataprovider.version>
+        <junit-dataprovider.version>1.12.0</junit-dataprovider.version>
 
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>1.10.5</mockito.version>
+        <mockito.version>1.10.19</mockito.version>
         <maven-source-plugin.version>2.4</maven-source-plugin.version>
         <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
 
@@ -113,7 +113,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-csv</artifactId>
-                <version>1.0</version>
+                <version>1.4</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -148,7 +148,7 @@
             <dependency>
                 <groupId>com.tngtech.jgiven</groupId>
                 <artifactId>jgiven-junit</artifactId>
-                <version>0.9.4</version>
+                <version>0.15.1</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
In this commit not all dependencies were forced to their latest state. The changes are listed in the following table

| dependency | old version | new version | latest version |
| --- | --- | --- | --- |
| ch.qos.logback:logback-classic | 1.1.2 | 1.2.3 | |
| ch.qos.logback:logback-core | 1.1.2 | 1.2.3 | |
| com.google.code.gson:gson | 2.6.2 | 2.8.0 | |
| com.google.guava:guava | 18.0 | 21.0 | 22.0-android |
| com.jcraft:jsch | 0.1.51 | 0.1.54 | |
| com.liferay.portal:portal-service | 6.2.1 | 6.2.2 | 6.2.5 |
| com.liferay.portal:util-bridges | 6.2.1 | 6.2.2 | 6.2.5 |
| com.liferay.portal:util-java | 6.2.1 | 6.2.2 | 6.2.5 |
| com.liferay.portal:util-taglib | 6.2.1 | 6.2.2 | 6.2.5 |
| commons-cli:commons-cli | 1.2 | 1.4 | |
| com.tngtech.java:junit-dataprovider | 1.10.0 | 1.12.0 | |
| com.tngtech.jgiven:jgiven-junit | 0.9.4 | 0.15.1 | |
| javax.mail:mail | 1.4 | 1.4.7 | 1.5.0-b01 |
| javax.portlet:portlet-api | 2.0 | **2.0** | 3.0.0 |
| javax.servlet.jsp:jsp-api | 2.0 | **2.0** | 2.2.1-b03 |
| javax.servlet:servlet-api | 2.4 | **2.4** | 3.0-alpha-1 |
| javax.servlet:servlet-api | 2.5 | **2.4** | 3.0-alpha-1 |
| junit:junit | 4.11 | 4.12 | |
| org.apache.commons:commons-csv | 1.0 | 1.4 | |
| org.apache.httpcomponents:httpcore | 4.3.3 | 4.4.6 | |
| org.apache.poi:poi | 3.9 | 3.16 | |
| org.apache.poi:poi-ooxml | 3.9 | 3.16 | |
| org.apache.thrift:libthrift | 0.9.3 | 0.9.3 | 0.10.0 |
| org.apache.velocity:velocity | 1.6.2 | 1.7 | |
| org.jetbrains:annotations | 13.0 | 15.0 | |
| org.mockito:mockito-all | 1.10.5 | 1.10.19 | 2.0.2-beta |
| org.slf4j:slf4j-api | 1.7.1 | 1.7.25 | 1.8.0-alpha2 |
| org.slf4j:slf4j-api | 1.7.7 | 1.7.25 | 1.8.0-alpha2 |
| org.slf4j:slf4j-log4j12 | 1.7.1 | 1.7.25 | 1.8.0-alpha2 |
| org.slf4j:slf4j-log4j12 | 1.7.7 | 1.7.25 | 1.8.0-alpha2 |
| org.springframework:spring-beans | 4.1.5.RELEASE | 4.3.8.RELEASE | |
| org.springframework:spring-context | 4.1.5.RELEASE | 4.3.8.RELEASE | |
| org.springframework:spring-webmvc | 4.1.5.RELEASE | 4.3.8.RELEASE | |

## 

to list the dependencies which need an update use
```
mvn versions:display-dependency-updates | grep '\->'  | sed 's/\[INFO\] *//' | sort | uniq
```
to force the update for all dependencies use
```
mvn versions:use-latest-releases
```