### PR TITLE
fix(migrations): do not add scripts to docker image

### DIFF
--- a/scripts/migrations/dockerized-migration-runner.Dockerfile
+++ b/scripts/migrations/dockerized-migration-runner.Dockerfile
@@ -20,4 +20,3 @@ RUN set -x \
 
 RUN mkdir -p /migrations
 WORKDIR /migrations
-ADD ./ /migrations

--- a/scripts/migrations/dockerized-migration-runner.sh
+++ b/scripts/migrations/dockerized-migration-runner.sh
@@ -20,8 +20,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # build docker image for migration
 docker build -t sw360/migration-runner \
        --rm=true --force-rm=true \
-       -f ./dockerized-migration-runner.Dockerfile \
-       .
+       - < ./dockerized-migration-runner.Dockerfile
 
 for scriptpath in "$@"; do
     scriptname="$(basename $scriptpath)"
@@ -31,6 +30,8 @@ for scriptpath in "$@"; do
     fi
 
     # run docker image
-    docker run -it --net=host sw360/migration-runner \
+    docker run -it --net=host \
+           -v "$(pwd)":/migrations \
+           sw360/migration-runner \
            "./$scriptname"
 done

--- a/scripts/migrations/dockerized-migration-runner.sh
+++ b/scripts/migrations/dockerized-migration-runner.sh
@@ -9,18 +9,33 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 # call as:
-# ./dockerized-migration-runner.sh migrationScript [migrationScript [...]]
+# $ ./dockerized-migration-runner.sh [--build|--save|--load] [migrationScript [migrationScript [...]]]
+#   where
+#     --build   implies that the docker image gets build
+#     --save    implies that the generated docker image gets saved to "migration-runner.tar"
+#     --load    implies that the generated image gets loaded from the tar
 # e.g.:
-# ./dockerized-migration-runner.sh 003_rename_release_contacts_to_contributors.py 004_move_release_ecc_fields_to_release_information.py
+# $ ./dockerized-migration-runner.sh --build
+# $ ./dockerized-migration-runner.sh 003_rename_release_contacts_to_contributors.py 004_move_release_ecc_fields_to_release_information.py
 
 set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# build docker image for migration
-docker build -t sw360/migration-runner \
-       --rm=true --force-rm=true \
-       - < ./dockerized-migration-runner.Dockerfile
+case "$1" in
+    "--build" )
+        echo "build docker image for migration"
+        docker build -t sw360/migration-runner \
+               --rm=true --force-rm=true \
+               - < ./dockerized-migration-runner.Dockerfile
+        shift ;;
+    "--save" )
+        docker save -o "migration-runner.tar" "sw360/migration-runner"
+        exit 0 ;;
+    "--load" )
+        docker load -i "migration-runner.tar"
+        shift ;;
+esac
 
 for scriptpath in "$@"; do
     scriptname="$(basename $scriptpath)"


### PR DESCRIPTION
Currently the migration scripts are hard-wired into the docker image related to the dockerized-migration-runner. This changes it to mount the folder with all the scripts as volume.

Now, one does not have to recreate the docker image, if the scripts have changed.