### PR TITLE
chore(header): add SPDX Identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ are excluded from the WAR file while packaging. Using below configuration,
 
 SPDX Short Identifier: http://spdx.org/licenses/EPL-1.0
 
+SPDX-License-Identifier: EPL-1.0
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 # Copyright (c) Bosch Software Innovations GmbH 2016.
 # Part of the SW360 Portal Project.
 #
+# SPDX-License-Identifier: EPL-1.0
+#
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src-common/pom.xml
+++ b/backend/src-common/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/DocumentSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/DocumentSummary.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/LicenseSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/LicenseSummary.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/LicenseTypeSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/LicenseTypeSummary.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ModerationRequestSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ModerationRequestSummary.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ProjectSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ProjectSummary.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ReleaseSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ReleaseSummary.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/SummaryType.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/SummaryType.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/UserSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/UserSummary.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/couchdb/SummaryAwareRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/couchdb/SummaryAwareRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/CustomPropertiesRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/CustomPropertiesRepository.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectVulnerabilityRatingRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectVulnerabilityRatingRepository.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/RepositoryUtils.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/RepositoryUtils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/VendorRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/VendorRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/VendorSearch.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/VendorSearch.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ComponentModerator.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ComponentModerator.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/LicenseModerator.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/LicenseModerator.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ProjectModerator.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ProjectModerator.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ReleaseModerator.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ReleaseModerator.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/mail/MailConstants.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/mail/MailConstants.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/mail/MailUtil.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/mail/MailUtil.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/main/java/org/eclipse/sw360/projects/Sw360ThriftServlet.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/projects/Sw360ThriftServlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/test/java/org/eclipse/sw360/components/summary/ProjectSummaryTest.java
+++ b/backend/src-common/src/test/java/org/eclipse/sw360/components/summary/ProjectSummaryTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerTest.java
+++ b/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/pom.xml
+++ b/backend/src/pom.xml
@@ -3,6 +3,8 @@
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-attachments/pom.xml
+++ b/backend/src/src-attachments/pom.xml
@@ -1,6 +1,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentHandler.java
+++ b/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentServlet.java
+++ b/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentServlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/db/AttachmentDatabaseHandler.java
+++ b/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/db/AttachmentDatabaseHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/db/AttachmentRepository.java
+++ b/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/db/AttachmentRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-attachments/src/test/java/org/eclipse/sw360/attachments/AttachmentHandlerTest.java
+++ b/backend/src/src-attachments/src/test/java/org/eclipse/sw360/attachments/AttachmentHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-attachments/src/test/java/org/eclipse/sw360/attachments/TestAttachmentClient.java
+++ b/backend/src/src-attachments/src/test/java/org/eclipse/sw360/attachments/TestAttachmentClient.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-components/pom.xml
+++ b/backend/src/src-components/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentServlet.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentServlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/ComponentHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/ComponentHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/TestComponentClient.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/TestComponentClient.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentSearchHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentSearchHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ProjectDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ProjectDatabaseHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/pom.xml
+++ b/backend/src/src-cvesearch/pom.xml
@@ -3,6 +3,8 @@
   ~ Copyright (c) Bosch Software Innovations GmbH 2016.
   ~ Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasink/VulnerabilityConnector.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasink/VulnerabilityConnector.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchApi.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchApi.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchApiImpl.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchApiImpl.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchData.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchData.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchGuesser.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchGuesser.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchWrapper.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchWrapper.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/heuristics/Heuristic.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/heuristics/Heuristic.java
@@ -3,6 +3,8 @@
  * Copyright Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/heuristics/SearchLevels.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/heuristics/SearchLevels.java
@@ -3,6 +3,8 @@
  * Copyright Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/json/CveSearchJsonParser.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/json/CveSearchJsonParser.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/matcher/ListMatcher.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/matcher/ListMatcher.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/matcher/ModifiedLevenshteinDistance.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/matcher/ModifiedLevenshteinDistance.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/entitytranslation/CveSearchDataToReleaseVulnerabilityRelationTranslator.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/entitytranslation/CveSearchDataToReleaseVulnerabilityRelationTranslator.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/entitytranslation/CveSearchDataToVulnerabilityTranslator.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/entitytranslation/CveSearchDataToVulnerabilityTranslator.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/entitytranslation/CveSearchDataTranslator.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/entitytranslation/CveSearchDataTranslator.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/entitytranslation/EntityTranslator.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/entitytranslation/EntityTranslator.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2015-2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/helper/VulnerabilityUtils.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/helper/VulnerabilityUtils.java
@@ -3,6 +3,8 @@
  * Copyright Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/service/CveSearchHandler.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/service/CveSearchHandler.java
@@ -3,6 +3,8 @@
  * With modifications by Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/service/CveSearchServlet.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/service/CveSearchServlet.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasink/VulnerabilityConnectorTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasink/VulnerabilityConnectorTest.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchApiImplTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchApiImplTest.java
@@ -3,6 +3,8 @@
  * With modifications by Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchDataTestHelper.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchDataTestHelper.java
@@ -3,6 +3,8 @@
  * With modifications by Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchGuesserTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchGuesserTest.java
@@ -3,6 +3,8 @@
  * With modifications by Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchWrapperTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchWrapperTest.java
@@ -3,6 +3,8 @@
  * With modifications by Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/json/CveSearchJsonParserTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/json/CveSearchJsonParserTest.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/matcher/ListMatcherTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/matcher/ListMatcherTest.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/matcher/ModifiedLevenshteinDistanceTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/matcher/ModifiedLevenshteinDistanceTest.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/entitytranslation/CveSearchDataTranslatorTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/entitytranslation/CveSearchDataTranslatorTest.java
@@ -3,6 +3,8 @@
  * With modifications by Siemens AG, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/service/CveSearchHandlerTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/service/CveSearchHandlerTest.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/pom.xml
