### PR TITLE
feat(components): restructure components view to show only latest components for performance reasons

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -159,11 +159,6 @@ public class ComponentDatabaseHandler {
         return releases;
     }
 
-    public List<Component> getRecentComponents() {
-        return componentRepository.getRecentComponents();
-    }
-
-
     public List<Release> getRecentReleases() {
         return releaseRepository.getRecentReleases();
     }
@@ -991,5 +986,13 @@ public class ComponentDatabaseHandler {
         }
 
         return CommonUtils.getIdentifierToListOfDuplicates(releaseIdentifierToReleaseId);
+    }
+
+    public List<Component> getRecentComponentsSummary(int limit, User user) {
+        return componentRepository.getRecentComponentsSummary(limit, user);
+    }
+
+    public int getTotalComponentsCount() {
+        return componentRepository.getTotalComponentsCount();
     }
 }

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -73,6 +73,19 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
+    public List<Component> getRecentComponentsSummary(int limit, User user) throws TException {
+        assertUser(user);
+
+        return handler.getRecentComponentsSummary(limit, user);
+    }
+
+    @Override
+    public int getTotalComponentsCount(User user) throws TException {
+        assertUser(user);
+        return handler.getTotalComponentsCount();
+    }
+
+    @Override
     public List<Release> getReleaseSummary(User user) throws TException {
         assertUser(user);
 
@@ -109,11 +122,6 @@ public class ComponentHandler implements ComponentService.Iface {
         assertUser(user);
 
         return handler.getSubscribedReleases(user.getEmail());
-    }
-
-    @Override
-    public List<Component> getRecentComponents() throws TException {
-        return handler.getRecentComponents();
     }
 
     @Override

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -92,16 +92,16 @@ public class ComponentDatabaseHandlerTest {
 
 
         components = new ArrayList<>();
-        Component component1 = new Component().setId("C1").setName("component1").setDescription("d1").setCreatedBy(email1).setMainLicenseIds(new HashSet<>(Arrays.asList("lic1")));
+        Component component1 = new Component().setId("C1").setName("component1").setDescription("d1").setCreatedBy(email1).setMainLicenseIds(new HashSet<>(Arrays.asList("lic1"))).setCreatedOn("2017-07-20");
         component1.addToReleaseIds("R1A");
         component1.addToReleaseIds("R1B");
         components.add(component1);
-        Component component2 = new Component().setId("C2").setName("component2").setDescription("d2").setCreatedBy(email2).setMainLicenseIds(new HashSet<>(Arrays.asList("lic2")));
+        Component component2 = new Component().setId("C2").setName("component2").setDescription("d2").setCreatedBy(email2).setMainLicenseIds(new HashSet<>(Arrays.asList("lic2"))).setCreatedOn("2017-07-21");
         component2.addToReleaseIds("R2A");
         component2.addToReleaseIds("R2B");
         component2.addToReleaseIds("R2C");
         components.add(component2);
-        Component component3 = new Component().setId("C3").setName("component3").setDescription("d3").setCreatedBy(email1).setMainLicenseIds(new HashSet<>(Arrays.asList("lic3")));
+        Component component3 = new Component().setId("C3").setName("component3").setDescription("d3").setCreatedBy(email1).setMainLicenseIds(new HashSet<>(Arrays.asList("lic3"))).setCreatedOn("2017-07-22");
         component3.addToSubscribers(email1);
         component3.addToLanguages("E");
         components.add(component3);
@@ -246,9 +246,17 @@ public class ComponentDatabaseHandlerTest {
 
     @Test
     public void testGetRecentComponents() throws Exception {
-        List<Component> recentComponents = handler.getRecentComponents();
+        List<Component> recentComponents = handler.getRecentComponentsSummary(5, user1);
         Iterable<String> componentIds = getComponentIds(recentComponents);
-        assertThat(componentIds, containsInAnyOrder("C1", "C2", "C3"));
+        assertThat(componentIds, contains("C3", "C2", "C1"));
+    }
+
+    @Test
+    public void testGetRecentComponents2() throws Exception {
+        List<Component> recentComponents = handler.getRecentComponentsSummary(2, user1);
+        Iterable<String> componentIds = getComponentIds(recentComponents);
+        assertEquals(2, recentComponents.size());
+        assertThat(componentIds, contains("C3", "C2"));
     }
 
     @Test

--- a/docs/architecture/adr-001.md
+++ b/docs/architecture/adr-001.md
@@ -1,0 +1,51 @@
+[//]: <> (Copyright Siemens AG, 2017.)
+[//]: <> (Part of the SW360 Portal Project.)
+[//]: <> ()
+[//]: <> (SPDX-License-Identifier: EPL-1.0)
+[//]: <> ()
+[//]: <> (All rights reserved. This program and the accompanying materials)
+[//]: <> (are made available under the terms of the Eclipse Public License v1.0)
+[//]: <> (which accompanies this distribution, and is available at)
+[//]: <> (http://www.eclipse.org/legal/epl-v10.html)
+
+## ADR 1: Pagination in Backend
+
+### Context
+  Components and Projects pages display entire contents of the database in one table. Reading data, generating HTML 
+  page, and rendering the table (which is paginated by datatables on the client) all take a long time with thousands of 
+  entities.
+  
+  Datatables supports server-side processing for displaying and paginating data. For that, the server must be able to
+  tell datatables how many rows are in the table in total and to load a page of data starting from given index.
+  
+  However, CouchDB cookbook strongly discourages loading of data starting from some index because of performance 
+  concerns. Instead, loading data starting from a specific key should be used. This is incompatible with what datatables
+  requires and also makes going to previous pages highly complicated.
+  
+  To support sorting of the table by multiple columns would require creating a CouchDB view per column.
+  
+  In addition, projects are filtered by visibility in backend after loading from CouchDB. This filtering cannot be
+  implemented in CouchDB. This complicates the matters even further with regards to pagination of projects table in
+  backend.
+
+### Decision
+  We will not use datatables' server-side processing as it's not worth the effort.
+  
+  We will load only some number of latest components by default and let the user increase that number up to all
+  available components. We will make this choice sticky between sessions.
+  
+  We will not change the projects table for now as the users have the option of loading only the projects from their
+  group and are not disturbed much by the performance of the page when all projects are displayed.
+ 
+### Status
+  Accepted
+
+### Consequences
+  Users will not see some components that are already created in the system and may try to create the "missing"
+  components. Quick Filter will not help them find the component as it works on client-side only.
+  To really make sure that a component is not in the system, users will have to use Advanced Search.
+  
+  Loading time of the components page (with default settings) will improve dramatically and will be independent of
+  the total number of components in the system.
+  
+  Loading time of unfiltered projects table will still be slow with thousands of projects.

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -63,6 +63,8 @@ public class PortalConstants {
     public static final String SELECTED_TAB = "selectedTab";
     public static final String IS_USER_AT_LEAST_CLEARING_ADMIN = "isUserAtLeastClearingAdmin";
     public static final String DOCUMENT_TYPE = "documentType";
+    public static final String VIEW_SIZE = "viewSize";
+    public static final String TOTAL_ROWS = "totalRows";
 
     //! Specialized keys for licenses
     public static final String KEY_LICENSE_DETAIL = "licenseDetail";
@@ -182,6 +184,7 @@ public class PortalConstants {
 
     //! Specialized keys for users
     public static final String CUSTOM_FIELD_PROJECT_GROUP_FILTER = "ProjectGroupFilter";
+    public static final String CUSTOM_FIELD_COMPONENTS_VIEW_SIZE = "ComponentsViewSize";
 
     //! Specialized keys for scheduling
     public static final String CVESEARCH_IS_SCHEDULED = "cveSearchIsScheduled";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/RecentComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/RecentComponentPortlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -12,9 +12,11 @@ package org.eclipse.sw360.portal.portlets.homepage;
 
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.portal.portlets.Sw360Portlet;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.portal.users.UserCacheHolder;
 
 import javax.portlet.PortletException;
 import javax.portlet.RenderRequest;
@@ -37,9 +39,10 @@ public class RecentComponentPortlet extends Sw360Portlet {
     @Override
     public void doView(RenderRequest request, RenderResponse response) throws IOException, PortletException {
         List<Component> components=null;
+        User user = UserCacheHolder.getUserFromRequest(request);
 
         try {
-            components = thriftClients.makeComponentClient().getRecentComponents();
+            components = thriftClients.makeComponentClient().getRecentComponentsSummary(5, user);
         } catch (TException e) {
             log.error("Could not fetch recent components from backend", e);
         }

--- a/frontend/sw360-portlet/src/main/webapp/css/dataTable_Siemens.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/dataTable_Siemens.css
@@ -1,6 +1,6 @@
 /**
 *
-* Modifications applied by Siemens AG 2014-2016.
+* Modifications applied by Siemens AG 2014-2017.
 * Modifications for supporting own application.
 *
 */
@@ -323,22 +323,22 @@ td.details {
 	width: 40%;
 }
 
-.paging_full_numbers {
+.paging_full_numbers, .paging_simple_numbers {
 	width: 400px;
 	height: 22px;
 	line-height: 22px;
 }
 
-.paging_full_numbers a:active {
+.paging_full_numbers a:active, .paging_simple_numbers a:active {
 	outline: none
 }
 
-.paging_full_numbers a:hover {
+.paging_full_numbers a:hover, .paging_simple_numbers a:hover {
 	text-decoration: none;
 }
 
-.paging_full_numbers a.paginate_button,
- 	.paging_full_numbers a.paginate_active {
+.paging_full_numbers a.paginate_button, .paging_full_numbers a.paginate_active,
+	.paging_simple_numbers a.paginate_button, .paging_simple_numbers a.paginate_active {
 	/*border: 1px solid #aaa;*/
 	-webkit-border-radius: 5px;
 	-moz-border-radius: 5px;
@@ -349,16 +349,16 @@ td.details {
 	color: #333 !important;
 }
 
-.paging_full_numbers a.paginate_button {
+.paging_full_numbers a.paginate_button, .paging_simple_numbers a.paginate_button {
 	/*background-color: #ddd;*/
 }
 
-.paging_full_numbers a.paginate_button:hover {
+.paging_full_numbers a.paginate_button:hover, .paging_simple_numbers a.paginate_button:hover {
 	/*background-color: #ccc;*/
 	text-decoration: none !important;
 }
 
-.paging_full_numbers a.paginate_active {
+.paging_full_numbers a.paginate_active, .paging_simple_numbers a.paginate_active {
 	background-color: #b2e0e0;
 }
 

--- a/frontend/sw360-portlet/src/main/webapp/css/dataTable_SiemensHomepage.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/dataTable_SiemensHomepage.css
@@ -1,6 +1,6 @@
 /**
 *
-* Modifications applied by Siemens AG 2014.
+* Modifications applied by Siemens AG 2014-2017.
 * Modifications for supporting own application.
 *
 */
@@ -316,22 +316,22 @@ div.dataTables_info {
 	width: 40%;
 }
 
-.paging_full_numbers {
+.paging_full_numbers, .paging_simple_numbers {
 	width: 400px;
 	height: 22px;
 	line-height: 22px;
 }
 
-.paging_full_numbers a:active {
+.paging_full_numbers a:active, .paging_simple_numbers a:active {
 	outline: none
 }
 
-.paging_full_numbers a:hover {
+.paging_full_numbers a:hover, .paging_simple_numbers a:hover {
 	text-decoration: none;
 }
 
-.paging_full_numbers a.paginate_button,
- 	.paging_full_numbers a.paginate_active {
+.paging_full_numbers a.paginate_button, .paging_full_numbers a.paginate_active,
+	.paging_simple_numbers a.paginate_button, .paging_simple_numbers a.paginate_active {
 	/*border: 1px solid #aaa;*/
 	-webkit-border-radius: 5px;
 	-moz-border-radius: 5px;
@@ -342,16 +342,16 @@ div.dataTables_info {
 	color: #333 !important;
 }
 
-.paging_full_numbers a.paginate_button {
+.paging_full_numbers a.paginate_button, .paging_simple_numbers a.paginate_button {
 	/*background-color: #ddd;*/
 }
 
-.paging_full_numbers a.paginate_button:hover {
+.paging_full_numbers a.paginate_button:hover, .paging_simple_numbers a.paginate_button:hover {
 	/*background-color: #ccc;*/
 	text-decoration: none !important;
 }
 
-.paging_full_numbers a.paginate_active {
+.paging_full_numbers a.paginate_active, .paging_simple_numbers a.paginate_active {
 	background-color: #b2e0e0;
 }
 

--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -1,5 +1,5 @@
 /**
- * Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
  * SPDX-License-Identifier: EPL-1.0
@@ -196,6 +196,11 @@ div.content2 {
     width: 90%;
     padding: 5px;
     height: 20px;
+}
+
+#searchInput select.searchbar {
+    min-width: 162px;
+    min-height: 28px;
 }
 
 #searchInput .searchbutton {

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/bulkReleaseEdit/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/bulkReleaseEdit/view.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
   ~
@@ -140,21 +140,19 @@
     function configureComponentBasicInfoTable(){
         var tbl;
         tbl = $('#ComponentBasicInfo').dataTable({
-            "sPaginationType": "full_numbers",
+            "pagingType": "simple_numbers",
+            dom: "lrtip",
             "bAutoWidth": false,
-            "aoColumnDefs": [
-                { "sWidth": "13%", "aTargets": [ 0 ] },
-                { "sWidth": "20%", "aTargets": [ 1 ] },
-                { "sWidth": "20%", "aTargets": [ 2 ] },
-                { "sWidth": "20%", "aTargets": [ 3 ] },
-                { "sWidth": "20%", "aTargets": [ 4 ] },
-                { "sWidth": "7%", "aTargets": [ 5 ] }
+            "columnDefs": [
+                { "width": "13%", "targets": [ 0 ] },
+                { "width": "20%", "targets": [ 1 ] },
+                { "width": "20%", "targets": [ 2 ] },
+                { "width": "20%", "targets": [ 3 ] },
+                { "width": "20%", "targets": [ 4 ] },
+                { "width": "7%", "targets": [ 5 ] }
             ]
         });
 
-        $('#ComponentBasicInfo_filter').hide();
-        $('#ComponentBasicInfo_first').hide();
-        $('#ComponentBasicInfo_last').hide();
         return tbl;
     }
 

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/bulkReleaseEdit/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/bulkReleaseEdit/view.jsp
@@ -48,7 +48,7 @@
         <thead>
         <tr>
             <th class="infoheading">
-                Display Filter
+                Quick Filter
             </th>
         </tr>
         </thead>
@@ -57,9 +57,6 @@
             <td>
                 <input type="text" class="searchbar"
                        id="keywordsearchinput" value="" onkeyup="useSearch('keywordsearchinput')">
-                <br/>
-                <input style="padding: 5px 20px 5px 20px; border: none; font-weight:bold;" type="button"
-                       name="searchBtn" value="Search" onclick="useSearch('keywordsearchinput')">
             </td>
         </tr>
         </tbody>
@@ -139,7 +136,7 @@
 
     function configureComponentBasicInfoTable(){
         var tbl;
-        tbl = $('#ComponentBasicInfo').dataTable({
+        tbl = $('#ComponentBasicInfo').DataTable({
             "pagingType": "simple_numbers",
             dom: "lrtip",
             "bAutoWidth": false,
@@ -214,7 +211,7 @@
     }
 
     function useSearch( buttonId) {
-        componentsInfoTable.fnFilter( $('#'+buttonId).val());
+        componentsInfoTable.search($('#'+buttonId).val()).draw();
     }
 </script>
 

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/databaseSanitation/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/databaseSanitation/view.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   - With contributions by Bosch Software Innovations GmbH, 2016-2017.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
@@ -107,12 +107,9 @@
     function setupPagination(tableId) {
         if ($(tableId)) {
             $(tableId).dataTable({
-                "sPaginationType": "full_numbers"
+                "pagingType": "simple_numbers",
+                dom: "lrtip"
             });
-
-            $(tableId + '_filter').hide();
-            $(tableId + '_first').hide();
-            $(tableId + '_last').hide();
         }
     }
 

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/user/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/user/view.jsp
@@ -35,7 +35,7 @@
         <thead>
         <tr>
             <th class="infoheading">
-                Display Filter
+                Quick Filter
             </th>
         </tr>
         </thead>
@@ -44,9 +44,6 @@
             <td>
                 <input type="text" class="searchbar"
                        id="keywordsearchinput" value="" onkeyup="useSearch('keywordsearchinput')">
-                <br/>
-                <input style="padding: 5px 20px 5px 20px; border: none; font-weight:bold;" type="button"
-                       name="searchBtn" value="Search" onclick="useSearch('keywordsearchinput')">
             </td>
         </tr>
         </tbody>
@@ -177,10 +174,10 @@
         usersMissingTable = setupPagination('#userMissingTable');
     }
 
-    function setupPagination(tableId){
+    function setupPagination(tableSelector){
         var tbl;
-        if ($(tableId)){
-            tbl = $(tableId).dataTable({
+        if ($(tableSelector)){
+            tbl = $(tableSelector).DataTable({
                 "pagingType": "simple_numbers",
                 dom: "lrtip"
             });
@@ -189,8 +186,9 @@
     }
 
     function useSearch( buttonId) {
-        usersTable.fnFilter( $('#'+buttonId).val());
-        usersMissingTable.fnFilter( $('#'+buttonId).val());
+        var searchText = $('#'+buttonId).val();
+        usersTable.search(searchText).draw();
+        usersMissingTable.search(searchText).draw();
     }
 </script>
 

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/user/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/user/view.jsp
@@ -181,12 +181,9 @@
         var tbl;
         if ($(tableId)){
             tbl = $(tableId).dataTable({
-                "sPaginationType": "full_numbers"
+                "pagingType": "simple_numbers",
+                dom: "lrtip"
             });
-
-            $(tableId+'_filter').hide();
-            $(tableId+'_first').hide();
-            $(tableId+'_last').hide();
         }
         return tbl;
     }

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/vendors/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/vendors/view.jsp
@@ -50,7 +50,7 @@
         <thead>
         <tr>
             <th class="infoheading">
-                Display Filter
+                Quick Filter
             </th>
         </tr>
         </thead>
@@ -59,9 +59,6 @@
             <td>
                 <input type="text" class="searchbar"
                        id="keywordsearchinput" value="" onkeyup="useSearch('keywordsearchinput')">
-                <br/>
-                <input style="padding: 5px 20px 5px 20px; border: none; font-weight:bold;" type="button"
-                       name="searchBtn" value="Search" onclick="useSearch('keywordsearchinput')">
             </td>
         </tr>
         </tbody>
@@ -107,7 +104,7 @@
     }
 
     function useSearch( buttonId) {
-        vendorsTable.fnFilter( $('#'+buttonId).val());
+        vendorsTable.search($('#'+buttonId).val()).draw();
     }
 
     function createVendorsTable() {
@@ -123,7 +120,7 @@
         });
         </core_rt:forEach>
 
-        vendorsTable = $('#vendorsTable').dataTable({
+        vendorsTable = $('#vendorsTable').DataTable({
             pagingType: "simple_numbers",
             dom: "lrtip",
             data: result,

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/vendors/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/vendors/view.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
   ~
@@ -124,7 +124,8 @@
         </core_rt:forEach>
 
         vendorsTable = $('#vendorsTable').dataTable({
-            pagingType: "full_numbers",
+            pagingType: "simple_numbers",
+            dom: "lrtip",
             data: result,
             columns: [
                 { "title": "Full Name" },
@@ -133,9 +134,6 @@
                 { "title": "Actions"}
             ]
         });
-        $('#vendorsTable_filter').hide();
-        $('#vendorsTable_first').hide();
-        $('#vendorsTable_last').hide();
     }
 
     function deleteVendor( id, name ) {

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/clearingStatus.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/clearingStatus.jspf
@@ -69,9 +69,9 @@
         </core_rt:forEach>
 
         releaseTable = $('#releasesTable').DataTable({
-            "sPaginationType": "full_numbers",
-            "aaData": result,
-            "aoColumns": [
+            "pagingType": "simple_numbers",
+            "data": result,
+            "columns": [
                 {"sTitle": "Release name"},
                 {"sTitle": "Release version"},
                 {"sTitle": "Clearing state"},
@@ -80,9 +80,6 @@
                 {"sTitle": "Actions"}
             ]
         });
-
-        $('#releasesTable_first').hide();
-        $('#releasesTable_last').hide();
 
     }
 

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/vulnerabilities.jspf
@@ -86,23 +86,23 @@
         </core_rt:forEach>
 
         vulnerabilityTable = $('#vulnerabilityTable').dataTable({
-            "sPaginationType": "full_numbers",
-            "aaData": result,
-            "aoColumns": [
-                {"sTitle": "Release"},
-                {"sTitle": "External id"},
-                {"sTitle": "Priority"},
-                {"sTitle": "Title"},
-                {"sTitle": "Matched by"},
+            pagingType: "simple_numbers",
+            "data": result,
+            "columns": [
+                {"title": "Release"},
+                {"title": "External id"},
+                {"title": "Priority"},
+                {"title": "Title"},
+                {"title": "Matched by"},
                 <core_rt:choose>
                 <core_rt:when test="${vulnerabilityVerificationEditable}">
-                {"sTitle": "Verification", "orderDataType": "sort-select" },
+                {"title": "Verification", "orderDataType": "sort-select" },
                 </core_rt:when>
                 <core_rt:otherwise>
-                {"sTitle": "Verification"},
+                {"title": "Verification"},
                 </core_rt:otherwise>
                 </core_rt:choose>
-                {"sTitle": "Action"}
+                {"title": "Action"}
             ],
             "order": [[ 2, 'asc' ], [ 3, 'desc' ]]
         });
@@ -114,10 +114,6 @@
                 return $(this).prop('title');
             }
         });
-
-        $('#vulnerabilityTable_first').hide();
-        $('#vulnerabilityTable_last').hide();
-
     }
 
     /*This can not be document ready function as liferay definitions need to be loaded first*/

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/vulnerabilities.jspf
@@ -87,22 +87,22 @@
         </core_rt:forEach>
 
         vulnerabilityTable = $('#vulnerabilityTable').dataTable({
-            "sPaginationType": "full_numbers",
-            "aaData": result,
-            "aoColumns": [
-                {"sTitle": "External id"},
-                {"sTitle": "Priority"},
-                {"sTitle": "Title"},
-                {"sTitle": "Matched by"},
+            pagingType: "simple_numbers",
+            "data": result,
+            "columns": [
+                {"title": "External id"},
+                {"title": "Priority"},
+                {"title": "Title"},
+                {"title": "Matched by"},
                 <core_rt:choose>
                     <core_rt:when test="${vulnerabilityVerificationEditable}">
-                        {"sTitle": "Verification", "orderDataType": "sort-select" },
+                        {"title": "Verification", "orderDataType": "sort-select" },
                     </core_rt:when>
                     <core_rt:otherwise>
-                        {"sTitle": "Verification"},
+                        {"title": "Verification"},
                     </core_rt:otherwise>
                 </core_rt:choose>
-                {"sTitle": "Action"}
+                {"title": "Action"}
             ],
             "order": [[1, 'asc'], [2, 'desc']]
         });
@@ -114,10 +114,6 @@
                 return $(this).prop('title');
             }
         });
-
-        $('#vulnerabilityTable_first').hide();
-        $('#vulnerabilityTable_last').hide();
-
     }
 
     /*This can not be document ready function as liferay definitions need to be loaded first*/

--- a/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
@@ -36,6 +36,8 @@
 <jsp:useBean id="vendorNames" class="java.lang.String" scope="request"/>
 <jsp:useBean id="mainLicenseIds" class="java.lang.String" scope="request"/>
 <jsp:useBean id="name" class="java.lang.String" scope="request"/>
+<jsp:useBean id="viewSize" type="java.lang.Integer" scope="request"/>
+<jsp:useBean id="totalRows" type="java.lang.Integer" scope="request"/>
 
 <core_rt:set var="programmingLanguages" value='<%=PortalConstants.PROGRAMMING_LANGUAGES%>'/>
 <core_rt:set var="operatingSystemsAutoC" value='<%=PortalConstants.OPERATING_SYSTEMS%>'/>
@@ -64,7 +66,8 @@
 
 <div id="header"></div>
 <p class="pageHeader">
-    <span class="pageHeaderBigSpan">Components</span> <span class="pageHeaderSmallSpan">(${componentList.size()})</span>
+    <span class="pageHeaderBigSpan">Components</span>
+    <span class="pageHeaderMediumSpan">(<core_rt:if test="${componentList.size() == totalRows}">${totalRows}</core_rt:if><core_rt:if test="${componentList.size() != totalRows}">${componentList.size()} latest of ${totalRows}</core_rt:if>)</span>
     <span class="pull-right">
           <input type="button" class="addButton" onclick="window.location.href='<%=addComponentURL%>'"
                 value="Add Component">
@@ -77,7 +80,28 @@
             <thead>
             <tr>
                 <th class="infoheading">
-                    Display Filter by Name
+                    Loading
+                </th>
+            </tr>
+            </thead>
+            <tbody style="background-color: #f8f7f7; border: none;">
+            <tr>
+                <td>
+                    <select class="searchbar" id="view_size" name="<portlet:namespace/><%=PortalConstants.VIEW_SIZE%>" onchange="reloadViewSize()">
+                        <option value="200" <core_rt:if test="${viewSize == 200}">selected</core_rt:if>>200 latest</option>
+                        <option value="500" <core_rt:if test="${viewSize == 500}">selected</core_rt:if>>500 latest</option>
+                        <option value="1000" <core_rt:if test="${viewSize == 1000}">selected</core_rt:if>>1000 latest</option>
+                        <option value="-1" <core_rt:if test="${viewSize == -1}">selected</core_rt:if>>All</option>
+                    </select>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <table>
+            <thead>
+            <tr>
+                <th class="infoheading">
+                    Quick Filter
                 </th>
             </tr>
             </thead>
@@ -87,9 +111,6 @@
                     <input type="text" class="searchbar"
                            id="keywordsearchinput" value=""
                            onkeyup="useSearch('keywordsearchinput')" />
-                    <br/>
-                    <input class="searchbutton" type="button"
-                           name="searchBtn" value="Search" onclick="useSearch('keywordsearchinput')" />
                 </td>
             </tr>
             </tbody>
@@ -99,7 +120,7 @@
             <thead>
             <tr>
                 <th class="infoheading">
-                    Filters
+                    Advanced Search
                 </th>
             </tr>
             </thead>
@@ -121,8 +142,7 @@
             <tr>
                 <td>
                     <label for="component_type">Component Type</label>
-                    <select class="searchbar toplabelledInput filterInput" id="component_type" name="<portlet:namespace/><%=Component._Fields.COMPONENT_TYPE%>"
-                            style="min-height: 28px;">
+                    <select class="searchbar toplabelledInput filterInput" id="component_type" name="<portlet:namespace/><%=Component._Fields.COMPONENT_TYPE%>">
                         <option value="<%=PortalConstants.NO_FILTER%>" class="textlabel stackedLabel">Any</option>
                         <sw360:DisplayEnumOptions type="<%=ComponentType.class%>" selectedName="${componentType}" useStringValues="true"/>
                     </select>
@@ -170,7 +190,7 @@
             </tbody>
         </table>
         <br/>
-        <input type="submit" class="addButton" value="Apply Filters">
+        <input type="submit" class="addButton" value="Search">
     </form>
 </div>
 <div id="componentsTableDiv" class="content2">
@@ -223,7 +243,7 @@
 
     function useSearch(buttonId) {
         var val = $.fn.dataTable.util.escapeRegex($('#' + buttonId).val());
-        componentsTable.columns(1).search('^'+val, true).draw();
+        componentsTable.columns(1).search(val, true).draw();
     }
 
     function exportSpreadsheet(){
@@ -242,6 +262,12 @@
         portletURL.setParameter('<%=Component._Fields.MAIN_LICENSE_IDS%>',$('#main_licenses').val());
         portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>',$('#extendedByReleases').val());
 
+        window.location.href=portletURL.toString();
+    }
+
+    function reloadViewSize(){
+        var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>');
+        portletURL.setParameter('<%=PortalConstants.VIEW_SIZE%>', $('#view_size').val());
         window.location.href=portletURL.toString();
     }
 
@@ -274,7 +300,11 @@
                 {"title": "Main Licenses", data: "lics"},
                 {"title": "Component Type", data: "cType"},
                 {"title": "Actions", data: "id", render: {display: renderComponentActions}}
-            ]
+            ],
+            order: [[1, 'asc']],
+            language: {
+                lengthMenu: "_MENU_ entries per page"
+            }
         });
     }
 

--- a/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
@@ -263,21 +263,18 @@
         </core_rt:forEach>
 
         componentsTable = $('#componentsTable').DataTable({
-            "sPaginationType": "full_numbers",
-            "iDisplayLength": 25,
-            "aaData": result,
-            "aoColumns": [
-                {"sTitle": "Vendor"},
-                {"sTitle": "Component Name"},
-                {"sTitle": "Main Licenses"},
-                {"sTitle": "Component Type"},
+            "pagingType": "simple_numbers",
+            dom: "lrtip",
+            "pageLength": 25,
+            "data": result,
+            "columns": [
+                {"title": "Vendor"},
+                {"title": "Component Name"},
+                {"title": "Main Licenses"},
+                {"title": "Component Type"},
                 {"title": "Actions"}
             ]
         });
-
-        $('#componentsTable_filter').hide();
-        $('#componentsTable_first').hide();
-        $('#componentsTable_last').hide();
     }
 
     function deleteComponent(id, name, numberOfReleases, attachmentsSize) {

--- a/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
@@ -253,12 +253,13 @@
         <core_rt:set var="licenseCollectionTagOutput"><tags:DisplayLicenseCollection licenseIds="${component.mainLicenseIds}" scopeGroupId="${pageContext.getAttribute('scopeGroupId')}"/></core_rt:set>
         result.push({
             "DT_RowId": "${component.id}",
-            "0": '<sw360:DisplayCollection value="${component.vendorNames}"/>',
-            "1": "<a href='" + createDetailURLfromComponentId("${component.id}") + "' target='_self'><sw360:out value="${component.name}"/></a>",
-            "2": "<tags:TrimLineBreaks input="${licenseCollectionTagOutput}"/>",
-            "3": '<sw360:DisplayEnum value="${component.componentType}"/>',
-            "4": "<a href='<portlet:renderURL ><portlet:param name="<%=PortalConstants.COMPONENT_ID%>" value="${component.id}"/><portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.PAGENAME_EDIT%>"/></portlet:renderURL>'><img src='<%=request.getContextPath()%>/images/edit.png' alt='Edit' title='Edit'> </a>"
-            + "<img src='<%=request.getContextPath()%>/images/Trash.png' onclick=\"deleteComponent('${component.id}', '<b>${component.name}</b>',${component.releaseIdsSize},${component.attachmentsSize})\"  alt='Delete' title='Delete'>"
+            "id": "${component.id}",
+            "vndrs": '<sw360:DisplayCollection value="${component.vendorNames}"/>',
+            "name": "${component.name}",
+            "lics": "<tags:TrimLineBreaks input="${licenseCollectionTagOutput}"/>",
+            "cType": '<sw360:DisplayEnum value="${component.componentType}"/>',
+            "lRelsSize": "${component.releaseIdsSize}",
+            "attsSize": "${component.attachmentsSize}"
         });
         </core_rt:forEach>
 
@@ -268,13 +269,39 @@
             "pageLength": 25,
             "data": result,
             "columns": [
-                {"title": "Vendor"},
-                {"title": "Component Name"},
-                {"title": "Main Licenses"},
-                {"title": "Component Type"},
-                {"title": "Actions"}
+                {"title": "Vendor", data: "vndrs"},
+                {"title": "Component Name", data: "name", render: {display: renderComponentNameLink}},
+                {"title": "Main Licenses", data: "lics"},
+                {"title": "Component Type", data: "cType"},
+                {"title": "Actions", data: "id", render: {display: renderComponentActions}}
             ]
         });
+    }
+
+    function renderComponentActions(id, type, row) {
+        <%--TODO most of this can be simplified to CSS properties --%>
+        return "<span id='componentAction" + id + "'></span>"
+            + renderLinkTo(
+                makeComponentUrl(id, '<%=PortalConstants.PAGENAME_EDIT%>'),
+                "",
+                "<img src='<%=request.getContextPath()%>/images/edit.png' alt='Edit' title='Edit'>")
+            + renderLinkTo(
+                makeComponentUrl(id, '<%=PortalConstants.PAGENAME_DUPLICATE%>'),
+                "",
+                "<img src='<%=request.getContextPath()%>/images/ic_clone.png' alt='Duplicate' title='Duplicate'>")
+            + "<img src='<%=request.getContextPath()%>/images/Trash.png'" +
+            " onclick=\"deleteComponent('" + id + "', '<b>" + replaceSingleQuote(row.name) + "</b>'," + replaceSingleQuote(row.lRelsSize) + "," + replaceSingleQuote(row.attsSize) + ")\" alt='Delete' title='Delete'/>";
+    }
+
+    function renderComponentNameLink(name, type, row) {
+        return renderLinkTo(makeComponentUrl(row.id, '<%=PortalConstants.PAGENAME_DETAIL%>'), name);
+    }
+
+    function makeComponentUrl(componentId, page) {
+        var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>')
+            .setParameter('<%=PortalConstants.PAGENAME%>', page)
+            .setParameter('<%=PortalConstants.COMPONENT_ID%>', componentId);
+        return portletURL.toString();
     }
 
     function deleteComponent(id, name, numberOfReleases, attachmentsSize) {

--- a/frontend/sw360-portlet/src/main/webapp/html/ecc/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/ecc/view.jsp
@@ -119,15 +119,13 @@
     function configureEccInfoTable(){
         var tbl;
         tbl = $('#eccInfoTable').dataTable({
-            "sPaginationType": "full_numbers",
-            "bAutoWidth": false,
+            pagingType: "simple_numbers",
+            dom: "lrtip",
+            "autoWidth": false,
             "order": [],
             "pageLength": 25
         });
 
-        $('#eccInfoTable_filter').hide();
-        $('#eccInfoTable_first').hide();
-        $('#eccInfoTable_last').hide();
         return tbl;
     }
 

--- a/frontend/sw360-portlet/src/main/webapp/html/ecc/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/ecc/view.jsp
@@ -48,7 +48,7 @@
         <thead>
         <tr>
             <th class="infoheading">
-                Display Filter
+                Quick Filter
             </th>
         </tr>
         </thead>
@@ -57,9 +57,6 @@
             <td>
                 <input type="text" class="searchbar"
                        id="keywordsearchinput" value="" onkeyup="useSearch('keywordsearchinput')">
-                <br/>
-                <input style="padding: 5px 20px 5px 20px; border: none; font-weight:bold;" type="button"
-                       name="searchBtn" value="Search" onclick="useSearch('keywordsearchinput')">
             </td>
         </tr>
         </tbody>
@@ -118,7 +115,7 @@
 
     function configureEccInfoTable(){
         var tbl;
-        tbl = $('#eccInfoTable').dataTable({
+        tbl = $('#eccInfoTable').DataTable({
             pagingType: "simple_numbers",
             dom: "lrtip",
             "autoWidth": false,
@@ -130,7 +127,7 @@
     }
 
     function useSearch( buttonId) {
-        eccInfoTable.fnFilter( $('#'+buttonId).val());
+        eccInfoTable.search($('#'+buttonId).val()).draw();
     }
 </script>
 

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/mycomponents/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/mycomponents/view.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~ With contributions by Bosch Software Innovations GmbH, 2016.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
@@ -45,19 +45,15 @@
         </core_rt:forEach>
 
         $('#myComponentsTable').dataTable({
-            pagingType: "full_numbers",
+            pagingType: "simple_numbers",
+            dom: "rtip",
             data: result,
-            "iDisplayLength": 10,
+            pageLength: 10,
             columns: [
                 {"title": "Component Name"},
                 {"title": "Description"}
             ]
         });
-
-        $('#myComponentsTable_filter').hide();
-        $('#myComponentsTable_first').hide();
-        $('#myComponentsTable_last').hide();
-        $('#myComponentsTable_length').hide();
     });
 
 </script>

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/myprojects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/myprojects/view.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
   ~
@@ -42,19 +42,15 @@
         </core_rt:forEach>
 
         $('#myProjectsTable').dataTable({
-            pagingType: "full_numbers",
+            pagingType: "simple_numbers",
+            dom: "rtip",
             data: result,
-            "iDisplayLength": 10,
+            pageLength: 10,
             columns: [
                 {"title": "Project Name"},
                 {"title": "Description"},
             ]
         });
-
-        $('#myProjectsTable_filter').hide();
-        $('#myProjectsTable_first').hide();
-        $('#myProjectsTable_last').hide();
-        $('#myProjectsTable_length').hide();
     });
 
 </script>

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/mytaskassignments/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/mytaskassignments/view.jsp
@@ -50,19 +50,15 @@
         </core_rt:forEach>
 
         $('#taskassignmentTable').dataTable({
-            pagingType: "full_numbers",
+            pagingType: "simple_numbers",
+            dom: "rtip",
             data: result,
-            "iDisplayLength":10,
+            pageLength:10,
             columns: [
                 {"title": "Document Name"},
                 {"title": "Status"},
             ]
         });
-
-        $('#taskassignmentTable_filter').hide();
-        $('#taskassignmentTable_first').hide();
-        $('#taskassignmentTable_last').hide();
-        $('#taskassignmentTable_length').hide();
     });
 
 </script>

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/mytasksubmissions/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/mytasksubmissions/view.jsp
@@ -56,20 +56,16 @@
         </core_rt:forEach>
 
         moderationRequestsTable = $('#tasksubmissionTable').DataTable({
-            pagingType: "full_numbers",
+            pagingType: "simple_numbers",
+            dom: "rtip",
             data: result,
-            "iDisplayLength": 10,
+            pageLength: 10,
             columns: [
                 {"title": "Document Name"},
                 {"title": "Status"},
                 {"title": "Actions"}
             ]
         });
-
-        $('#tasksubmissionTable_filter').hide();
-        $('#tasksubmissionTable_first').hide();
-        $('#tasksubmissionTable_last').hide();
-        $('#tasksubmissionTable_length').hide();
     }
     function deleteModerationRequest(id, docName) {
 

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/view.jsp
@@ -50,7 +50,7 @@
             <thead>
             <tr>
                 <th class="infoheading">
-                    Display Filter
+                    Quick Filter
                 </th>
             </tr>
             </thead>
@@ -59,9 +59,6 @@
                 <td>
                     <input type="text" class="searchbar"
                            id="keywordsearchinput" value="" onkeyup="useSearch('keywordsearchinput')">
-                    <br/>
-                    <input class="searchbutton"
-                           type="button" name="searchBtn" value="Search" onclick="useSearch('keywordsearchinput')">
                 </td>
             </tr>
             </tbody>
@@ -107,12 +104,12 @@
         });
     </core_rt:forEach>
 
-        licenseTable = $('#licensesTable').dataTable({
+        licenseTable = $('#licensesTable').DataTable({
             pagingType: "simple_numbers",
             dom: "lrtip",
             pageLength: 10,
-            "oLanguage": {
-                "sLengthMenu": 'Display <select>\
+            "language": {
+                "lengthMenu": 'Display <select>\
                 <option value="5">5</option>\
                 <option value="10">10</option>\
                 <option value="20">20</option>\
@@ -130,7 +127,7 @@
     }
 
     function useSearch(searchFieldId) {
-        licenseTable.fnFilter( $('#'+searchFieldId).val());
+        licenseTable.search($('#'+searchFieldId).val()).draw();
     }
 
 </script>

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/view.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
   ~
@@ -108,8 +108,9 @@
     </core_rt:forEach>
 
         licenseTable = $('#licensesTable').dataTable({
-            "sPaginationType": "full_numbers",
-            "iDisplayLength": 10,
+            pagingType: "simple_numbers",
+            dom: "lrtip",
+            pageLength: 10,
             "oLanguage": {
                 "sLengthMenu": 'Display <select>\
                 <option value="5">5</option>\
@@ -119,18 +120,13 @@
                 <option value="100">100</option>\
                 </select> licenses'
             },
-            "aaData": result,
-            "aoColumns": [
-                { "sTitle": "License Shortname" },
-                { "sTitle": "License Fullname" },
-                { "sTitle": "License Type" }
+            "data": result,
+            "columns": [
+                { "title": "License Shortname" },
+                { "title": "License Fullname" },
+                { "title": "License Type" }
             ]
         });
-
-        $('#licensesTable_filter').hide();
-        $('#licensesTable_first').hide();
-        $('#licensesTable_last').hide();
-
     }
 
     function useSearch(searchFieldId) {

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
@@ -44,7 +44,7 @@
                         <thead>
                         <tr>
                             <th class="infoheading">
-                                Display Filter
+                                Quick Filter
                             </th>
                         </tr>
                         </thead>
@@ -53,9 +53,6 @@
                             <td>
                                 <input type="text" class="searchbar"
                                        id="keywordsearchinput" value="" onkeyup="useSearch('keywordsearchinput')">
-                                <br/>
-                                <input class="searchbutton" type="button"
-                                       name="searchBtn" value="Search" onclick="useSearch('keywordsearchinput')">
                             </td>
                         </tr>
                         </tbody>
@@ -89,10 +86,10 @@
     </div>
 </div>
 
+<script src="<%=request.getContextPath()%>/webjars/jquery/1.12.4/jquery.min.js"></script>
 <script src="<%=request.getContextPath()%>/webjars/jquery-validation/1.15.1/jquery.validate.min.js" type="text/javascript"></script>
 <script src="<%=request.getContextPath()%>/webjars/jquery-validation/1.15.1/additional-methods.min.js" type="text/javascript"></script>
 <script src="<%=request.getContextPath()%>/webjars/github-com-craftpip-jquery-confirm/3.0.1/jquery-confirm.min.js" type="text/javascript"></script>
-<script src="<%=request.getContextPath()%>/webjars/jquery/1.12.4/jquery.min.js"></script>
 <script src="<%=request.getContextPath()%>/webjars/jquery-ui/1.12.1/jquery-ui.min.js"></script>
 <script type="text/javascript" src="<%=request.getContextPath()%>/webjars/datatables/1.10.7/js/jquery.dataTables.min.js"></script>
 

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
@@ -165,7 +165,8 @@
 
     function createModerationsTable(tableId, tableData) {
         var tbl = $(tableId).DataTable({
-            pagingType: "full_numbers",
+            pagingType: "simple_numbers",
+            dom: "lrtip",
             data: tableData,
             columns: [
                 {"title": "Document Name"},
@@ -175,10 +176,6 @@
                 {"title": "Actions"}
             ]
         });
-
-        $(tableId+'_filter').hide();
-        $(tableId+'_first').hide();
-        $(tableId+'_last').hide();
 
         return tbl;
     }

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/clearingStatus.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/clearingStatus.jspf
@@ -80,11 +80,8 @@
                 {title: "Project Mainline State"},
                 {title: "Action", data: "DT_RowId", render: renderActions}
             ],
-            paginationType: "full_numbers"
+            pagingType: "simple_numbers"
         });
-
-        $('#releasesTable_first').hide();
-        $('#releasesTable_last').hide();
 
     }
 

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/vulnerabilities.jspf
@@ -88,23 +88,23 @@
         </core_rt:forEach>
 
         projectVulnerabilityTable = $('#vulnerabilityTable').DataTable({
-            "sPaginationType": "full_numbers",
-            "aaData": result,
-            "aoColumns": [
-                {"sTitle": "Release"},
-                {"sTitle": "External id"},
-                {"sTitle": "Priority"},
-                {"sTitle": "Matched by"},
-                {"sTitle": "Title"},
+            pagingType: "simple_numbers",
+            "data": result,
+            "columns": [
+                {"title": "Release"},
+                {"title": "External id"},
+                {"title": "Priority"},
+                {"title": "Matched by"},
+                {"title": "Title"},
                 <core_rt:choose>
                     <core_rt:when test="${vulnerabilityRatingsEditable}">
-                        {"sTitle": "Relevance for project", "orderDataType": "sort-select" },
+                        {"title": "Relevance for project", "orderDataType": "sort-select" },
                     </core_rt:when>
                     <core_rt:otherwise>
-                        {"sTitle": "Relevance for project"},
+                        {"title": "Relevance for project"},
                      </core_rt:otherwise>
                 </core_rt:choose>
-                {"sTitle": "Action"}
+                {"title": "Action"}
             ],
             "order": [[ 2, 'asc' ], [ 3, 'desc' ]]
         });
@@ -116,9 +116,6 @@
                 return $(this).prop('title');
             }
         });
-
-        $('#vulnerabilityTable_first').hide();
-        $('#vulnerabilityTable_last').hide();
     }
 
     /*This can not be document ready function as liferay definitions need to be loaded first*/

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -288,10 +288,11 @@
         </core_rt:forEach>
 
         projectsTable = $('#projectsTable').DataTable({
-            "sPaginationType": "full_numbers",
-            "aaData": result,
+            "pagingType": "simple_numbers",
+            "data": result,
+            dom: "lrtip",
             search: {smart: false},
-            "aoColumns": [
+            "columns": [
                 {title: "Project Name", data: "name", render: {display: renderProjectNameLink}},
                 {title: "Description", data: "description"},
                 {title: "Project Responsible", data: "responsible"},
@@ -300,10 +301,6 @@
                 {title: "Actions", data: "id", render: {display: renderProjectActions}}
             ]
         });
-
-        $('#projectsTable_filter').hide();
-        $('#projectsTable_first').hide();
-        $('#projectsTable_last').hide();
     }
 
     const clearingColumnIndex = 4;

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -81,7 +81,7 @@
         <thead>
         <tr>
             <th class="infoheading">
-                Display Filter by Name
+                Quick Filter
             </th>
         </tr>
         </thead>
@@ -90,9 +90,6 @@
             <td>
                 <input type="text" class="searchbar"
                        id="keywordsearchinput" value="" onkeyup="useSearch('keywordsearchinput')" />
-                <br/>
-                <input type="button" class="searchbutton"
-                       name="searchBtn" value="Search" onclick="useSearch('keywordsearchinput')" />
             </td>
         </tr>
         </tbody>
@@ -103,7 +100,7 @@
             <thead>
             <tr>
                 <th class="infoheading">
-                    Filters
+                    Advanced Search
                 </th>
             </tr>
             </thead>
@@ -139,8 +136,7 @@
             <tr>
                 <td>
                     <label for="group">Group</label>
-                    <select class="searchbar toplabelledInput filterInput" id="group" name="<portlet:namespace/><%=Project._Fields.BUSINESS_UNIT%>"
-                            style="min-height: 28px;">
+                    <select class="searchbar toplabelledInput filterInput" id="group" name="<portlet:namespace/><%=Project._Fields.BUSINESS_UNIT%>">
                         <option value="" class="textlabel stackedLabel"
                                 <core_rt:if test="${empty businessUnit}"> selected="selected"</core_rt:if>
                         ></option>
@@ -170,7 +166,7 @@
             </tbody>
         </table>
         <br/>
-        <input type="submit" class="addButton" value="Apply Filters">
+        <input type="submit" class="addButton" value="Search">
     </form>
 </div>
 <div id="projectsTableDiv" class="content2">
@@ -228,9 +224,8 @@
     });
 
     function useSearch(buttonId) {
-        <%-- we only want to search names starting with the value in the search box--%>
         var val = $.fn.dataTable.util.escapeRegex($('#' + buttonId).val());
-        projectsTable.columns(0).search('^' + val, true).draw();
+        projectsTable.columns(0).search(val, true).draw();
     }
 
     function makeProjectUrl(projectId, page) {

--- a/frontend/sw360-portlet/src/main/webapp/html/search/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/search/view.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~ With contributions by Bosch Software Innovations GmbH, 2016.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
@@ -163,20 +163,18 @@
         </core_rt:forEach>
 
         $('#searchTable').dataTable({
-            "sPaginationType": "full_numbers",
-            "aaData": result,
-            "aoColumns": [
-                { "sTitle": "Type",
-                    "mRender": function ( data, type, full ) {
+            pagingType: "simple_numbers",
+            dom: "lrtip",
+            data: result,
+            columns: [
+                { "title": "Type",
+                    "render": function ( data, type, full ) {
                         return typeColumn( data, type, full );
                     }
                 },
-                { "sTitle": "Text" }
+                { "title": "Text" }
             ]
         });
-        $('#searchTable_filter').hide();
-        $('#searchTable_first').hide();
-        $('#searchTable_last').hide();
     }
 </script>
 

--- a/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/view.jsp
@@ -35,7 +35,7 @@
         <thead>
         <tr>
             <th class="infoheading">
-                Display Filter
+                Quick Filter
             </th>
         </tr>
         </thead>
@@ -44,9 +44,6 @@
             <td>
                 <input type="text" class="searchbar"
                        id="keywordsearchinput" value="" onkeyup="useSearch('keywordsearchinput')">
-                <br/>
-                <input class="searchbutton" type="button"
-                       name="searchBtn" value="Search" onclick="useSearch('keywordsearchinput')">
             </td>
         </tr>
         </tbody>
@@ -83,7 +80,7 @@
     }
 
     function useSearch(searchFieldId) {
-        vulnerabilityTable.fnFilter( $('#'+searchFieldId).val());
+        vulnerabilityTable.api().search($('#'+searchFieldId).val()).draw();
     }
 
     function createVulnerabilityTable() {

--- a/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/view.jsp
@@ -111,22 +111,20 @@
         </core_rt:forEach>
 
         vulnerabilityTable = $('#vulnerabilitiesTable').dataTable({
-            "sPaginationType": "full_numbers",
-            "aaData": result,
-            "aoColumns": [
-                {"sTitle": "External Id"},
-                {"sTitle": "Title", "width": "30%"},
-                {"sTitle": "Weighting"},
-                {"sTitle": "Publish date"},
-                {"sTitle": "Last update"}
+            pagingType: "simple_numbers",
+            dom: "lrtip",
+            "data": result,
+            "columns": [
+                {"title": "External Id"},
+                {"title": "Title", "width": "30%"},
+                {"title": "Weighting"},
+                {"title": "Publish date"},
+                {"title": "Last update"}
             ],
             "order": [[2, 'asc'], [3, 'desc']]
         });
         vulnerabilityTable.$('td').tooltip({"delay": 0, "track": true, "fade": 250});
 
-        $('#vulnerabilitiesTable_filter').hide();
-        $('#vulnerabilitiesTable_first').hide();
-        $('#vulnerabilitiesTable_last').hide();
     }
 
     function createDetailURLFromVulnerabilityId(paramVal) {

--- a/frontend/sw360-portlet/src/main/webapp/js/licenses.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/licenses.js
@@ -63,8 +63,8 @@ function createLicenseTable(data) {
         pagingType: "simple_numbers",
         dom: "lrtip",
         pageLength: 10,
-        "oLanguage": {
-            "sLengthMenu": 'Display <select>\
+        "language": {
+            "lengthMenu": 'Display <select>\
                 <option value="5">5</option>\
                 <option value="10">10</option>\
                 <option value="20">20</option>\
@@ -80,8 +80,4 @@ function createLicenseTable(data) {
         ]
     });
 
-}
-
-function licenseSearch(searchFieldId) {
-    licensesTable.fnFilter( $('#'+searchFieldId).val());
 }

--- a/frontend/sw360-portlet/src/main/webapp/js/licenses.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/licenses.js
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -60,8 +60,9 @@ function getLicenseType(lic) {
 function createLicenseTable(data) {
 
     licensesTable = $('#licensesTable').dataTable({
-        "sPaginationType": "full_numbers",
-        "iDisplayLength": 10,
+        pagingType: "simple_numbers",
+        dom: "lrtip",
+        pageLength: 10,
         "oLanguage": {
             "sLengthMenu": 'Display <select>\
                 <option value="5">5</option>\
@@ -71,17 +72,13 @@ function createLicenseTable(data) {
                 <option value="100">100</option>\
                 </select> licenses'
         },
-        "aaData": data,
-        "aoColumns": [
-            { "sTitle": "License Shortname" },
-            { "sTitle": "License Fullname" },
-            { "sTitle": "License Type" }
+        "data": data,
+        "columns": [
+            { "title": "License Shortname" },
+            { "title": "License Fullname" },
+            { "title": "License Type" }
         ]
     });
-
-    $('#licensesTable_filter').hide();
-    $('#licensesTable_first').hide();
-    $('#licensesTable_last').hide();
 
 }
 

--- a/frontend/sw360-portlet/src/main/webapp/js/search.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/search.js
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -34,18 +34,16 @@ function parseList(listString ){
 
 function createSearchTable(data) {
     $('#searchTable').dataTable({
-        "sPaginationType": "full_numbers",
-        "aaData": data,
-        "aoColumns": [
-            { "sTitle": "Type",
+        "pagingType": "simple_numbers",
+        dom: "lrtip",
+        "data": data,
+        "columns": [
+            { "title": "Type",
                 "mRender": function ( data, type, full ) {
                     return typeColumn( data, type, full );
                 }
             },
-            { "sTitle": "Text" }
+            { "title": "Text" }
         ]
     });
-    $('#searchTable_filter').hide();
-    $('#searchTable_first').hide();
-    $('#searchTable_last').hide();
 }

--- a/frontend/sw360-theme/src/main/webapp/css/custom.css
+++ b/frontend/sw360-theme/src/main/webapp/css/custom.css
@@ -1,6 +1,6 @@
 /**
 *
-* Modifications applied by Siemens AG 2014.
+* Modifications applied by Siemens AG 2014-2017.
 * Modifications for supporting own infrastructure.
 *
 * Original file from: Liferay Inc.
@@ -533,6 +533,13 @@ hr, .separator {
 	border-bottom: none;
 }
 
+.pageHeaderMediumSpan {
+	color: red;
+	font-family: arial-black, sans-serif;
+	font-size: 18px;
+	display: inline;
+	border-bottom: none;
+}
 .pageHeaderSmallSpan {
 	color: red;
 	font-family: arial-black, sans-serif;
@@ -540,7 +547,6 @@ hr, .separator {
 	display: inline;
 	border-bottom: none;
 }
-
 
 div.content1 {
 	padding: 0px;

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -315,6 +315,17 @@ service ComponentService {
     list<Component> getComponentSummary(1: User user);
 
     /**
+     * summary of up to `limit` components reverse ordered by `createdOn`. Negative `limit` will result in
+     * all components being returned
+     **/
+    list<Component> getRecentComponentsSummary(1: i32 limit, 2: User user);
+
+    /**
+     * total number of components in the DB, irrespective of whether the user may see them or not
+     **/
+    i32 getTotalComponentsCount(1: User user);
+
+    /**
      * short summary of all releases visible to user
      **/
     list<Release> getReleaseSummary(1: User user);
@@ -343,11 +354,6 @@ service ComponentService {
      * information for home portlet
      **/
     list<Release> getSubscribedReleases(1: User user);
-
-    /**
-     * information for home portlet
-     **/
-    list<Component> getRecentComponents();
 
     /**
      * information for home portlet


### PR DESCRIPTION
feat(components): restructure components view to show only latest components for performance reasons
rename Display Filter to Quick Filter and Filters to Advanced Search
use new datatables search api throughout the application
chore(components): reduce view page size by restructuring generated data js code
chore(tables): replace unnecessary hiding of control elements with proper datatables api usage