### PR TITLE
fix(travis): add missing test explicitly to matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ script: mvn --fail-at-end $MVN_ARGS
 
 matrix:
   include:
+    - env: MVN_ARGS="package"
     - env: MVN_ARGS="validate"
       before_install:
     - env: MVN_ARGS="dependency:analyze -DfailOnWarning"


### PR DESCRIPTION
The pull request https://github.com/sw360/sw360portal/pull/415 has modified the travis configuration to run multiple tests (see https://travis-ci.org/sw360/sw360portal/builds/236344373). But currently only two of them (`validate` and `dependency:analyze`) are called.

This PR should fix that.