+++ b/backend/src/src-fossology/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/FossologyServlet.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/FossologyServlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/SpringTServlet.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/SpringTServlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologyConfig.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologyConfig.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologySettings.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologySettings.java
@@ -3,6 +3,8 @@
  * With modifications by Bosch Software Innovations GmbH, 2016
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/db/FossologyFingerPrintRepository.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/db/FossologyFingerPrintRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/handler/FossologyFileHandler.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/handler/FossologyFileHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/handler/FossologyHostKeyHandler.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/handler/FossologyHostKeyHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/handler/FossologyScriptsHandler.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/handler/FossologyScriptsHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/ssh/FossologySshConnector.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/ssh/FossologySshConnector.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/ssh/FossologyUploader.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/ssh/FossologyUploader.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/ssh/JSchSessionProvider.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/ssh/JSchSessionProvider.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/ssh/keyrepo/FossologyHostKeyRepository.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/ssh/keyrepo/FossologyHostKeyRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/resources/scripts/duplicateUpload
+++ b/backend/src/src-fossology/src/main/resources/scripts/duplicateUpload
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
 #
+# SPDX-License-Identifier: EPL-1.0
+#
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/resources/scripts/folderManager
+++ b/backend/src/src-fossology/src/main/resources/scripts/folderManager
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
 #
+# SPDX-License-Identifier: EPL-1.0
+#
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/resources/scripts/getStatusOfUpload
+++ b/backend/src/src-fossology/src/main/resources/scripts/getStatusOfUpload
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
 #
+# SPDX-License-Identifier: EPL-1.0
+#
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/resources/scripts/uploadFromSW360
+++ b/backend/src/src-fossology/src/main/resources/scripts/uploadFromSW360
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
 #
+# SPDX-License-Identifier: EPL-1.0
+#
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/main/resources/scripts/utilsSW360
+++ b/backend/src/src-fossology/src/main/resources/scripts/utilsSW360
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
 #
+# SPDX-License-Identifier: EPL-1.0
+#
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/FossologyHandlerTest.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/FossologyHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/config/FossologySettingsTest.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/config/FossologySettingsTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/config/TestConfig.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/config/TestConfig.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/handler/FossologyFileHandlerTest.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/handler/FossologyFileHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/handler/FossologyHostKeyHandlerTest.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/handler/FossologyHostKeyHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/handler/FossologyScriptsHandlerTest.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/handler/FossologyScriptsHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/ssh/FossologySshConnectorTest.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/ssh/FossologySshConnectorTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/ssh/FossologyUploaderFunctionalTest.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/ssh/FossologyUploaderFunctionalTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/ssh/FossologyUploaderTest.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/ssh/FossologyUploaderTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/ssh/JSchSessionProviderTest.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/ssh/JSchSessionProviderTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/ssh/RealSshConnectionUtils.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/ssh/RealSshConnectionUtils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/ssh/keyrepo/FossologyHostKeyRepositoryTest.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/ssh/keyrepo/FossologyHostKeyRepositoryTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/pom.xml
+++ b/backend/src/src-licenseinfo/pom.xml
@@ -1,6 +1,8 @@
 <!--
   ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoServlet.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoServlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
@@ -2,6 +2,8 @@
  * Copyright Bosch Software Innovations GmbH, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
@@ -2,6 +2,8 @@
  * Copyright Bosch Software Innovations GmbH, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/LicenseInfoGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/LicenseInfoGenerator.java
@@ -3,6 +3,8 @@
  * With modifications by Siemens AG, 2017.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
@@ -3,6 +3,8 @@
  * With modifications by Siemens AG, 2017.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
@@ -3,6 +3,8 @@
  * With modifications by Siemens AG, 2017.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AttachmentContentProvider.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AttachmentContentProvider.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParser.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParser.java
@@ -3,6 +3,8 @@
  * Copyright Siemens AG, 2016-2017.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
@@ -2,6 +2,8 @@
  * Copyright Bosch Software Innovations GmbH, 2017.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandlerTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/TestHelper.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/TestHelper.java
@@ -2,6 +2,8 @@
  * Copyright Bosch Software Innovations GmbH, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
@@ -2,6 +2,8 @@
  * Copyright Bosch Software Innovations GmbH, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
@@ -3,6 +3,8 @@
  * With modifications by Bosch Software Innovations GmbH, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParserTest.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2017.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParserTest.java
@@ -2,6 +2,8 @@
  * Copyright Bosch Software Innovations GmbH, 2017.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
@@ -2,6 +2,8 @@
  * Copyright Bosch Software Innovations GmbH, 2016-2017.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenses/pom.xml
+++ b/backend/src/src-licenses/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/LicenseServlet.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/LicenseServlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016-2017.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseRepository.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseTypeRepository.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseTypeRepository.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/ObligationRepository.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/ObligationRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/RiskCategoryRepository.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/RiskCategoryRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/RiskRepository.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/RiskRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/TodoRepository.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/TodoRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/tools/SpdxConnector.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/tools/SpdxConnector.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2017.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenses/src/test/java/org/eclipse/sw360/licenses/LicenseHandlerTest.java
+++ b/backend/src/src-licenses/src/test/java/org/eclipse/sw360/licenses/LicenseHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-licenses/src/test/java/org/eclipse/sw360/licenses/TestLicenseClient.java
+++ b/backend/src/src-licenses/src/test/java/org/eclipse/sw360/licenses/TestLicenseClient.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/pom.xml
+++ b/backend/src/src-moderation/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/ModerationServlet.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/ModerationServlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/COTSDetailsModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/COTSDetailsModerationRequestGenerator.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ClearingInformationModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ClearingInformationModerationRequestGenerator.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ComponentModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ComponentModerationRequestGenerator.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/DocumentDatabaseHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/DocumentDatabaseHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/EccInformationModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/EccInformationModerationRequestGenerator.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/LicenseModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/LicenseModerationRequestGenerator.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestGenerator.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestRepository.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ProjectModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ProjectModerationRequestGenerator.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ReleaseModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ReleaseModerationRequestGenerator.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/test/java/org/eclipse/sw360/moderation/TestModerationClient.java
+++ b/backend/src/src-moderation/src/test/java/org/eclipse/sw360/moderation/TestModerationClient.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-moderation/src/test/java/org/eclipse/sw360/moderation/testutil/DatabaseTestSetup.java
+++ b/backend/src/src-moderation/src/test/java/org/eclipse/sw360/moderation/testutil/DatabaseTestSetup.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-projects/pom.xml
+++ b/backend/src/src-projects/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectServlet.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectServlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-projects/src/test/java/org/eclipse/sw360/projects/ProjectHandlerTest.java
+++ b/backend/src/src-projects/src/test/java/org/eclipse/sw360/projects/ProjectHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-projects/src/test/java/org/eclipse/sw360/projects/TestProjectClient.java
+++ b/backend/src/src-projects/src/test/java/org/eclipse/sw360/projects/TestProjectClient.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-schedule/pom.xml
+++ b/backend/src/src-schedule/pom.xml
@@ -3,6 +3,8 @@
   ~ Copyright (c) Bosch Software Innovations GmbH 2016.
   ~ Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/service/ScheduleHandler.java
