### PR TITLE
fix(export): improve performance of spreadsheet export and fix simultaneous exports

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ProjectSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ProjectSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -44,17 +44,8 @@ public class ProjectSummary extends DocumentSummary<Project> {
     }
 
     protected static void setSummaryFields(Project document, Project copy) {
-
         for (_Fields field : Project.metaDataMap.keySet()) {
-            switch (field) {
-                case RELEASE_IDS:
-                    if (document.isSetReleaseIdToUsage()) {
-                        copy.setReleaseIds(document.releaseIdToUsage.keySet());
-                    }
-                    break;
-                default:
-                    copyField(document, copy, field);
-            }
+            copyField(document, copy, field);
         }
     }
 

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -391,13 +391,7 @@ public class ProjectDatabaseHandler {
     }
 
     public List<Project> fillClearingStateSummary(List<Project> projects, User user) {
-        Function<Project, Set<String>> extractReleaseIds = project -> {
-            if (project.isSetReleaseIds()) {
-                return project.getReleaseIds();
-            } else {
-                return CommonUtils.nullToEmptyMap(project.getReleaseIdToUsage()).keySet();
-            }
-        };
+        Function<Project, Set<String>> extractReleaseIds = project -> CommonUtils.nullToEmptyMap(project.getReleaseIdToUsage()).keySet();
 
         Set<String> allReleaseIds = projects.stream().map(extractReleaseIds).reduce(Sets.newHashSet(), Sets::union);
         if (!allReleaseIds.isEmpty()) {

--- a/backend/src-common/src/test/java/org/eclipse/sw360/components/summary/ProjectSummaryTest.java
+++ b/backend/src-common/src/test/java/org/eclipse/sw360/components/summary/ProjectSummaryTest.java
@@ -34,9 +34,6 @@ public class ProjectSummaryTest {
                 case STATE:
                     project.state = ProjectState.ACTIVE;
                     break;
-                case RELEASE_IDS:
-                    project.releaseIds = ImmutableSet.of("2","3");
-                    break;
                 case PERMISSIONS:
                     project.permissions = Collections.emptyMap();
                     break;

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ProjectModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ProjectModerationRequestGenerator.java
@@ -47,7 +47,6 @@ public class ProjectModerationRequestGenerator extends ModerationRequestGenerato
                     //ignored fields and concluded fields
                     case PERMISSIONS:
                     case DOCUMENT_STATE:
-                    case RELEASE_IDS:
                     case RELEASE_CLEARING_STATE_SUMMARY:
                         break;
                     case ATTACHMENTS:

--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -52,9 +52,7 @@ public class ProjectHandler implements ProjectService.Iface {
 
     @Override
     public List<Project> refineSearch(String text, Map<String, Set<String>> subQueryRestrictions,User user) throws TException {
-        List<Project> foundProjects = searchHandler.search(text, subQueryRestrictions, user);
-        foundProjects.forEach(p -> p.releaseIds = p.isSetReleaseIdToUsage() ? p.releaseIdToUsage.keySet() : Collections.EMPTY_SET);
-        return foundProjects;
+        return searchHandler.search(text, subQueryRestrictions, user);
     }
 
     @Override

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -233,7 +233,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
         try {
             boolean extendedByReleases = Boolean.valueOf(request.getParameter(PortalConstants.EXTENDED_EXCEL_EXPORT));
             List<Component> components = getFilteredComponentList(request);
-            ComponentExporter exporter = new ComponentExporter(thriftClients.makeComponentClient(), extendedByReleases);
+            ComponentExporter exporter = new ComponentExporter(thriftClients.makeComponentClient(), components, extendedByReleases);
             PortletResponseUtil.sendFile(request, response, "Components.xlsx", exporter.makeExcelExport(components),
                     CONTENT_TYPE_OPENXML_SPREADSHEET);
         } catch (IOException | SW360Exception e) {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -267,6 +267,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                     thriftClients.makeComponentClient(),
                     thriftClients.makeProjectClient(),
                     user,
+                    projects,
                     extendedByReleases);
             PortletResponseUtil.sendFile(request, response, "Projects.xlsx", exporter.makeExcelExport(projects), CONTENT_TYPE_OPENXML_SPREADSHEET);
         } catch (IOException | SW360Exception e) {
@@ -287,7 +288,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             if (project != null) {
                 Map<Release, ProjectNamesWithMainlineStatesTuple> releaseStringMap = getProjectsNamesWithMainlineStatesByRelease(id, user);
                 List<Release> releases = releaseStringMap.keySet().stream().sorted(Comparator.comparing(SW360Utils::printFullname)).collect(Collectors.toList());
-                ReleaseExporter exporter = new ReleaseExporter(thriftClients.makeComponentClient());
+                ReleaseExporter exporter = new ReleaseExporter(thriftClients.makeComponentClient(), releases);
                 PortletResponseUtil.sendFile(request, response,
                         String.format("releases-%s-%s-%s.xlsx", project.getName(), project.getVersion(), SW360Utils.getCreatedOn()),
                         exporter.makeExcelExport(releases), CONTENT_TYPE_OPENXML_SPREADSHEET);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayProjectChanges.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayProjectChanges.java
@@ -86,7 +86,6 @@ public class DisplayProjectChanges extends NameSpaceAwareTag {
                     case CREATED_ON:
                     case PERMISSIONS:
                     case RELEASE_CLEARING_STATE_SUMMARY:
-                    case RELEASE_IDS:
                     case DOCUMENT_STATE:
                         //Taken care of externally
                     case ATTACHMENTS:

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentHelper.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.exporter;
+
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+
+import java.util.*;
+
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
+import static org.eclipse.sw360.datahandler.common.SW360Utils.fieldValueAsString;
+import static org.eclipse.sw360.datahandler.common.SW360Utils.getReleaseNames;
+import static org.eclipse.sw360.exporter.ComponentExporter.*;
+
+class ComponentHelper implements ExporterHelper<Component> {
+
+    private ReleaseHelper releaseHelper;
+    private boolean extendedByReleases;
+
+    ComponentHelper(boolean extendedByReleases, ReleaseHelper releaseHelper) {
+        this.extendedByReleases = extendedByReleases;
+        this.releaseHelper = releaseHelper;
+    }
+
+    @Override
+    public int getColumns() {
+        return getHeaders().size();
+    }
+
+    @Override
+    public List<String> getHeaders() {
+        return extendedByReleases ? HEADERS_EXTENDED_BY_RELEASES : HEADERS;
+    }
+
+    @Override
+    public SubTable makeRows(Component component) throws SW360Exception {
+        return extendedByReleases ? makeRowsWithReleases(component) : makeRowForComponentOnly(component);
+    }
+
+    private SubTable makeRowsWithReleases(Component component) throws SW360Exception {
+        List<Release> releases = getReleases(component);
+        SubTable table = new SubTable();
+
+        if (releases.size() > 0) {
+            for (Release release : releases) {
+                List<String> currentRow = makeRowForComponent(component);
+                currentRow.addAll(releaseHelper.makeRows(release).elements.get(0));
+                table.addRow(currentRow);
+            }
+        } else {
+            List<String> componentRowWithEmptyReleaseFields = makeRowForComponent(component);
+            for (int i = 0; i < releaseHelper.getColumns(); i++) {
+                componentRowWithEmptyReleaseFields.add("");
+            }
+            table.addRow(componentRowWithEmptyReleaseFields);
+        }
+        return table;
+    }
+
+    private List<String> makeRowForComponent(Component component) throws SW360Exception {
+        if (!component.isSetAttachments()) {
+            component.setAttachments(Collections.EMPTY_SET);
+        }
+        List<String> row = new ArrayList<>(getColumns());
+        for (Component._Fields renderedField : COMPONENT_RENDERED_FIELDS) {
+            addFieldValueToRow(row, renderedField, component);
+        }
+        return row;
+    }
+
+    private void addFieldValueToRow(List<String> row, Component._Fields field, Component component) throws SW360Exception {
+        if (component.isSet(field)) {
+            Object fieldValue = component.getFieldValue(field);
+            switch (field) {
+                case RELEASE_IDS:
+                    row.add(fieldValueAsString(getReleaseNames(getReleases(component))));
+                    break;
+                case ATTACHMENTS:
+                    row.add(component.attachments.size() + "");
+                    break;
+                default:
+                    row.add(fieldValueAsString(fieldValue));
+            }
+        } else {
+            row.add("");
+        }
+    }
+
+    private SubTable makeRowForComponentOnly(Component component) throws SW360Exception {
+        return new SubTable(makeRowForComponent(component));
+    }
+
+    private List<Release> getReleases(Component component) throws SW360Exception {
+        return getReleases(nullToEmptySet(component.releaseIds));
+    }
+
+    List<Release> getReleases(Set<String> ids) throws SW360Exception {
+        return releaseHelper.getReleases(ids);
+    }
+
+    public void setPreloadedLinkedReleases(Map<String, Release> preloadedLinkedReleases) {
+        releaseHelper.setPreloadedLinkedReleases(preloadedLinkedReleases);
+    }
+}

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExporterHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExporterHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,9 +9,11 @@
 
 package org.eclipse.sw360.exporter;
 
+import com.google.common.collect.Lists;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Created by bodet on 06/02/15.
@@ -20,10 +22,20 @@ import java.util.List;
  */
 public interface ExporterHelper<T> {
 
-    public int getColumns();
+    static List<String> addSubheadersWithPrefixesAsNeeded(List<String> headers, List<String> subheaders, String prefix) {
+        List<String> prefixedSubheaders = subheaders
+                .stream()
+                .map(h -> headers.contains(h) ? prefix + h : h)
+                .collect(Collectors.toList());
+        List<String> copy = Lists.newArrayList(headers);
+        copy.addAll(prefixedSubheaders);
+        return copy;
+    }
 
-    public List<String> getHeaders();
+    int getColumns();
 
-    public SubTable makeRows(T document) throws SW360Exception;
+    List<String> getHeaders();
+
+    SubTable makeRows(T document) throws SW360Exception;
 
 }

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/LicenseExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/LicenseExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
  * All rights reserved. This program and the accompanying materials
@@ -26,14 +26,14 @@ import static org.eclipse.sw360.commonIO.ConvertRecord.licenseSerializer;
  *
  * @author cedric.bodet@tngtech.com
  */
-public class LicenseExporter extends ExcelExporter<License> {
+public class LicenseExporter extends ExcelExporter<License, LicenseExporter.LicenseHelper> {
     private static final Logger log = Logger.getLogger(LicenseExporter.class);
 
     public LicenseExporter(Function<Logger, List<LicenseType>> getLicenseTypes) {
         super(new LicenseHelper(() -> getLicenseTypes.apply(log)));
     }
 
-    private static class LicenseHelper implements ExporterHelper<License> {
+    static class LicenseHelper implements ExporterHelper<License> {
         private final ConvertRecord.Serializer<License> converter;
         private Supplier<List<LicenseType>> getLicenseTypes;
         private HashMap<String, String> formattedStringToTypeId = new HashMap<>();

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectHelper.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
+ * With modifications by Bosch Software Innovations GmbH, 2016.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.exporter;
+
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyMap;
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
+import static org.eclipse.sw360.datahandler.common.SW360Utils.*;
+import static org.eclipse.sw360.exporter.ProjectExporter.*;
+
+class ProjectHelper implements ExporterHelper<Project> {
+
+    private final ProjectService.Iface projectClient;
+    private final User user;
+    private boolean extendedByReleases;
+    private ReleaseHelper releaseHelper;
+    private Map<String, Project> preloadedLinkedProjects;
+
+    ProjectHelper(ProjectService.Iface projectClient, User user, boolean extendedByReleases, ReleaseHelper releaseHelper) {
+        this.projectClient = projectClient;
+        this.user = user;
+        this.extendedByReleases = extendedByReleases;
+        this.releaseHelper = releaseHelper;
+    }
+
+    @Override
+    public int getColumns() {
+        return getHeaders().size();
+    }
+
+    @Override
+    public List<String> getHeaders() {
+        return extendedByReleases ? HEADERS_EXTENDED_BY_RELEASES : HEADERS;
+    }
+
+    @Override
+    public SubTable makeRows(Project project) throws SW360Exception {
+        return extendedByReleases ? makeRowsWithReleases(project) : makeRowForProjectOnly(project);
+    }
+
+    private SubTable makeRowsWithReleases(Project project) throws SW360Exception {
+        List<Release> releases = getReleases(project);
+        SubTable table = new SubTable();
+
+        if (releases.size() > 0) {
+            for (Release release : releases) {
+                List<String> currentRow = makeRowForProject(project);
+                currentRow.addAll(releaseHelper.makeRows(release).elements.get(0));
+                table.addRow(currentRow);
+            }
+        } else {
+            List<String> projectRowWithEmptyReleaseFields = makeRowForProject(project);
+            for (int i = 0; i < releaseHelper.getColumns(); i++) {
+                projectRowWithEmptyReleaseFields.add("");
+            }
+            table.addRow(projectRowWithEmptyReleaseFields);
+        }
+        return table;
+    }
+
+    private List<String> makeRowForProject(Project project) throws SW360Exception {
+        if (!project.isSetAttachments()) {
+            project.setAttachments(Collections.EMPTY_SET);
+        }
+        List<String> row = new ArrayList<>(getColumns());
+        for (Project._Fields renderedField : PROJECT_RENDERED_FIELDS) {
+            addFieldValueToRow(row, renderedField, project);
+        }
+
+        return row;
+    }
+
+    private void addFieldValueToRow(List<String> row, Project._Fields field, Project project) throws SW360Exception {
+        if (project.isSet(field)) {
+            Object fieldValue = project.getFieldValue(field);
+            switch (field) {
+                case RELEASE_ID_TO_USAGE:
+                    row.add(fieldValueAsString(putReleaseNamesInMap(project.releaseIdToUsage, getReleases(project))));
+                    break;
+                case LINKED_PROJECTS:
+                    row.add(fieldValueAsString(putProjectNamesInMap(project.getLinkedProjects(), getProjects(project
+                            .getLinkedProjects()
+                            .keySet(), user))));
+                    break;
+                case ATTACHMENTS:
+                    row.add(project.attachments.size() + "");
+                    break;
+                default:
+                    row.add(fieldValueAsString(fieldValue));
+            }
+        } else {
+            row.add("");
+        }
+    }
+
+    private SubTable makeRowForProjectOnly(Project project) throws SW360Exception {
+        return new SubTable(makeRowForProject(project));
+    }
+
+    public void setPreloadedLinkedReleases(Map<String, Release> preloadedLinkedReleases) {
+        releaseHelper.setPreloadedLinkedReleases(preloadedLinkedReleases);
+    }
+
+    List<Release> getReleases(Project project) throws SW360Exception {
+        return getReleases(nullToEmptyMap(project.getReleaseIdToUsage()).keySet());
+    }
+    List<Release> getReleases(Set<String> ids) throws SW360Exception {
+        return releaseHelper.getReleases(ids);
+    }
+
+    List<Project> getProjects(Set<String> ids, User user) throws SW360Exception {
+        if (preloadedLinkedProjects != null) {
+            return getPreloadedProjects(ids);
+        }
+        List<Project> projects;
+        try {
+            projects = projectClient.getProjectsById(new ArrayList<>(ids), user);
+        } catch (TException e) {
+            throw new SW360Exception("Error fetching linked projects");
+        }
+        return projects;
+    }
+
+    private List<Project> getPreloadedProjects(Set<String> ids) {
+        return ids.stream().map(preloadedLinkedProjects::get).filter(Objects::nonNull).collect(Collectors.toList());
+    }
+
+    void setPreloadedLinkedProjects(Map<String, Project> preloadedLinkedProjects) {
+        this.preloadedLinkedProjects = preloadedLinkedProjects;
+    }
+}

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseHelper.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.exporter;
+
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.UncheckedSW360Exception;
+import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.components.*;
+import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
+import static org.eclipse.sw360.datahandler.common.SW360Utils.fieldValueAsString;
+import static org.eclipse.sw360.datahandler.common.SW360Utils.putReleaseNamesInMap;
+import static org.eclipse.sw360.exporter.ReleaseExporter.*;
+
+class ReleaseHelper implements ExporterHelper<Release> {
+    private final ComponentService.Iface client;
+
+    private Map<String, Release> preloadedLinkedReleases = null;
+
+    protected ReleaseHelper(ComponentService.Iface client) {
+        this.client = client;
+    }
+
+
+
+    @Override
+    public int getColumns() {
+        return getHeaders().size();
+    }
+
+    @Override
+    public List<String> getHeaders() {
+        return HEADERS;
+    }
+
+    @Override
+    public SubTable makeRows(Release release) throws SW360Exception {
+        if (!release.isSetAttachments()) {
+            release.setAttachments(Collections.emptySet());
+        }
+        List<String> row = new ArrayList<>();
+        for (Release._Fields renderedField : RELEASE_RENDERED_FIELDS) {
+            addFieldValueToRow(row, renderedField, release);
+        }
+        return new SubTable(row);
+    }
+
+    private void addFieldValueToRow(List<String> row, Release._Fields field, Release release) throws SW360Exception {
+        switch (field) {
+            case VENDOR:
+                addVendorToRow(release.getVendor(), row);
+                break;
+            case COTS_DETAILS:
+                addCotsDetailsToRow(release.getCotsDetails(), row);
+                break;
+            case CLEARING_INFORMATION:
+                addClearingInformationToRow(release.getClearingInformation(), row);
+                break;
+            case ECC_INFORMATION:
+                addEccInformationToRow(release.getEccInformation(), row);
+                break;
+            case RELEASE_ID_TO_RELATIONSHIP:
+                addReleaseIdToRelationShipToRow(release.getReleaseIdToRelationship(), row);
+                break;
+            case ATTACHMENTS:
+                row.add(release.attachments.size() + "");
+                break;
+            default:
+                Object fieldValue = release.getFieldValue(field);
+                row.add(fieldValueAsString(fieldValue));
+        }
+    }
+
+    private void addVendorToRow(Vendor vendor, List<String> row) throws SW360Exception {
+        try {
+            Vendor.metaDataMap
+                    .keySet()
+                    .stream()
+                    .filter(f -> !VENDOR_IGNORED_FIELDS.contains(f))
+                    .forEach(f -> {
+                        if (vendor != null && vendor.isSet(f)) {
+                            try {
+                                row.add(fieldValueAsString(vendor.getFieldValue(f)));
+                            } catch (SW360Exception e) {
+                                throw new UncheckedSW360Exception(e);
+                            }
+                        } else {
+                            row.add("");
+                        }
+                    });
+        } catch (UncheckedSW360Exception e) {
+            throw e.getSW360ExceptionCause();
+        }
+
+    }
+
+    private void addCotsDetailsToRow(COTSDetails cotsDetails, List<String> row) throws SW360Exception {
+        try {
+            COTSDetails.metaDataMap.keySet().forEach(f -> {
+                if (cotsDetails != null && cotsDetails.isSet(f)) {
+                    try {
+                        row.add(fieldValueAsString(cotsDetails.getFieldValue(f)));
+                    } catch (SW360Exception e) {
+                        throw new UncheckedSW360Exception(e);
+                    }
+                } else {
+                    row.add("");
+                }
+            });
+        } catch (UncheckedSW360Exception e) {
+            throw e.getSW360ExceptionCause();
+        }
+    }
+
+    private void addClearingInformationToRow(ClearingInformation clearingInformation, List<String> row) throws SW360Exception {
+        try {
+            ClearingInformation.metaDataMap.keySet().forEach(f -> {
+                if (clearingInformation != null && clearingInformation.isSet(f)) {
+                    try {
+                        row.add(fieldValueAsString(clearingInformation.getFieldValue(f)));
+                    } catch (SW360Exception e) {
+                        throw new UncheckedSW360Exception(e);
+                    }
+                } else {
+                    row.add("");
+                }
+            });
+        } catch (UncheckedSW360Exception e) {
+            throw e.getSW360ExceptionCause();
+        }
+    }
+
+    private void addEccInformationToRow(EccInformation eccInformation, List<String> row) throws SW360Exception {
+        try {
+            EccInformation.metaDataMap.keySet().forEach(f -> {
+                if (eccInformation != null && eccInformation.isSet(f)) {
+                    try {
+                        row.add(fieldValueAsString(eccInformation.getFieldValue(f)));
+                    } catch (SW360Exception e) {
+                        throw new UncheckedSW360Exception(e);
+                    }
+                } else {
+                    row.add("");
+                }
+            });
+        } catch (UncheckedSW360Exception e) {
+            throw e.getSW360ExceptionCause();
+        }
+    }
+
+    private void addReleaseIdToRelationShipToRow(Map<String, ReleaseRelationship> releaseIdToRelationship, List<String> row) throws SW360Exception {
+        if (releaseIdToRelationship != null) {
+            row.add(fieldValueAsString(putReleaseNamesInMap(releaseIdToRelationship, getReleases(releaseIdToRelationship
+                    .keySet()))));
+        } else {
+            row.add("");
+        }
+    }
+
+    public void setPreloadedLinkedReleases(Map<String, Release> preloadedLinkedReleases) {
+        this.preloadedLinkedReleases = preloadedLinkedReleases;
+    }
+
+    List<Release> getReleases(Set<String> ids) throws SW360Exception {
+        if (preloadedLinkedReleases != null){
+            return getPreloadedReleases(ids);
+        }
+        List<Release> releasesByIdsForExport;
+        try {
+            releasesByIdsForExport = client.getReleasesByIdsForExport(nullToEmptySet(ids));
+        } catch (TException e) {
+            throw new SW360Exception("Error fetching release information");
+        }
+        return releasesByIdsForExport;
+    }
+
+    private List<Release> getPreloadedReleases(Set<String> ids) {
+        return ids.stream().map(preloadedLinkedReleases::get).filter(Objects::nonNull).collect(Collectors.toList());
+    }
+}

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/VendorExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/VendorExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -24,7 +24,7 @@ import static org.eclipse.sw360.datahandler.thrift.vendors.Vendor._Fields.*;
  *
  * @author Johannes.Najjar@tngtech.com
  */
-public class VendorExporter  extends  ExcelExporter<Vendor>{
+public class VendorExporter  extends  ExcelExporter<Vendor, VendorExporter.VendorHelper>{
 
     public static final List<Vendor._Fields> RENDERED_FIELDS = ImmutableList.<Vendor._Fields>builder()
             .add(FULLNAME)
@@ -42,7 +42,7 @@ public class VendorExporter  extends  ExcelExporter<Vendor>{
         super(new VendorHelper());
     }
 
-    private static class VendorHelper implements ExporterHelper<Vendor> {
+    static class VendorHelper implements ExporterHelper<Vendor> {
 
         @Override
         public int getColumns() {

--- a/libraries/exporters/src/test/java/org/eclipse/sw360/exporter/ProjectExporterTest.java
+++ b/libraries/exporters/src/test/java/org/eclipse/sw360/exporter/ProjectExporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,7 +12,11 @@ import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -20,6 +24,7 @@ import static org.junit.Assert.assertThat;
 /**
  * Created by heydenrb on 06.11.15.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class ProjectExporterTest {
     @Mock
     ComponentService.Iface componentClient;
@@ -33,7 +38,7 @@ public class ProjectExporterTest {
     @Test
     public void testEveryRenderedProjectFieldHasAHeader() throws Exception {
         ProjectExporter exporter = new ProjectExporter(componentClient,
-                projectClient, user, false);
-        assertThat(exporter.PROJECT_RENDERED_FIELDS.size(), is(exporter.HEADERS.size()));
+                projectClient, user, Collections.emptyList(), false);
+        assertThat(ProjectExporter.PROJECT_RENDERED_FIELDS.size(), is(ProjectExporter.HEADERS.size()));
     }
 }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
@@ -246,7 +246,6 @@ public class ThriftValidate {
 
         // Unset temporary fields
         project.unsetPermissions();
-        project.unsetReleaseIds();
         project.unsetReleaseClearingStateSummary();
     }
 

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -114,7 +114,7 @@ struct Project {
     70: optional DocumentState documentState,
 
     // Optional fields for summaries!
-    100: optional set<string> releaseIds,
+//    100: optional set<string> releaseIds, //deleted
     101: optional ReleaseClearingStateSummary releaseClearingStateSummary,
 
     200: optional map<RequestedAction, bool> permissions,


### PR DESCRIPTION
- use streaming poi api to improve performance of spreadsheet export with many documents
- preload related data in ExcelExporters to reduce roundtrips to DB
- enable simultaneous parallel exports (they were mangled by usage of static fields)
- delete unused field Project.releaseIds

closes #422