### PR TITLE
chore(performance): improve page loading by skipping DB lookups of users

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
@@ -1,12 +1,12 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.sw360.users.db;
+package org.eclipse.sw360.datahandler.db;
 
 import com.google.common.base.Strings;
 import org.eclipse.sw360.components.summary.SummaryType;
@@ -16,6 +16,7 @@ import org.eclipse.sw360.datahandler.couchdb.SummaryAwareRepository;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.ektorp.support.View;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -51,4 +52,8 @@ public class UserRepository extends SummaryAwareRepository<User> {
         return makeSummaryFromFullDocs(SummaryType.SUMMARY, byname);
     }
 
+    @Override
+    public List<User> get(Collection<String> ids) {
+        return getConnector().get(User.class, ids, true);
+    }
 }

--- a/backend/src/src-users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
+++ b/backend/src/src-users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
@@ -9,6 +9,7 @@
 package org.eclipse.sw360.users.db;
 
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
+import org.eclipse.sw360.datahandler.db.UserRepository;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUserEmailCollection.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUserEmailCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -32,9 +32,16 @@ import java.util.List;
 public class DisplayUserEmailCollection extends SimpleTagSupport {
 
     private Collection<String> value;
+    private Boolean bare = false;
+
+    private static final UserService.Iface client = new ThriftClients().makeUserClient();
 
     public void setValue(Collection<String> value) {
         this.value = value;
+    }
+
+    public void setBare(Boolean bare) {
+        this.bare = bare;
     }
 
     public void doTag() throws JspException, IOException {
@@ -44,21 +51,19 @@ public class DisplayUserEmailCollection extends SimpleTagSupport {
 
             List<String> resultList = new ArrayList<>();
 
-            UserService.Iface client = new ThriftClients().makeUserClient();
-
-            if (client != null) {
-
-                for (String email : valueList) {
-                    User user = null;
+            for (String email : valueList) {
+                User user = null;
+                if (!bare) {
                     try {
-                        if (!Strings.isNullOrEmpty(email)) {
+                        if (!Strings.isNullOrEmpty(email) && client != null) {
                             user = client.getByEmail(email);
                         }
                     } catch (TException e) {
                         user = null;
                     }
-                    if (user != null || !Strings.isNullOrEmpty(email))
-                        resultList.add(UserUtils.displayUser(email, user));
+                }
+                if (user != null || !Strings.isNullOrEmpty(email)) {
+                    resultList.add(UserUtils.displayUser(email, user));
                 }
             }
             getJspContext().getOut().print(CommonUtils.COMMA_JOINER.join(resultList));

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUserGroup.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUserGroup.java
@@ -11,7 +11,6 @@ package org.eclipse.sw360.portal.tags;
 import com.google.common.base.Strings;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.portal.users.UserCacheHolder;
-import org.eclipse.sw360.portal.users.UserUtils;
 
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.tagext.SimpleTagSupport;
@@ -20,7 +19,7 @@ import java.io.IOException;
 import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
 
 /**
- * This displays a user's group
+ * This displays a user's group. It makes a DB roundtrip for each invocation. Use with caution!
  *
  * @author alex.borodin@evosoft.com
  */

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
@@ -313,6 +313,12 @@
             <type>java.util.Collection</type>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
+        <attribute>
+            <name>bare</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
     </tag>
     <tag>
         <name>DisplayLink</name>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/vulnerabilities.jspf
@@ -135,8 +135,8 @@
             dataType: 'json',
             data: {"<%=PortalConstants.COMPONENT_ID%>":"${componentId}" },
             success: function(response){
-                displayResponse(response)
-            },
+                displayResponse(response);
+            }
         });
     }
 
@@ -179,7 +179,7 @@
                         break;
                     default:
                 }
-            },
+            }
         });
     }
 

--- a/frontend/sw360-portlet/src/main/webapp/html/ecc/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/ecc/view.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
@@ -90,8 +90,8 @@
                     <sw360:DisplayEnum value="${release.eccInformation.eccStatus}"/></td>
                 <td width="20%"><sw360:DisplayReleaseLink showName="true" release="${release}"/></td>
                 <td width="10%"><sw360:out value="${release.version}"/></td>
-                <td width="10%"><sw360:DisplayUserGroup email="${release.createdBy}"/></td>
-                <td width="20%"><sw360:DisplayUserEmail email="${release.eccInformation.assessorContactPerson}"/></td>
+                <td width="10%"><sw360:out value="${release.creatorDepartment}"/></td>
+                <td width="20%"><sw360:DisplayUserEmail email="${release.eccInformation.assessorContactPerson}" bare="true"/></td>
                 <td width="20%"><sw360:out value="${release.eccInformation.assessorDepartment}"/></td>
                 <td width="10%"><sw360:out value="${release.eccInformation.assessmentDate}"/></td>
             </tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
@@ -130,8 +130,8 @@
             result.push({
                 "DT_RowId": "${moderation.id}",
                 "0": "<sw360:DisplayModerationRequestLink moderationRequest="${moderation}"/>",
-                "1": '<sw360:DisplayUserEmail email="${moderation.requestingUser}"/>',
-                "2": '<sw360:DisplayUserEmailCollection value="${moderation.moderators}"/>',
+                "1": '<sw360:DisplayUserEmail email="${moderation.requestingUser}" bare="true"/>',
+                "2": '<sw360:DisplayUserEmailCollection value="${moderation.moderators}" bare="true"/>',
                 "3": '<sw360:DisplayEnum value="${moderation.moderationState}"/>',
                 "4": 'TODO'
             });