+++ b/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/service/ScheduleHandler.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/service/ScheduleServlet.java
+++ b/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/service/ScheduleServlet.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/timer/SW360Task.java
+++ b/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/timer/SW360Task.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  * With modifications from Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/timer/ScheduleConstants.java
+++ b/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/timer/ScheduleConstants.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  * With modifications from Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/timer/ScheduleSyncTask.java
+++ b/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/timer/ScheduleSyncTask.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  * With modifications from Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/timer/Scheduler.java
+++ b/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/timer/Scheduler.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  * With modifications from Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-search/pom.xml
+++ b/backend/src/src-search/pom.xml
@@ -1,6 +1,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-search/src/main/java/org/eclipse/sw360/search/SearchHandler.java
+++ b/backend/src/src-search/src/main/java/org/eclipse/sw360/search/SearchHandler.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-search/src/main/java/org/eclipse/sw360/search/SearchServlet.java
+++ b/backend/src/src-search/src/main/java/org/eclipse/sw360/search/SearchServlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-search/src/main/java/org/eclipse/sw360/search/common/SearchConstants.java
+++ b/backend/src/src-search/src/main/java/org/eclipse/sw360/search/common/SearchConstants.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-search/src/main/java/org/eclipse/sw360/search/db/DatabaseSearchHandler.java
+++ b/backend/src/src-search/src/main/java/org/eclipse/sw360/search/db/DatabaseSearchHandler.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-search/src/main/java/org/eclipse/sw360/search/db/SearchDocument.java
+++ b/backend/src/src-search/src/main/java/org/eclipse/sw360/search/db/SearchDocument.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-search/src/test/java/org/eclipse/sw360/search/SearchHandlerTest.java
+++ b/backend/src/src-search/src/test/java/org/eclipse/sw360/search/SearchHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-search/src/test/java/org/eclipse/sw360/search/TestSearchClient.java
+++ b/backend/src/src-search/src/test/java/org/eclipse/sw360/search/TestSearchClient.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-search/src/test/java/org/eclipse/sw360/search/db/SearchDocumentTest.java
+++ b/backend/src/src-search/src/test/java/org/eclipse/sw360/search/db/SearchDocumentTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-users/pom.xml
+++ b/backend/src/src-users/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-users/src/main/java/org/eclipse/sw360/users/UserHandler.java
+++ b/backend/src/src-users/src/main/java/org/eclipse/sw360/users/UserHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-users/src/main/java/org/eclipse/sw360/users/UserServlet.java
+++ b/backend/src/src-users/src/main/java/org/eclipse/sw360/users/UserServlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
+++ b/backend/src/src-users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-users/src/test/java/org/eclipse/sw360/users/TestUserClient.java
+++ b/backend/src/src-users/src/test/java/org/eclipse/sw360/users/TestUserClient.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-vendors/pom.xml
+++ b/backend/src/src-vendors/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
+++ b/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorServlet.java
+++ b/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorServlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-vendors/src/test/java/org/eclipse/sw360/vendors/TestVendorClient.java
+++ b/backend/src/src-vendors/src/test/java/org/eclipse/sw360/vendors/TestVendorClient.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-vendors/src/test/java/org/eclipse/sw360/vendors/VendorHandlerTest.java
+++ b/backend/src/src-vendors/src/test/java/org/eclipse/sw360/vendors/VendorHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-vulnerabilities/pom.xml
+++ b/backend/src/src-vulnerabilities/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
@@ -3,6 +3,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityServlet.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityServlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/common/VulnerabilityMapper.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/common/VulnerabilityMapper.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityDatabaseHandler.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityDatabaseHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityRelationRepository.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityRelationRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityRepository.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/svc-common/pom.xml
+++ b/backend/svc-common/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc-common/src/main/java/org/eclipse/sw360/SW360ServiceContextListener.java
+++ b/backend/svc-common/src/main/java/org/eclipse/sw360/SW360ServiceContextListener.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/svc/pom.xml
+++ b/backend/svc/pom.xml
@@ -3,6 +3,8 @@
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-attachments/pom.xml
+++ b/backend/svc/svc-attachments/pom.xml
@@ -1,6 +1,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-attachments/src/main/webapp/WEB-INF/web.xml
+++ b/backend/svc/svc-attachments/src/main/webapp/WEB-INF/web.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-attachments/src/main/webapp/index.jsp
+++ b/backend/svc/svc-attachments/src/main/webapp/index.jsp
@@ -1,6 +1,8 @@
 <!--
 Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
 
+SPDX-License-Identifier: EPL-1.0
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/backend/svc/svc-components/pom.xml
+++ b/backend/svc/svc-components/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-components/src/main/webapp/WEB-INF/web.xml
+++ b/backend/svc/svc-components/src/main/webapp/WEB-INF/web.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-components/src/main/webapp/index.jsp
+++ b/backend/svc/svc-components/src/main/webapp/index.jsp
@@ -1,6 +1,8 @@
 <!--
 Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
 
+SPDX-License-Identifier: EPL-1.0
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/backend/svc/svc-cvesearch/pom.xml
+++ b/backend/svc/svc-cvesearch/pom.xml
@@ -3,6 +3,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With modifications from Bosch Software Innovations GmbH, 2015.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-cvesearch/src/main/webapp/WEB-INF/web.xml
+++ b/backend/svc/svc-cvesearch/src/main/webapp/WEB-INF/web.xml
@@ -3,6 +3,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With modifications from Bosch Software Innovations GmbH, 2015-2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-cvesearch/src/main/webapp/index.jsp
+++ b/backend/svc/svc-cvesearch/src/main/webapp/index.jsp
@@ -2,6 +2,8 @@
 Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
 With modifications from Bosch Software Innovations GmbH, 2015-2016.
 
