### PR TITLE
fix(ui): adding sort functionality to usingProjects table

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/usingProjectsTable.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/usingProjectsTable.jspf
@@ -9,29 +9,45 @@
 --%>
 
 <core_rt:if test="${usingProjects != null  && usingProjects.size()>0}">
-    <table class="table info_table" title="Usage overview">
-        <thead>
-        <tr>
-            <th colspan="3"> ${documentName} is used by the following projects</th>
-        </tr>
-        <tr>
-            <th>Project name</th>
-            <th>Group</th>
-            <th>Responsible</th>
-        </tr>
-        </thead>
-        <core_rt:forEach var="project" items="${usingProjects}" varStatus="loop">
-            <tr>
-                <td>
-                    <sw360:DisplayProjectLink project="${project}"/>
-                </td>
-                <td>
-                    <sw360:out value="${project.businessUnit}"/>
-                </td>
-                <td>
-                    <sw360:DisplayUserEmail email="${project.projectResponsible}" bare="true"/>
-                </td>
-            </tr>
-        </core_rt:forEach>
-    </table>
+    <div id="usingProjectsTableDiv">
+        <table id="usingProjectsTable" title="Usage overview" class="table info_table">
+                <thead>
+                <tr>
+                    <th colspan="3">${documentName} is used by the following projects</th>
+                </tr>
+                <tr>
+                    <th>Project Name</th><th>Group</th><th>Responsible</th>
+                </tr>
+                </thead>
+        </table>
+    </div>
+
+    <script>
+          var usingProjectsTable;
+
+          function createUsingProjectsTable() {
+                var result = [];
+
+                <core_rt:forEach items="${usingProjects}" var="project">
+                result.push([
+                    "<sw360:DisplayProjectLink project="${project}"/>",
+                    '<sw360:out value="${project.businessUnit}"/>',
+                    '<sw360:DisplayUserEmail email="${project.projectResponsible}" bare="true"/>'
+                ]);
+                </core_rt:forEach>
+
+                usingProjectsTable = $('#usingProjectsTable').DataTable({
+                    "pagingType": "simple_numbers",
+                    "data": result,
+                    dom: "lrtip",
+                    "searching": false,
+                    "lengthChange": false
+                });
+          }
+
+          $( window ).on( "load", function() {
+              createUsingProjectsTable();
+          });
+
+    </script>
 </core_rt:if>


### PR DESCRIPTION
Creates the table using the DataTables plugin, so it can be sorted by clicking on the headers. 
This fixes issue #453