@@ -145,8 +145,8 @@
             result.push({
                 "DT_RowId": "${moderation.id}",
                 "0": "<sw360:DisplayModerationRequestLink moderationRequest="${moderation}"/>",
-                "1": '<sw360:DisplayUserEmail email="${moderation.requestingUser}"/>',
-                "2": '<sw360:DisplayUserEmailCollection value="${moderation.moderators}"/>',
+                "1": '<sw360:DisplayUserEmail email="${moderation.requestingUser}" bare="true"/>',
+                "2": '<sw360:DisplayUserEmailCollection value="${moderation.moderators}" bare="true"/>',
                 "3": '<sw360:DisplayEnum value="${moderation.moderationState}"/>',
                 <core_rt:if test="${isUserAtLeastClearingAdmin == 'Yes'}">
                 "4": "<img src='<%=request.getContextPath()%>/images/Trash.png' onclick=\"deleteModerationRequest('${moderation.id}','<b>${moderation.documentName}</b>')\"  alt='Delete' title='Delete'>"

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/ajax/searchProjectsAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/ajax/searchProjectsAjax.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
@@ -7,17 +7,10 @@
   ~ http://www.eclipse.org/legal/epl-v10.html
   --%>
 
-
-<%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%@include file="/html/init.jsp"%>
-
-
-
 
 <portlet:defineObjects />
 <liferay-theme:defineObjects />
-
-<%@ page import="org.eclipse.sw360.datahandler.thrift.projects.Project" %>
 
 <jsp:useBean id="projectSearch" type="java.util.List<org.eclipse.sw360.datahandler.thrift.projects.Project>" class="java.util.ArrayList" scope="request"/>
 
@@ -26,7 +19,7 @@
         <tr>
             <td><input type="checkbox" name="<portlet:namespace/>projectId" value="${entry.id}"></td>
             <td><sw360:ProjectName project="${entry}"/></td>
-            <td><sw360:DisplayUserEmail email="${entry.projectResponsible}"/></td>
+            <td><sw360:DisplayUserEmail email="${entry.projectResponsible}" bare="true"/></td>
             <td><sw360:out value="${entry.description}"/></td>
         </tr>
     </core_rt:forEach>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
@@ -1,3 +1,13 @@
+<%--
+  ~ Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
+  ~ Copyright Bosch Software Innovations GmbH, 2017.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+--%>
+
 <table class="table info_table" id="LinkedProjectsInfo" title="Linked Releases And Projects" style="table-layout: auto">
     <thead>
     <tr>
@@ -92,7 +102,7 @@
                     </td>
                     <td>
                     <td>
-                        <sw360:DisplayUserEmail email="${attachment.createdBy}"/>
+                        <sw360:DisplayUserEmail email="${attachment.createdBy}" bare="true"/>
                     </td>
                     <td>
                         <sw360:out value="${attachment.createdTeam}"/>

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/usingProjectsTable.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/usingProjectsTable.jspf
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~ With contributions by Bosch Software Innovations GmbH, 2016.
   ~
   ~ All rights reserved. This program and the accompanying materials
@@ -29,7 +29,7 @@
                     <sw360:out value="${project.businessUnit}"/>
                 </td>
                 <td>
-                    <sw360:DisplayUserEmail email="${project.projectResponsible}"/>
+                    <sw360:DisplayUserEmail email="${project.projectResponsible}" bare="true"/>
                 </td>
             </tr>
         </core_rt:forEach>

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -142,7 +142,7 @@ public class DatabaseConnector extends StdCouchDbConnector {
     /**
      * Get a list of documents from their IDs. All documents should be of the same type.
      */
-    public <T> List<T> get(Class<T> type, Collection<String> ids) {
+    public <T> List<T> get(Class<T> type, Collection<String> ids, boolean ignoreNotFound) {
         if (ids == null) return Collections.emptyList();
 
         // Copy to set in order to avoid duplicates
@@ -152,8 +152,13 @@ public class DatabaseConnector extends StdCouchDbConnector {
                 .allDocs()
                 .includeDocs(true)
                 .keys(idSet);
+        q.setIgnoreNotFound(ignoreNotFound);
 
         return queryView(q, type);
+    }
+
+    public <T> List<T> get(Class<T> type, Collection<String> ids) {
+        return get(type, ids, false);
     }
 
     @Override

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseRepository.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -28,6 +28,10 @@ public class DatabaseRepository<T> extends CouchDbRepositorySupport<T> {
 
     private final Class<T> type;
     private final DatabaseConnector connector;
+
+    protected DatabaseConnector getConnector(){
+        return connector;
+    }
 
     public static Set<String> getIds(ViewResult rows) {
         HashSet<String> ids = new HashSet<>();

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -201,6 +201,7 @@ public class ThriftValidate {
         // Unset optionals
         release.unsetPermissions();
         release.unsetVendor();
+        release.unsetCreatorDepartment();
     }
 
     public static Release ensureEccInformationIsSet(Release release) {

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -187,6 +187,7 @@ struct Release {
 
     // string details
     30: optional string createdBy, // person who created the release
+    131: optional string creatorDepartment, // department of user in `createdBy`. transient
     32: optional set<string> contributors, // contributors to the release
     34: optional set<string> moderators, // people who can modify the data
     36: optional set<string> subscribers, // List of subscribers


### PR DESCRIPTION
- skip looking up real names where many roundtrips are expected
- drop usage of DisplayUserGroup for ECC overview and preload creators' departments to releases instead