+SPDX-License-Identifier: EPL-1.0
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/backend/svc/svc-fossology/pom.xml
+++ b/backend/svc/svc-fossology/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-fossology/src/main/webapp/WEB-INF/web.xml
+++ b/backend/svc/svc-fossology/src/main/webapp/WEB-INF/web.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-fossology/src/main/webapp/index.jsp
+++ b/backend/svc/svc-fossology/src/main/webapp/index.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-licenseinfo/pom.xml
+++ b/backend/svc/svc-licenseinfo/pom.xml
@@ -1,6 +1,8 @@
 <!--
   ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-licenseinfo/src/main/webapp/WEB-INF/web.xml
+++ b/backend/svc/svc-licenseinfo/src/main/webapp/WEB-INF/web.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-licenseinfo/src/main/webapp/index.jsp
+++ b/backend/svc/svc-licenseinfo/src/main/webapp/index.jsp
@@ -1,6 +1,8 @@
 <!--
 Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
 
+SPDX-License-Identifier: EPL-1.0
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/backend/svc/svc-licenses/pom.xml
+++ b/backend/svc/svc-licenses/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-licenses/src/main/webapp/WEB-INF/web.xml
+++ b/backend/svc/svc-licenses/src/main/webapp/WEB-INF/web.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-licenses/src/main/webapp/index.jsp
+++ b/backend/svc/svc-licenses/src/main/webapp/index.jsp
@@ -1,6 +1,8 @@
 <!--
 Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
 
+SPDX-License-Identifier: EPL-1.0
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/backend/svc/svc-moderation/pom.xml
+++ b/backend/svc/svc-moderation/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-moderation/src/main/webapp/WEB-INF/web.xml
+++ b/backend/svc/svc-moderation/src/main/webapp/WEB-INF/web.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-moderation/src/main/webapp/index.jsp
+++ b/backend/svc/svc-moderation/src/main/webapp/index.jsp
@@ -1,6 +1,8 @@
 <!--
 Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
 
+SPDX-License-Identifier: EPL-1.0
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/backend/svc/svc-projects/pom.xml
+++ b/backend/svc/svc-projects/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-projects/src/main/webapp/WEB-INF/web.xml
+++ b/backend/svc/svc-projects/src/main/webapp/WEB-INF/web.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-projects/src/main/webapp/index.jsp
+++ b/backend/svc/svc-projects/src/main/webapp/index.jsp
@@ -1,6 +1,8 @@
 <!--
 Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
 
+SPDX-License-Identifier: EPL-1.0
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/backend/svc/svc-schedule/pom.xml
+++ b/backend/svc/svc-schedule/pom.xml
@@ -3,6 +3,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With modifications from Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-schedule/src/main/webapp/WEB-INF/web.xml
+++ b/backend/svc/svc-schedule/src/main/webapp/WEB-INF/web.xml
@@ -3,6 +3,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With modifications from Bosch Software Innovations GmbH, 2015-2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-schedule/src/main/webapp/index.jsp
+++ b/backend/svc/svc-schedule/src/main/webapp/index.jsp
@@ -2,6 +2,8 @@
 Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
 With modifications from Bosch Software Innovations GmbH, 2015-2016.
 
+SPDX-License-Identifier: EPL-1.0
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/backend/svc/svc-search/pom.xml
+++ b/backend/svc/svc-search/pom.xml
@@ -1,6 +1,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-search/src/main/webapp/WEB-INF/web.xml
+++ b/backend/svc/svc-search/src/main/webapp/WEB-INF/web.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-search/src/main/webapp/index.jsp
+++ b/backend/svc/svc-search/src/main/webapp/index.jsp
@@ -1,6 +1,8 @@
 <!--
 Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
 
+SPDX-License-Identifier: EPL-1.0
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/backend/svc/svc-users/pom.xml
+++ b/backend/svc/svc-users/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-users/src/main/webapp/WEB-INF/web.xml
+++ b/backend/svc/svc-users/src/main/webapp/WEB-INF/web.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-users/src/main/webapp/index.jsp
+++ b/backend/svc/svc-users/src/main/webapp/index.jsp
@@ -1,6 +1,8 @@
 <!--
 Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
 
+SPDX-License-Identifier: EPL-1.0
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/backend/svc/svc-vendors/pom.xml
+++ b/backend/svc/svc-vendors/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-vendors/src/main/webapp/WEB-INF/web.xml
+++ b/backend/svc/svc-vendors/src/main/webapp/WEB-INF/web.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-vendors/src/main/webapp/index.jsp
+++ b/backend/svc/svc-vendors/src/main/webapp/index.jsp
@@ -1,6 +1,8 @@
 <!--
 Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
 
+SPDX-License-Identifier: EPL-1.0
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/backend/svc/svc-vulnerabilities/pom.xml
+++ b/backend/svc/svc-vulnerabilities/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-vulnerabilities/src/main/webapp/WEB-INF/web.xml
+++ b/backend/svc/svc-vulnerabilities/src/main/webapp/WEB-INF/web.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/svc/svc-vulnerabilities/src/main/webapp/index.jsp
+++ b/backend/svc/svc-vulnerabilities/src/main/webapp/index.jsp
@@ -1,6 +1,8 @@
 <!--
 Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
 
+SPDX-License-Identifier: EPL-1.0
+
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/backend/utils/pom.xml
+++ b/backend/utils/pom.xml
@@ -1,6 +1,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/backend/utils/src/main/java/org/eclipse/sw360/UtilsEntryPoint.java
+++ b/backend/utils/src/main/java/org/eclipse/sw360/UtilsEntryPoint.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/utils/src/main/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloader.java
+++ b/backend/utils/src/main/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloader.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/backend/utils/src/test/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloaderTest.java
+++ b/backend/utils/src/test/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloaderTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/layouttpl/pom.xml
+++ b/frontend/layouttpl/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/layouttpl/src/main/webapp/sw360layout_3_col_cstm.tpl
+++ b/frontend/layouttpl/src/main/webapp/sw360layout_3_col_cstm.tpl
@@ -1,6 +1,8 @@
 <!-- 
   Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
  
