### PR TITLE
fix(utils): handle empty resourceFilePath in CommonUtils.loadResource()

### DIFF
--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
@@ -14,7 +14,6 @@ import com.google.common.base.*;
 import com.google.common.collect.*;
 import org.eclipse.sw360.datahandler.thrift.*;
 import org.eclipse.sw360.datahandler.thrift.attachments.*;
-import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.licenses.Todo;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
@@ -513,6 +512,9 @@ public class CommonUtils {
     }
 
     public static Optional<byte[]> loadResource(Class<?> clazz, String resourceFilePath, boolean useSystemResourses) {
+        if (isNullOrEmpty(resourceFilePath)){
+            return Optional.empty();
+        }
         if(useSystemResourses) {
             File systemResourceFile = new File(SYSTEM_CONFIGURATION_PATH, resourceFilePath);
             if(systemResourceFile.exists()){


### PR DESCRIPTION
CommonUtils.loadResource returns an `Optional` with empty byte array when the resourceFilePath is an empty string, because the resulting filename to be read happens to be the `/etc/sw360` folder). Instead, it should return an empty `Optional`.