### PR TITLE
chore(repositories): refactor and cleanup CouchDB Repositories

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
@@ -48,20 +48,20 @@ public class ComponentSummary extends DocumentSummary<Component> {
 
         Component copy = new Component();
         if (type == SummaryType.EXPORT_SUMMARY) {
-            ImmutableListMultimap<String, Release> fullReleases = releaseRepository.getFullReleases();
-            return makeExportSummary(document, fullReleases);
+            List<Release> releases = releaseRepository.getReleasesFromComponentId(document.getId());
+            return makeExportSummary(document, releases);
         } else if (type == SummaryType.DETAILED_EXPORT_SUMMARY) {
-            ImmutableListMultimap<String, Release> fullReleases = releaseRepository.getFullReleases();
+            List<Release> releases = releaseRepository.getReleasesFromComponentId(document.getId());
 
             final Map<String, Vendor> vendorsById = ThriftUtils.getIdMap(vendorRepository.getAll());
 
-            for (Release release : fullReleases.values()) {
+            for (Release release : releases) {
                 if (!release.isSetVendor() && release.isSetVendorId()) {
                     release.setVendor(vendorsById.get(release.getVendorId()));
                 }
             }
 
-            return makeDetailedExportSummary(document, fullReleases);
+            return makeDetailedExportSummary(document, releases);
         } else if (type == SummaryType.HOME) {
             copyField(document, copy, Component._Fields.ID);
             copyField(document, copy, Component._Fields.DESCRIPTION);
@@ -81,15 +81,14 @@ public class ComponentSummary extends DocumentSummary<Component> {
         return copy;
     }
 
-    private Component makeDetailedExportSummary(Component document, ImmutableListMultimap<String, Release> fullReleases) {
+    private Component makeDetailedExportSummary(Component document, List<Release> releases) {
 
-        final ImmutableList<Release> releases = fullReleases.get(document.getId());
         document.setReleases(releases);
 
         return document;
     }
 
-    private Component makeExportSummary(Component document, ImmutableListMultimap<String, Release> fullReleases) {
+    private Component makeExportSummary(Component document, List<Release> releases) {
 
         if (releaseRepository == null) {
             throw new IllegalStateException("Cannot make export summary without database connection!");
@@ -106,8 +105,6 @@ public class ComponentSummary extends DocumentSummary<Component> {
         copyField(document, copy, Component._Fields.CREATED_ON);
         copyField(document, copy, Component._Fields.VENDOR_NAMES);
 
-
-        final ImmutableList<Release> releases = fullReleases.get(document.getId());
 
         for (Release release : releases) {
             Release exportRelease = new Release();

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -195,10 +195,9 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
     }
 
     public List<Component> getMyComponents(String user) {
-        //This call could be sped up, because we want the full documents
-        Set<String> myComponentIds = componentRepository.getMyComponentIds(user);
+        Collection<Component> myComponents = componentRepository.getMyComponents(user);
 
-        return componentRepository.makeSummary(SummaryType.HOME, myComponentIds);
+        return componentRepository.makeSummaryFromFullDocs(SummaryType.HOME, myComponents);
     }
 
     public List<Component> getSummaryForExport() {
@@ -335,7 +334,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
     }
 
     private boolean isDuplicate(Component component){
-        Set<String> duplicates = componentRepository.getMyComponentIdsByName(component.getName());
+        Set<String> duplicates = componentRepository.getComponentIdsByName(component.getName());
         return duplicates.size()>0;
     }
 
@@ -1118,7 +1117,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
     public Map<String, List<String>> getDuplicateReleases() {
         ListMultimap<String, String> releaseIdentifierToReleaseId = ArrayListMultimap.create();
 
-        for (Release release : releaseRepository.getAll()) {
+        for (Release release : getAllReleases()) {
             releaseIdentifierToReleaseId.put(SW360Utils.printName(release), release.getId());
         }
 
@@ -1138,7 +1137,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
     public Map<String,List<String>> getDuplicateReleaseSources() {
         ListMultimap<String, String> releaseIdentifierToReleaseId = ArrayListMultimap.create();
 
-        for (Release release : releaseRepository.getAll()) {
+        for (Release release : getAllReleases()) {
 
             if(release.isSetAttachments()) {
                 for (Attachment attachment : release.getAttachments()) {

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -852,8 +852,12 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return getLinkedReleases(relations, releaseMap, new ArrayDeque<>());
     }
 
+    public List<Release> getAllReleases() {
+        return releaseRepository.getAll();
+    }
+
     public Map<String, Release> getAllReleasesIdMap() {
-        final List<Release> releases = releaseRepository.getAll();
+        final List<Release> releases = getAllReleases();
         return ThriftUtils.getIdMap(releases);
     }
 
@@ -906,16 +910,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     @NotNull
     private ReleaseLink createReleaseLink(Release release) {
-        String vendorName = "";
-        if (release.isSetVendor()){
-            vendorName = release.getVendor().getShortname();
-        } else if (!isNullOrEmpty(release.getVendorId())) {
-            final Vendor vendor = vendorRepository.get(release.getVendorId());
-            vendorName = vendor != null ? vendor.getShortname() : "";
-            release.setVendor(vendor);
-        }
+        vendorRepository.fillVendor(release);
+        String vendorName = release.isSetVendor() ? release.getVendor().getShortname() : "";
         ReleaseLink releaseLink = new ReleaseLink(release.id, vendorName, release.name, release.version, SW360Utils.printFullname(release),
-                !nullToEmptyMap(release.getReleaseIdToRelationship()).isEmpty());
+                 !nullToEmptyMap(release.getReleaseIdToRelationship()).isEmpty());
         releaseLink
                 .setClearingState(release.getClearingState())
                 .setComponentType(

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
@@ -20,6 +20,7 @@ import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.ektorp.ViewQuery;
 import org.ektorp.support.View;
+import org.ektorp.support.Views;
 
 import java.util.List;
 import java.util.Set;
@@ -33,64 +34,43 @@ import static com.google.common.base.Strings.isNullOrEmpty;
  * @author cedric.bodet@tngtech.com
  * @author Johannes.Najjar@tngtech.com
  */
-@View(name = "all", map = "function(doc) { if (doc.type == 'release') emit(null, doc._id) }")
-public class ReleaseRepository extends SummaryAwareRepository<Release> {
-
-    private static final String BY_NAME_VIEW = "function(doc) { if(doc.type == 'release') { emit(doc.name, doc) } }";
-
-    private static final String RECENT_VIEW = "function(doc) { if(doc.type == 'release') { emit(doc.createdOn, doc._id) } }";
-
-    private static final String SUBSCRIBERS_VIEW =
-            "function(doc) {" +
+@Views({
+        @View(name = "all",
+                map = "function(doc) { if (doc.type == 'release') emit(null, doc._id) }"),
+        @View(name = "byname",
+                map = "function(doc) { if(doc.type == 'release') { emit(doc.name, doc) } }"),
+        @View(name = "byCreatedOn",
+                map = "function(doc) { if(doc.type == 'release') { emit(doc.createdOn, doc._id) } }"),
+        @View(name = "subscribers",
+                map = "function(doc) {" +
                     " if (doc.type == 'release'){" +
                     "    for(var i in doc.subscribers) {" +
                     "      emit(doc.subscribers[i], doc._id);" +
                     "    }" +
                     "  }" +
-                    "}";
-
-    private static final String RELEASE_BY_VENDORID_VIEW =
-            "function(doc) {" +
+                    "}"),
+        @View(name = "releaseByVendorId",
+                map = "function(doc) {" +
                     " if (doc.type == 'release'){" +
                     "     emit(doc.vendorId, doc);" +
                     "  }" +
-                    "}";
-
-    private static final String RELEASES_BY_COMPONENT_ID =
-            "function(doc) {" +
+                    "}"),
+        @View(name = "releasesByComponentId",
+                map = "function(doc) {" +
                     " if (doc.type == 'release'){" +
                     "      emit(doc.componentId, doc);" +
                     "  }" +
-                    "}";
-
-    private static final String RELEASE_IDS_BY_LICENSE_ID =
-            "function(doc) {" +
+                    "}"),
+        @View(name = "releaseIdsByLicenseId",
+                map = "function(doc) {" +
                       "  if (doc.type == 'release'){" +
                       "    for(var i in doc.mainLicenseIds) {" +
                       "      emit(doc.mainLicenseIds[i], doc);" +
                       "    }" +
                       "  }" +
-                      "}";
-
-    private static final String MY_COMPONENTS_VIEW =
-            "function(doc) {" +
-                    " if (doc.type == 'release'){" +
-                    "    emit(doc.createdBy, doc.componentId);" +
-                    "    for(var i in doc.contributors) {" +
-                    "      emit(doc.contributors[i], doc.componentId);" +
-                    "    }" +
-                    "    for(var i in doc.moderators) {" +
-                    "      emit(doc.moderators[i], doc.componentId);" +
-                    "    }" +
-                    "  }" +
-                    "}";
-
-    private static final String FULL_RELEASE_BY_COMPONENTID_VIEW =
-            "function(doc) {" +
-                    " if (doc.type == 'release'){" +
-                    "     emit(doc.componentId, doc);" +
-                    "  }" +
-                    "}";
+                      "}")
+})
+public class ReleaseRepository extends SummaryAwareRepository<Release> {
 
     public ReleaseRepository(DatabaseConnector db, VendorRepository vendorRepository) {
         super(Release.class, db, new ReleaseSummary(vendorRepository));
@@ -98,7 +78,6 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
         initStandardDesignDocument();
     }
 
-    @View(name = "byname", map = BY_NAME_VIEW)
     public List<Release> searchByNamePrefix(String name) {
         return makeSummary(SummaryType.SHORT, queryForIdsByPrefix("byname", name));
     }
@@ -115,42 +94,28 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
         return makeSummary(SummaryType.SUMMARY, getAllIds());
     }
 
-    @View(name = "recent", map = RECENT_VIEW)
     public List<Release> getRecentReleases() {
-        ViewQuery query = createQuery("recent");
+        ViewQuery query = createQuery("byCreatedOn");
         // Get the 5 last documents
         query.limit(5).descending(true).includeDocs(false);
         return makeSummary(SummaryType.SHORT, queryForIds(query));
     }
 
-    @View(name = "subscribers", map = SUBSCRIBERS_VIEW)
     public List<Release> getSubscribedReleases(String email) {
         Set<String> ids = queryForIds("subscribers", email);
         return makeSummary(SummaryType.SHORT, ids);
     }
 
-    @View(name = "releaseIdByVendorId", map = RELEASE_BY_VENDORID_VIEW)
     public List<Release> getReleasesFromVendorId(String id, User user) {
-        return  makeSummaryWithPermissionsFromFullDocs(SummaryType.SUMMARY, queryView("releaseIdByVendorId", id), user);
+        return  makeSummaryWithPermissionsFromFullDocs(SummaryType.SUMMARY, queryView("releaseByVendorId", id), user);
     }
 
-    @View(name = "releasesByComponentId", map = RELEASES_BY_COMPONENT_ID)
+    public List<Release> getReleasesFromComponentId(String id) {
+         return queryView("releasesByComponentId", id);
+    }
+
     public List<Release> getReleasesFromComponentId(String id, User user) {
         return makeSummaryWithPermissionsFromFullDocs(SummaryType.SUMMARY, queryView("releasesByComponentId", id), user);
-    }
-
-    @View(name = "mycomponents", map = MY_COMPONENTS_VIEW)
-    public Set<String> getMyComponentIds(String user) {
-        return queryForIdsAsValue("mycomponents", user);
-    }
-
-    @View(name = "fullbycomponentId", map = FULL_RELEASE_BY_COMPONENTID_VIEW)
-    public List<Release> getFullReleasesByComponentid(String componentId) {
-        return queryView("fullbycomponentId", componentId);
-    }
-
-    public ImmutableListMultimap<String, Release> getFullReleases() {
-        return FluentIterable.from(queryView("fullbycomponentId")).index(Release::getComponentId);
     }
 
     public List<Release> getReleasesFromVendorIds(Set<String> ids) {
@@ -158,7 +123,6 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
         return makeSummaryFromFullDocs(SummaryType.SHORT, queryByIds("releaseIdByVendorId", ids));
     }
 
-    @View(name = "releaseIdsByLicenseId", map = RELEASE_IDS_BY_LICENSE_ID)
     public List<Release> searchReleasesByUsingLicenseId(String licenseId) {
 
         return queryView("releaseIdsByLicenseId", licenseId);

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
@@ -19,7 +19,6 @@ import org.ektorp.support.View;
 import java.util.Collection;
 import java.util.List;
 
-
 /**
  * CRUD access for the User class
  *

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/VendorRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/VendorRepository.java
@@ -21,6 +21,7 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.ektorp.support.View;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 
@@ -39,37 +40,10 @@ public class VendorRepository extends DatabaseRepository<Vendor> {
         initStandardDesignDocument();
     }
 
-
-
-    public RequestStatus deleteVendor(String id, User user) throws SW360Exception {
-        Vendor vendor = get(id);
-        assertNotNull(vendor);
-
-        if (makePermission(vendor, user).isActionAllowed(RequestedAction.DELETE)) {
-            remove(id);
-            return RequestStatus.SUCCESS;
-        } else {
-            log.error("User is not allowed to delete!");
-            return RequestStatus.FAILURE;
-        }
-
-
-    }
-
-    public RequestStatus updateVendor(Vendor vendor, User user) {
-        if (makePermission(vendor, user).isActionAllowed(RequestedAction.WRITE)) {
-            update(vendor);
-            return RequestStatus.SUCCESS;
-        } else {
-            log.error("User is not allowed to delete!");
-            return RequestStatus.FAILURE;
-        }
-    }
-
     public void fillVendor(Release release) {
         if (release.isSetVendorId()) {
             final String vendorId = release.getVendorId();
-            if (!Strings.isNullOrEmpty(vendorId)) {
+            if (!isNullOrEmpty(vendorId)) {
                 final Vendor vendor = get(vendorId);
                 if (vendor != null)
                     release.setVendor(vendor);

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasink/VulnerabilityConnector.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasink/VulnerabilityConnector.java
@@ -14,16 +14,15 @@ package org.eclipse.sw360.cvesearch.datasink;
 import com.google.common.base.Strings;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
-import org.eclipse.sw360.datahandler.db.ComponentRepository;
-import org.eclipse.sw360.datahandler.db.ProjectRepository;
-import org.eclipse.sw360.datahandler.db.ReleaseRepository;
-import org.eclipse.sw360.datahandler.db.VendorRepository;
+import org.eclipse.sw360.datahandler.db.*;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.cvesearch.UpdateType;
 import org.eclipse.sw360.datahandler.thrift.cvesearch.VulnerabilityUpdateStatus;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.ReleaseVulnerabilityRelation;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.vulnerabilities.common.VulnerabilityMapper;
@@ -35,15 +34,17 @@ import java.util.*;
 public class VulnerabilityConnector {
 
     VulnerabilityDatabaseHandler vulnerabilityDatabaseHandler;
+    ProjectDatabaseHandler projectDatabaseHandler;
     ComponentRepository componentRepository;
     ReleaseRepository releaseRepository;
     ProjectRepository projectRepository;
     VendorRepository vendorRepository;
 
     public VulnerabilityConnector() throws IOException{
-        vulnerabilityDatabaseHandler = new VulnerabilityDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_VM);
-
         DatabaseConnector db = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE);
+
+        vulnerabilityDatabaseHandler = new VulnerabilityDatabaseHandler(db);
+        projectDatabaseHandler = new ProjectDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS);
         vendorRepository = new VendorRepository(db);
         releaseRepository = new ReleaseRepository(db, vendorRepository);
         componentRepository = new ComponentRepository(db, releaseRepository, vendorRepository);
@@ -54,14 +55,11 @@ public class VulnerabilityConnector {
     // get objects from database     //
     ///////////////////////////////////
     public Optional<Release> getRelease(String releaseId){
-        return Optional.ofNullable(fillVendor(releaseRepository.get(releaseId)));
-    }
-
-    private Release fillVendor(Release release){
-        if (release != null) {
-            vendorRepository.fillVendor(release);
-        }
-        return release;
+        return Optional.ofNullable(releaseRepository.get(releaseId))
+                .map(r -> {
+                    vendorRepository.fillVendor(r);
+                    return r;
+                });
     }
 
     public Optional<Component> getComponent(String componentId){

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseRepository.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseRepository.java
@@ -15,8 +15,11 @@ import org.eclipse.sw360.components.summary.SummaryType;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.couchdb.SummaryAwareRepository;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.ektorp.ViewQuery;
 import org.ektorp.support.View;
+import org.ektorp.support.Views;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -24,11 +27,12 @@ import java.util.List;
  *
  * @author cedric.bodet@tngtech.com
  */
-@View(name = "all", map = "function(doc) { if (doc.type == 'license') emit(null, doc._id) }")
+@Views({
+        @View(name = "all", map = "function(doc) { if (doc.type == 'license') emit(null, doc._id) }"),
+        @View(name = "byname", map = "function(doc) { if(doc.type == 'license') { emit(doc.fullname, doc) } }"),
+        @View(name = "byshortname", map = "function(doc) { if(doc.type == 'license') { emit(doc._id, doc) } }")
+})
 public class LicenseRepository extends SummaryAwareRepository<License> {
-
-    private static final String BY_NAME_VIEW = "function(doc) { if(doc.type == 'license') { emit(doc.fullname, doc) } }";
-    private static final String BY_SHORT_NAME_VIEW = "function(doc) { if(doc.type == 'license') { emit(doc._id, doc) } }";
 
     public LicenseRepository(DatabaseConnector db) {
         super(License.class, db, new LicenseSummary());
@@ -36,12 +40,10 @@ public class LicenseRepository extends SummaryAwareRepository<License> {
         initStandardDesignDocument();
     }
 
-    @View(name = "byname", map = BY_NAME_VIEW)
     public List<License> searchByName(String name) {
         return queryByPrefix("byname", name);
     }
 
-    @View(name = "byshortname", map = BY_SHORT_NAME_VIEW)
     public List<License> searchByShortName(String name) {
         return queryByPrefix("byshortname", name);
     }

--- a/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorDatabaseHandler.java
+++ b/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorDatabaseHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2017.
+ * Part of the SW360 Portal Project.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.vendors;
+
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
+import org.eclipse.sw360.datahandler.db.VendorRepository;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+import org.ektorp.http.HttpClient;
+
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Strings.nullToEmpty;
+import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
+import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
+import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.prepareVendor;
+
+public class VendorDatabaseHandler {
+    private static final Logger log = Logger.getLogger(VendorDatabaseHandler.class);
+    private final VendorRepository repository;
+
+    public VendorDatabaseHandler(Supplier<HttpClient> httpClient, String dbName) throws MalformedURLException {
+        DatabaseConnector db = new DatabaseConnector(httpClient, dbName);
+        repository = new VendorRepository(db);
+    }
+
+    public VendorDatabaseHandler(DatabaseConnector db) throws MalformedURLException {
+        repository = new VendorRepository(db);
+    }
+
+    public Vendor getByID(String id) throws TException {
+        return repository.get(id);
+    }
+
+    public List<Vendor> getAllVendors() throws TException {
+        return repository.getAll();
+    }
+
+    public String addVendor(Vendor vendor) throws TException {
+        prepareVendor(vendor);
+        repository.add(vendor);
+        return vendor.getId();
+    }
+
+    public RequestStatus deleteVendor(String id, User user) throws SW360Exception {
+        Vendor vendor = repository.get(id);
+        assertNotNull(vendor);
+
+        if (makePermission(vendor, user).isActionAllowed(RequestedAction.DELETE)) {
+            repository.remove(id);
+            return RequestStatus.SUCCESS;
+        } else {
+            log.error("User is not allowed to delete!");
+            return RequestStatus.FAILURE;
+        }
+
+
+    }
+
+    public RequestStatus updateVendor(Vendor vendor, User user) {
+        if (makePermission(vendor, user).isActionAllowed(RequestedAction.WRITE)) {
+            repository.update(vendor);
+            return RequestStatus.SUCCESS;
+        } else {
+            log.error("User is not allowed to delete!");
+            return RequestStatus.FAILURE;
+        }
+    }
+
+
+    public void fillVendor(Release release){
+        repository.fillVendor(release);
+    }
+}

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityDatabaseHandler.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityDatabaseHandler.java
@@ -49,6 +49,12 @@ public class VulnerabilityDatabaseHandler {
         relationRepo = new VulnerabilityRelationRepository(db);
     }
 
+    public VulnerabilityDatabaseHandler(DatabaseConnector db) throws MalformedURLException {
+        this.db = db;
+        vulRepo = new VulnerabilityRepository(db);
+        relationRepo = new VulnerabilityRelationRepository(db);
+    }
+
     public <T extends TBase> RequestStatus add(T element) {
         if (element == null) {
             log.error("cannot add null element");


### PR DESCRIPTION
This PR tackles multiple issues:
1. Couchdb recommends that Views should not emit the document, i.e. instead of `emit(null, doc)` one should use `emit(null, doc._id)`. This improves performance and reduces the size of the cached views. The documents are still delivered via the `includeDocs=true` property
2. The `ComponentSummary` was inefficiently implemented. If one wanted to have a summary of Components it collected **all Releases for every component** and filtered them later to fill in the details.
  - this raises the question whether Summaries should only be projections?
3. There was no `VendorDatabaseHandler` and there was much logic in the `VendorRepository`.