+  SPDX-License-Identifier: EPL-1.0
+
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Public License v1.0
   which accompanies this distribution, and is available at

--- a/frontend/layouttpl/src/main/webapp/sw360layout_3_col_cstm.wap.tpl
+++ b/frontend/layouttpl/src/main/webapp/sw360layout_3_col_cstm.wap.tpl
@@ -1,6 +1,8 @@
 <!-- 
   Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
  
+  SPDX-License-Identifier: EPL-1.0
+
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Public License v1.0
   which accompanies this distribution, and is available at

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/pom.xml
+++ b/frontend/sw360-portlet/pom.xml
@@ -3,6 +3,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/AttachmentPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/AttachmentPortletUtils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CommonVulnerabilityPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CommonVulnerabilityPortletUtils.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/JsonHelpers.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/JsonHelpers.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ResumableUpload.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ResumableUpload.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ThriftJsonSerializer.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ThriftJsonSerializer.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/UsedAsLiferayAction.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/UsedAsLiferayAction.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/datatables/DataTablesParser.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/datatables/DataTablesParser.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/datatables/data/DataTablesColumn.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/datatables/data/DataTablesColumn.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/datatables/data/DataTablesOrder.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/datatables/data/DataTablesOrder.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/datatables/data/DataTablesParameters.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/datatables/data/DataTablesParameters.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/datatables/data/DataTablesSearch.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/datatables/data/DataTablesSearch.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/page/PortletDefaultPage.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/page/PortletDefaultPage.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/page/PortletPage.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/page/PortletPage.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/page/PortletReleasePage.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/page/PortletReleasePage.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/hooks/BuildInfoForVelocityProviderHook.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/hooks/BuildInfoForVelocityProviderHook.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/AttachmentAwarePortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/AttachmentAwarePortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/FossologyAwarePortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/FossologyAwarePortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/LinkToPortletConfiguration.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/LinkToPortletConfiguration.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2015-2017. Part of the SW360 Portal Project,
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/LinkedReleasesAndProjectsAwarePortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/LinkedReleasesAndProjectsAwarePortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/AttachmentVacuum.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/AttachmentVacuum.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/BulkReleaseEdit.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/BulkReleaseEdit.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/ComponentUploadPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/ComponentUploadPortlet.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/DatabaseSanitation.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/DatabaseSanitation.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/FossologyAdminPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/FossologyAdminPortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/ScheduleAdminPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/ScheduleAdminPortlet.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/UserPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/UserPortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/VendorPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/VendorPortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortletUtils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/ecc/EccPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/ecc/EccPortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyComponentsPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyComponentsPortlet.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyProjectsPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyProjectsPortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MySubscriptionsPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MySubscriptionsPortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyTaskAssignmentsPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyTaskAssignmentsPortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyTaskSubmissionsPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyTaskSubmissionsPortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/RecentComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/RecentComponentPortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/RecentReleasesPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/RecentReleasesPortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/licenses/LicensesPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/licenses/LicensesPortlet.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectImportPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectImportPortlet.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2015.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/search/SearchPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/search/SearchPortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/signup/Registrant.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/signup/Registrant.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/signup/SignupPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/signup/SignupPortlet.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/signup/SignupPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/signup/SignupPortletUtils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/vulnerabilities/VulnerabilitiesPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/vulnerabilities/VulnerabilitiesPortlet.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/CompareAttachments.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/CompareAttachments.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/CompareTodos.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/CompareTodos.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/ContextAwareTag.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/ContextAwareTag.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayBoolean.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayBoolean.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayCVEReferences.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayCVEReferences.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayCollection.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayCollection.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayComponentChanges.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayComponentChanges.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayDescription.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayDescription.java
@@ -2,6 +2,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayEnum.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayEnum.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayEnumSelection.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayEnumSelection.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayLicensesEdit.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayLicensesEdit.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayMap.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayMap.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayMapOfEmailStringSets.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayMapOfEmailStringSets.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayMapOfMaps.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayMapOfMaps.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayOutputFormats.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayOutputFormats.java
@@ -2,6 +2,8 @@
  * Copyright Bosch Software Innovations GmbH, 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayProjectChanges.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayProjectChanges.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayReleaseChanges.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayReleaseChanges.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayReleaseClearingStateSummary.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayReleaseClearingStateSummary.java
@@ -2,6 +2,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplaySubscribeButton.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplaySubscribeButton.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUser.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUser.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUserEdit.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUserEdit.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUserEmail.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUserEmail.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUserEmailCollection.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUserEmailCollection.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUserGroup.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayUserGroup.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayVendorAdvisories.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayVendorAdvisories.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayVendorEdit.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayVendorEdit.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/LicenseName.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/LicenseName.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/NameSpaceAwareTag.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/NameSpaceAwareTag.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/OutTag.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/OutTag.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/ProjectName.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/ProjectName.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/ReleaseName.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/ReleaseName.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/UserAwareTag.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/UserAwareTag.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/UserName.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/UserName.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLink.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLink.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkAbstract.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkAbstract.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToComponent.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToComponent.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToLicense.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToLicense.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2015-2016. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToModerationRequest.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToModerationRequest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToProject.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToProject.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToRelease.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToRelease.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2015-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToSearchResult.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToSearchResult.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToVulnerability.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToVulnerability.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/urlutils/LinkedReleaseRenderer.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/urlutils/LinkedReleaseRenderer.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/urlutils/UrlWriter.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/urlutils/UrlWriter.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/urlutils/UrlWriterImpl.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/urlutils/UrlWriterImpl.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/LifeRayUserSession.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/LifeRayUserSession.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/LoginAction.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/LoginAction.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/SSOAutoLogin.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/SSOAutoLogin.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/TestAutoLogin.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/TestAutoLogin.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserCSV.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserCSV.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserCache.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserCache.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserCacheHolder.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserCacheHolder.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserPortletUtils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserUtils.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/liferay-portlet.xml
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/liferay-portlet.xml
@@ -3,6 +3,8 @@
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/portlet.xml
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/portlet.xml
@@ -3,6 +3,8 @@
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/tags/DisplayLicenseCollection.tag
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/tags/DisplayLicenseCollection.tag
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/tags/TrimLineBreaks.tag
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/tags/TrimLineBreaks.tag
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/tags/yesno.tag
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/tags/yesno.tag
@@ -3,6 +3,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/css/main.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/main.css
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/css/search.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/search.css
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2014. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/attachmentVacuum/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/attachmentVacuum/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/bulkReleaseEdit/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/bulkReleaseEdit/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/databaseSanitation/duplicatesAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/databaseSanitation/duplicatesAjax.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/databaseSanitation/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/databaseSanitation/view.jsp
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   - With contributions by Bosch Software Innovations GmbH, 2016-2017.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/fossyAdmin/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/fossyAdmin/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/scheduleAdmin/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/scheduleAdmin/view.jsp
@@ -1,6 +1,8 @@
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %><%--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/vendors/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/vendors/edit.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/vendors/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/vendors/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/ajax/vendorAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/ajax/vendorAjax.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/ajax/vendorSearch.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/ajax/vendorSearch.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/detail.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/detail.jsp
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/detailRelease.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/detailRelease.jsp
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/edit.jsp
@@ -2,6 +2,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
@@ -2,6 +2,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/detailOverview.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/detailOverview.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/editBasicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/editBasicInfo.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/summary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/summary.jspf
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~ With contributions by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/vulnerabilities.jspf
@@ -7,6 +7,8 @@
   ~ Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
   ~ With modifications from Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/clearingDetails.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/clearingDetails.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/commercialDetails.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/commercialDetails.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/detailOverview.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/detailOverview.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/eccDetails.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/eccDetails.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editCommercialDetails.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editCommercialDetails.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseClearingInformation.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseClearingInformation.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseECCInformation.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseECCInformation.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseInformation.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseInformation.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseRepository.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseRepository.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/releases.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/releases.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/summaryRelease.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/summaryRelease.jspf
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/vulnerabilities.jspf
@@ -6,6 +6,8 @@
   ~ Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
   ~ With modifications from Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/vendors/addVendorForm.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/vendors/addVendorForm.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/vendors/vendorDetail.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/vendors/vendorDetail.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/vendors/vendorSearchForm.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/vendors/vendorSearchForm.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/ecc/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/ecc/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/mycomponents/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/mycomponents/view.jsp
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With contributions by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/myprojects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/myprojects/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/mysubscriptions/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/mysubscriptions/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/mytaskassignments/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/mytaskassignments/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/mytasksubmissions/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/mytasksubmissions/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/recentcomponents/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/recentcomponents/view.jsp
@@ -4,6 +4,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/recentreleases/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/recentreleases/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/signup/success.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/signup/success.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/signup/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/signup/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/welcome/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/welcome/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/init.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/init.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/detail.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/detail.jsp
@@ -3,6 +3,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/edit.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailAddTodo.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailAddTodo.jspf
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailOverview.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailOverview.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailRisks.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailRisks.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailSummary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailSummary.jspf
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailText.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailText.jspf
@@ -3,6 +3,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailTodos.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailTodos.jspf
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/editDetailSummary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/editDetailSummary.jspf
@@ -4,6 +4,8 @@
 <%--
   ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/editDetailText.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/editDetailText.jspf
@@ -2,6 +2,8 @@
 <%--
   ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/components/delete.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/components/delete.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/components/merge.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/components/merge.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/includes/moderationActionButtons.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/includes/moderationActionButtons.jspf
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/includes/moderationActions.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/includes/moderationActions.jspf
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/licenses/merge.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/licenses/merge.jsp
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/projects/delete.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/projects/delete.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/projects/merge.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/projects/merge.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/releases/delete.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/releases/delete.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/releases/merge.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/releases/merge.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/users/merge.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/users/merge.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal User.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/ajax/linkedProjectsAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/ajax/linkedProjectsAjax.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/ajax/searchProjectsAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/ajax/searchProjectsAjax.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/ajax/sendableTable.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/ajax/sendableTable.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/detail.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/detail.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
@@ -2,6 +2,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/import.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/import.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright (c) Bosch Software Innovations GmbH 2015-2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
   ~ Copyright Bosch Software Innovations GmbH, 2017.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/detailOverview.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/detailOverview.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/linkedProjectDelete.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/linkedProjectDelete.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/linkedProjects.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/linkedProjects.jspf
@@ -3,6 +3,8 @@
 <%@ page import="javax.portlet.PortletRequest" %><%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/linkedProjectsEdit.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/linkedProjectsEdit.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/administration.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/administration.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/basicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/basicInfo.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/clearingStatus.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/clearingStatus.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/summary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/summary.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/vulnerabilities.jspf
@@ -7,6 +7,8 @@
   ~ Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
   ~ With modifications from Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/searchProjects.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/searchProjects.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/licenseInfo.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/licenseInfo.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/sourceCodeBundle.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/sourceCodeBundle.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/search/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/search/view.jsp
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With contributions by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/licenseListAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/licenseListAjax.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedProjectsRows.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedProjectsRows.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedReleasesAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedReleasesAjax.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedReleasesRelationAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedReleasesRelationAjax.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedReleasesRows.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedReleasesRows.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/searchReleasesAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/searchReleasesAjax.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/userListAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/userListAjax.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsDelete.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsDelete.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsUpload.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsUpload.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/editAttachments.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/editAttachments.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/editLinkedReleases.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/editLinkedReleases.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/errorKeyToMessage.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/errorKeyToMessage.jspf
@@ -2,6 +2,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/expandableTreetableSetup.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/expandableTreetableSetup.jspf
@@ -1,6 +1,8 @@
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %><%--
   ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/fossologyClearing.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/fossologyClearing.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/linkedReleaseDelete.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/linkedReleaseDelete.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/linkedReleaseDetails.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/linkedReleaseDetails.jspf
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/linkedReleasesEdit.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/linkedReleasesEdit.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/mapEdit.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/mapEdit.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016-2017.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/modal.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/modal.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchAndSelect.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchAndSelect.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal User.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchLicenses.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchLicenses.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal User.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchReleases.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchReleases.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchReleasesFromRelease.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchReleasesFromRelease.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchUsers.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchUsers.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal User.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/sortSelect.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/sortSelect.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/usingComponentsTable.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/usingComponentsTable.jspf
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~ With contributions by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/usingProjectsTable.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/usingProjectsTable.jspf
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
   ~ With contributions by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/vulnerabilityModal.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/vulnerabilityModal.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/vulnerabilityTab.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/vulnerabilityTab.jspf
@@ -2,6 +2,8 @@
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/detail.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/detail.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/metaData.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/metaData.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/references.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/references.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/summary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/summary.jspf
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/view.jsp
@@ -2,6 +2,8 @@
   ~ Copyright (c) Bosch Software Innovations GmbH 2016.
   ~ Copyright (c) Siemens AG 2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/js/addableTable.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/addableTable.js
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/js/licenses.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/licenses.js
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/js/loadTags.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/loadTags.js
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/js/main.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/main.js
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/js/releaseTools.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/releaseTools.js
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/js/resumableAttachments.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/resumableAttachments.js
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/js/search.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/search.js
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/main/webapp/js/searchAndSelectIds.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/searchAndSelectIds.js
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/common/PortletUtilsTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/common/PortletUtilsTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/common/datatables/DataTablesParserTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/common/datatables/DataTablesParserTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/FossologyAwarePortletTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/FossologyAwarePortletTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectImportPortletTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectImportPortletTest.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2015.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/frontend/sw360-theme/pom.xml
+++ b/frontend/sw360-theme/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/libraries/commonIO/pom.xml
+++ b/libraries/commonIO/pom.xml
@@ -3,6 +3,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/ConvertRecord.java
+++ b/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/ConvertRecord.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/ConvertUtil.java
+++ b/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/ConvertUtil.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/SampleOptions.java
+++ b/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/SampleOptions.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/TypeMappings.java
+++ b/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/TypeMappings.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/commonIO/src/test/java/org/eclipse/sw360/commonIO/ConvertRecordTest.java
+++ b/libraries/commonIO/src/test/java/org/eclipse/sw360/commonIO/ConvertRecordTest.java
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/pom.xml
+++ b/libraries/exporters/pom.xml
@@ -3,6 +3,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/CSVExport.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/CSVExport.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentExporter.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentHelper.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExporterHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExporterHelper.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/LicenseExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/LicenseExporter.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectHelper.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseHelper.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/SubTable.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/SubTable.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/VendorExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/VendorExporter.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ZipTools.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ZipTools.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/exporters/src/test/java/org/eclipse/sw360/exporter/ProjectExporterTest.java
+++ b/libraries/exporters/src/test/java/org/eclipse/sw360/exporter/ProjectExporterTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/pom.xml
+++ b/libraries/importers/component-importer/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentAttachmentCSVRecord.java
+++ b/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentAttachmentCSVRecord.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentAttachmentCSVRecordBuilder.java
+++ b/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentAttachmentCSVRecordBuilder.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentAwareCSVRecord.java
+++ b/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentAwareCSVRecord.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentCSVRecord.java
+++ b/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentCSVRecord.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentCSVRecordBuilder.java
+++ b/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentCSVRecordBuilder.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentImportUtils.java
+++ b/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentImportUtils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/CustomizedCSVRecord.java
+++ b/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/CustomizedCSVRecord.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/CustomizedCSVRecordBuilder.java
+++ b/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/CustomizedCSVRecordBuilder.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ReleaseLinkCSVRecord.java
+++ b/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ReleaseLinkCSVRecord.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ReleaseLinkCSVRecordBuilder.java
+++ b/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ReleaseLinkCSVRecordBuilder.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ComponentAndAttachmentAwareDBTest.java
+++ b/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ComponentAndAttachmentAwareDBTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ComponentAttachmentCSVRecordBuilderTest.java
+++ b/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ComponentAttachmentCSVRecordBuilderTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ComponentCSVRecordBuilderTest.java
+++ b/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ComponentCSVRecordBuilderTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ComponentImportUtilsTest.java
+++ b/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ComponentImportUtilsTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ReleaseLinkCSVRecordBuilderTest.java
+++ b/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ReleaseLinkCSVRecordBuilderTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/license-importer/pom.xml
+++ b/libraries/importers/license-importer/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/libraries/importers/license-importer/src/test/java/org/eclipse/sw360/importer/ConvertUtilTest.java
+++ b/libraries/importers/license-importer/src/test/java/org/eclipse/sw360/importer/ConvertUtilTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/license-importer/src/test/java/org/eclipse/sw360/importer/ImportCSVTest.java
+++ b/libraries/importers/license-importer/src/test/java/org/eclipse/sw360/importer/ImportCSVTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/importers/pom.xml
+++ b/libraries/importers/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/libraries/importers/tools/convertSqlDumpToCsv
+++ b/libraries/importers/tools/convertSqlDumpToCsv
@@ -3,6 +3,8 @@
 # 
 # Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
 # 
+# SPDX-License-Identifier: EPL-1.0
+#
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/pom.xml
+++ b/libraries/lib-datahandler/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/businessrules/ReleaseClearingStateSummaryComputer.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/businessrules/ReleaseClearingStateSummaryComputer.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
@@ -3,6 +3,8 @@
  * With modifications by Bosch Software Innovations GmbH, 2016
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ConcatClosingInputStream.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ConcatClosingInputStream.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/DatabaseSettings.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/DatabaseSettings.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/Duration.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/Duration.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ImportCSV.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ImportCSV.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/JacksonUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/JacksonUtils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/Moderator.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/Moderator.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Assert.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Assert.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/UncheckedSW360Exception.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/UncheckedSW360Exception.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentConnector.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentDownloader.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentDownloader.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentWrapper.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentWrapper.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnector.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2017.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseConnector.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseInstance.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseInstance.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseInstanceTracker.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseInstanceTracker.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseMixIn.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseMixIn.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseNestedMixIn.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseNestedMixIn.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseRepository.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseRepository.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DocumentWrapper.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DocumentWrapper.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/MapperFactory.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/MapperFactory.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneAwareDatabaseConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneAwareDatabaseConnector.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneSearchView.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneSearchView.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ComponentPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ComponentPermissions.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissions.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/LicensePermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/LicensePermissions.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/PermissionUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/PermissionUtils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissions.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ReleasePermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ReleasePermissions.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/UserPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/UserPermissions.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/VendorPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/VendorPermissions.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/VulnerabilityPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/VulnerabilityPermissions.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftClients.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftClients.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2016. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/attachments.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/attachments.thrift
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/bdpimport.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/bdpimport.thrift
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2015.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/cvesearch.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/cvesearch.thrift
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/fossology.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/fossology.thrift
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/importstatus.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/importstatus.thrift
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2015.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/licenses.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenses.thrift
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/moderation.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/moderation.thrift
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/schedule.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/schedule.thrift
@@ -2,6 +2,8 @@
  * Copyright (c) Bosch Software Innovations GmbH 2016.
  * Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/search.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/search.thrift
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/users.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/users.thrift
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/vendors.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/vendors.thrift
@@ -2,6 +2,8 @@
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/main/thrift/vulnerabilities.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/vulnerabilities.thrift
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/TEnumToString.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/TEnumToString.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/TestUtils.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/TestUtils.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/businessrules/ReleaseClearingStateSummaryComputerTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/businessrules/ReleaseClearingStateSummaryComputerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/businessrules/jgivens/GivenReleasesWithFossologyStatus.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/businessrules/jgivens/GivenReleasesWithFossologyStatus.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/businessrules/jgivens/ThenReleaseClearingState.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/businessrules/jgivens/ThenReleaseClearingState.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/businessrules/jgivens/WhenComputeClearingState.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/businessrules/jgivens/WhenComputeClearingState.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/CommonUtilsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/CommonUtilsTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/ConcatClosingInputStreamTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/ConcatClosingInputStreamTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/SW360ConstantsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/SW360ConstantsTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/SW360UtilsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/SW360UtilsTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtilsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtilsTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentConnectorTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentConnectorTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentDownloaderTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentDownloaderTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentWrapperTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentWrapperTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnectorTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnectorTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/DatabaseConnectorTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/DatabaseConnectorTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/DatabaseTestProperties.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/DatabaseTestProperties.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/DocumentWrapperTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/DocumentWrapperTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/MapperFactoryTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/MapperFactoryTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissionsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissionsTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissionsVisibilityTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissionsVisibilityTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/ReleasePermissionsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/ReleasePermissionsTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/GivenProject.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/GivenProject.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/ThenHighestAllowedAction.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/ThenHighestAllowedAction.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/ThenVisible.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/ThenVisible.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/WhenComputePermissions.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/WhenComputePermissions.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/WhenComputeVisibility.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/WhenComputeVisibility.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/test/TestServiceHandler.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/test/TestServiceHandler.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/test/TestServiceHandlerTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/test/TestServiceHandlerTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/thrift/ThriftUtilsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/thrift/ThriftUtilsTest.java
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/lib-datahandler/src/test/thrift/test.thrift
+++ b/libraries/lib-datahandler/src/test/thrift/test.thrift
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
  *
+ * SPDX-License-Identifier: EPL-1.0
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/libraries/pom.xml
+++ b/libraries/pom.xml
@@ -3,6 +3,8 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With contributions by Bosch Software Innovations GmbH, 2016.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,8 @@
 <!--
   ~ Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
   ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v1.0
   ~ which accompanies this distribution, and is available at

--- a/scripts/catalinaOpts.sh
+++ b/scripts/catalinaOpts.sh
@@ -4,6 +4,8 @@
 #
 # Copyright Siemens AG, 2014-2015. Part of the SW360 Portal Project.
 #
+# SPDX-License-Identifier: EPL-1.0
+#
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/scripts/migrations/dockerized-migration-runner.Dockerfile
+++ b/scripts/migrations/dockerized-migration-runner.Dockerfile
@@ -1,6 +1,8 @@
 # Copyright Bosch Software Innovations GmbH, 2017.
 # Part of the SW360 Portal Project.
 #
+# SPDX-License-Identifier: EPL-1.0
+#
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/scripts/migrations/dockerized-migration-runner.sh
+++ b/scripts/migrations/dockerized-migration-runner.sh
@@ -3,6 +3,8 @@
 # Copyright Bosch Software Innovations GmbH, 2017.
 # Part of the SW360 Portal Project.
 #
+# SPDX-License-Identifier: EPL-1.0
+#
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/sw360dev.Dockerfile
+++ b/sw360dev.Dockerfile
@@ -1,6 +1,8 @@
 # Copyright (c) Bosch Software Innovations GmbH 2016.
 # Part of the SW360 Portal Project.
 #
+# SPDX-License-Identifier: EPL-1.0
+#
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at


### PR DESCRIPTION
The Identifiers were added via the following script:
```bash
#!/usr/bin/env bash

set -e

cd $(dirname $0)
cd sw360-sw360portal

firstLineOfEPLHeader="All rights reserved. This program and the accompanying materials"
spdxLicenseIdentifier="SPDX-License-Identifier: EPL-1.0"

SAVEIFS=$IFS
IFS=$(echo -en "\n\b")
for filename in $(find . -type f -not \( -path ./.git -prune \)); do
    if ! grep -q "$spdxLicenseIdentifier" "$filename"; then
        sed -i '/^ \* '"$firstLineOfEPLHeader"'/i \
 * '"$spdxLicenseIdentifier"'\
 *' "$filename"
        sed -i '/^# '"$firstLineOfEPLHeader"'/i \
# '"$spdxLicenseIdentifier"'\
#' "$filename"
        sed -i '/^  ~ '"$firstLineOfEPLHeader"'/i \
  ~ '"$spdxLicenseIdentifier"'\
  ~' "$filename"
        sed -i '/^'"$firstLineOfEPLHeader"'/i \
'"$spdxLicenseIdentifier"'\
' "$filename"
        sed -i '/^  '"$firstLineOfEPLHeader"'/i \
  '"$spdxLicenseIdentifier"'\
' "$filename"
    fi
done

# test:
for filename in $(find . -type f -not \( -path ./.git -prune \)); do
    if grep -q "$firstLineOfEPLHeader" "$filename"; then
        if ! grep -q "$spdxLicenseIdentifier" "$filename"; then
            echo "EPL and no SPDX in: $filename"
        fi
    else
        echo "no EPL in:          $filename"
    fi
done
IFS=$SAVEIFS
```