### PR TITLE
feat(clearing export): add project origin and component type to exported data

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -46,14 +46,19 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Sets.newHashSet;
-import static org.eclipse.sw360.datahandler.common.CommonUtils.*;
+import static org.eclipse.sw360.datahandler.common.CommonUtils.getBestClearingReport;
+import static org.eclipse.sw360.datahandler.common.CommonUtils.isInProgressOrPending;
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyMap;
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static org.eclipse.sw360.datahandler.common.Duration.durationOf;
 import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
 import static org.eclipse.sw360.datahandler.common.SW360Assert.fail;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import static org.eclipse.sw360.datahandler.thrift.ThriftUtils.copyFields;
 import static org.eclipse.sw360.datahandler.thrift.ThriftUtils.immutableOfComponent;
-import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.*;
+import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.ensureEccInformationIsSet;
+import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.prepareComponents;
+import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.prepareReleases;
 
 /**
  * Class for accessing Component information from the database
@@ -128,6 +133,9 @@ public class ComponentDatabaseHandler {
     /////////////////////
     // SUMMARY GETTERS //
     /////////////////////
+    public List<Component> getComponentsShort(Set<String> ids) {
+        return componentRepository.makeSummary(SummaryType.SHORT, ids);
+    }
 
     public List<Component> getComponentSummary(User user) {
         return componentRepository.getComponentSummary(user);

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -27,7 +27,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import static org.eclipse.sw360.datahandler.common.SW360Assert.*;
+import static org.eclipse.sw360.datahandler.common.SW360Assert.assertId;
+import static org.eclipse.sw360.datahandler.common.SW360Assert.assertIdUnset;
+import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
+import static org.eclipse.sw360.datahandler.common.SW360Assert.assertUser;
 
 /**
  * Implementation of the Thrift service
@@ -62,6 +65,10 @@ public class ComponentHandler implements ComponentService.Iface {
     /////////////////////
     // SUMMARY GETTERS //
     /////////////////////
+    @Override
+    public List<Component> getComponentsShort(Set<String> ids) {
+        return handler.getComponentsShort(ids);
+    }
 
     @Override
     public List<Component> getComponentSummary(User user) throws TException {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/FossologyAwarePortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/FossologyAwarePortlet.java
@@ -36,6 +36,7 @@ import javax.portlet.PortletException;
 import javax.portlet.PortletRequest;
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
+
 import java.io.IOException;
 import java.util.*;
 
@@ -44,7 +45,9 @@ import static org.eclipse.sw360.datahandler.common.CommonUtils.joinStrings;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyMap;
 import static org.eclipse.sw360.datahandler.common.SW360Utils.printName;
 import static org.eclipse.sw360.datahandler.thrift.projects.projectsConstants.CLEARING_TEAM_UNKNOWN;
-import static org.eclipse.sw360.portal.common.PortalConstants.*;
+import static org.eclipse.sw360.portal.common.PortalConstants.CLEARING_TEAM;
+import static org.eclipse.sw360.portal.common.PortalConstants.PROJECT_ID;
+import static org.eclipse.sw360.portal.common.PortalConstants.RELEASE_ID;
 
 /**
  * Fossology aware portlet implementation
@@ -208,13 +211,15 @@ public abstract class FossologyAwarePortlet extends LinkedReleasesAndProjectsAwa
     }
 
     protected void putReleasesAndProjectIntoRequest(PortletRequest request, String projectId, User user) throws TException {
-        Map<Release, ProjectNamesWithMainlineStatesTuple> releaseStringMap = getProjectsNamesWithMainlineStatesByRelease(projectId, user);
+        ProjectService.Iface client = thriftClients.makeProjectClient();
+        Project project = client.getProjectById(projectId, user);
+        Map<Release, ProjectNamesWithMainlineStatesTuple> releaseStringMap = getProjectsNamesWithMainlineStatesByRelease(
+                project, user);
         request.setAttribute(PortalConstants.RELEASES_AND_PROJECTS, releaseStringMap);
     }
 
-    protected Map<Release, ProjectNamesWithMainlineStatesTuple> getProjectsNamesWithMainlineStatesByRelease(String projectId, User user) throws TException {
-        ProjectService.Iface client = thriftClients.makeProjectClient();
-        Project project = client.getProjectById(projectId, user);
+    protected Map<Release, ProjectNamesWithMainlineStatesTuple> getProjectsNamesWithMainlineStatesByRelease(
+            Project project, User user) throws TException {
         SetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdsToProject = releaseIdToProjects(project, user);
         List<Release> releasesById = thriftClients.makeComponentClient().getFullReleasesById(releaseIdsToProject.keySet(), user);
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -51,6 +51,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.portlet.*;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URLConnection;
@@ -286,9 +287,12 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 project = thriftClients.makeProjectClient().getProjectById(id, user);
             }
             if (project != null) {
-                Map<Release, ProjectNamesWithMainlineStatesTuple> releaseStringMap = getProjectsNamesWithMainlineStatesByRelease(id, user);
+                Map<Release, ProjectNamesWithMainlineStatesTuple> releaseStringMap = getProjectsNamesWithMainlineStatesByRelease(
+                        project, user);
                 List<Release> releases = releaseStringMap.keySet().stream().sorted(Comparator.comparing(SW360Utils::printFullname)).collect(Collectors.toList());
-                ReleaseExporter exporter = new ReleaseExporter(thriftClients.makeComponentClient(), releases);
+                ReleaseExporter exporter = new ReleaseExporter(thriftClients.makeComponentClient(), releases,
+                        releaseStringMap);
+
                 PortletResponseUtil.sendFile(request, response,
                         String.format("releases-%s-%s-%s.xlsx", project.getName(), project.getVersion(), SW360Utils.getCreatedOn()),
                         exporter.makeExcelExport(releases), CONTENT_TYPE_OPENXML_SPREADSHEET);

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentExporter.java
@@ -9,7 +9,6 @@
 package org.eclipse.sw360.exporter;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.log4j.Logger;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
@@ -23,7 +22,6 @@ import java.util.stream.Collectors;
 import static org.eclipse.sw360.datahandler.thrift.components.Component._Fields.*;
 
 public class ComponentExporter extends ExcelExporter<Component, ComponentHelper> {
-    private static final Logger log = Logger.getLogger(ComponentExporter.class);
 
     private static final Map<String, String> nameToDisplayName;
 

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentHelper.java
@@ -17,7 +17,9 @@ import java.util.*;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static org.eclipse.sw360.datahandler.common.SW360Utils.fieldValueAsString;
 import static org.eclipse.sw360.datahandler.common.SW360Utils.getReleaseNames;
-import static org.eclipse.sw360.exporter.ComponentExporter.*;
+import static org.eclipse.sw360.exporter.ComponentExporter.COMPONENT_RENDERED_FIELDS;
+import static org.eclipse.sw360.exporter.ComponentExporter.HEADERS;
+import static org.eclipse.sw360.exporter.ComponentExporter.HEADERS_EXTENDED_BY_RELEASES;
 
 class ComponentHelper implements ExporterHelper<Component> {
 
@@ -66,7 +68,7 @@ class ComponentHelper implements ExporterHelper<Component> {
 
     private List<String> makeRowForComponent(Component component) throws SW360Exception {
         if (!component.isSetAttachments()) {
-            component.setAttachments(Collections.EMPTY_SET);
+            component.setAttachments(Collections.emptySet());
         }
         List<String> row = new ArrayList<>(getColumns());
         for (Component._Fields renderedField : COMPONENT_RENDERED_FIELDS) {
@@ -105,7 +107,7 @@ class ComponentHelper implements ExporterHelper<Component> {
         return releaseHelper.getReleases(ids);
     }
 
-    public void setPreloadedLinkedReleases(Map<String, Release> preloadedLinkedReleases) {
+    public void setPreloadedLinkedReleases(Map<String, Release> preloadedLinkedReleases) throws SW360Exception {
         releaseHelper.setPreloadedLinkedReleases(preloadedLinkedReleases);
     }
 }

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
@@ -18,17 +18,16 @@ import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.apache.log4j.Logger;
 
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.eclipse.sw360.datahandler.thrift.projects.Project._Fields.*;
+import static org.eclipse.sw360.datahandler.thrift.projects.Project._Fields.DOCUMENT_STATE;
+import static org.eclipse.sw360.datahandler.thrift.projects.Project._Fields.PERMISSIONS;
+import static org.eclipse.sw360.datahandler.thrift.projects.Project._Fields.REVISION;
 
 public class ProjectExporter extends ExcelExporter<Project, ProjectHelper> {
-
-    private static final Logger log = Logger.getLogger(ProjectHelper.class);
 
     private static final Map<String, String> nameToDisplayName;
 

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectHelper.java
@@ -11,7 +11,6 @@ package org.eclipse.sw360.exporter;
 
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
-import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
@@ -21,9 +20,12 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyMap;
-import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
-import static org.eclipse.sw360.datahandler.common.SW360Utils.*;
-import static org.eclipse.sw360.exporter.ProjectExporter.*;
+import static org.eclipse.sw360.datahandler.common.SW360Utils.fieldValueAsString;
+import static org.eclipse.sw360.datahandler.common.SW360Utils.putProjectNamesInMap;
+import static org.eclipse.sw360.datahandler.common.SW360Utils.putReleaseNamesInMap;
+import static org.eclipse.sw360.exporter.ProjectExporter.HEADERS;
+import static org.eclipse.sw360.exporter.ProjectExporter.HEADERS_EXTENDED_BY_RELEASES;
+import static org.eclipse.sw360.exporter.ProjectExporter.PROJECT_RENDERED_FIELDS;
 
 class ProjectHelper implements ExporterHelper<Project> {
 
@@ -77,7 +79,7 @@ class ProjectHelper implements ExporterHelper<Project> {
 
     private List<String> makeRowForProject(Project project) throws SW360Exception {
         if (!project.isSetAttachments()) {
-            project.setAttachments(Collections.EMPTY_SET);
+            project.setAttachments(Collections.emptySet());
         }
         List<String> row = new ArrayList<>(getColumns());
         for (Project._Fields renderedField : PROJECT_RENDERED_FIELDS) {
@@ -114,7 +116,7 @@ class ProjectHelper implements ExporterHelper<Project> {
         return new SubTable(makeRowForProject(project));
     }
 
-    public void setPreloadedLinkedReleases(Map<String, Release> preloadedLinkedReleases) {
+    public void setPreloadedLinkedReleases(Map<String, Release> preloadedLinkedReleases) throws SW360Exception {
         releaseHelper.setPreloadedLinkedReleases(preloadedLinkedReleases);
     }
 

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
@@ -9,21 +9,21 @@
 package org.eclipse.sw360.exporter;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
 import org.eclipse.sw360.datahandler.thrift.components.*;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectNamesWithMainlineStatesTuple;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.eclipse.sw360.datahandler.common.SW360Utils.*;
+import static org.eclipse.sw360.datahandler.common.SW360Utils.displayNameFor;
 import static org.eclipse.sw360.datahandler.thrift.components.Release._Fields.*;
 
 
 public class ReleaseExporter extends ExcelExporter<Release, ReleaseHelper> {
-    private static final Logger log = Logger.getLogger(ReleaseExporter.class);
+
     private static final Map<String, String> nameToDisplayName;
 
     static {
@@ -70,8 +70,11 @@ public class ReleaseExporter extends ExcelExporter<Release, ReleaseHelper> {
 
     static final List<String> HEADERS = makeHeaders();
 
-    public ReleaseExporter(ComponentService.Iface client, List<Release> releases) throws SW360Exception {
-        super(new ReleaseHelper(client));
+    static final List<String> HEADERS_EXTENDED_BY_ADDITIONAL_DATA = makeHeadersForExtendedExport();
+
+    public ReleaseExporter(ComponentService.Iface cClient, List<Release> releases,
+            Map<Release, ProjectNamesWithMainlineStatesTuple> releaseToShortenedStringsMap) throws SW360Exception {
+        super(new ReleaseHelper(cClient, releaseToShortenedStringsMap));
         preloadLinkedReleasesFor(releases);
     }
 
@@ -81,6 +84,20 @@ public class ReleaseExporter extends ExcelExporter<Release, ReleaseHelper> {
             addToHeaders(headers, field);
         }
         return headers;
+    }
+
+    private static List<String> makeHeadersForExtendedExport() {
+        List<String> completeHeaders = new ArrayList<>();
+        completeHeaders.addAll(makeHeaders());
+
+        List<String> additionalHeaders = new ArrayList<>();
+        additionalHeaders.add(displayNameFor("component type", nameToDisplayName));
+        additionalHeaders.add(displayNameFor("project origin", nameToDisplayName));
+        completeHeaders.addAll(
+                completeHeaders.indexOf(displayNameFor(COMPONENT_ID.getFieldName(), nameToDisplayName)) + 1,
+                additionalHeaders);
+
+        return completeHeaders;
     }
 
     private static void addToHeaders(List<String> headers, Release._Fields field) {

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -308,6 +308,11 @@ struct ReleaseLink{
 service ComponentService {
 
     /**
+     * short summary of all components identified by the given ids
+     **/
+    list<Component> getComponentsShort(1: set<string> ids);
+
+    /**
      * short summary of all components visible to user
      **/
     list<Component> getComponentSummary(1: User user);


### PR DESCRIPTION
* added project origin string from gui to export which means that after three project names only "..." will be printed if there are more
* added component type to exported data and therefore added db query for component info for each release (=export row)
* fixed changing releases because of unset attachments - this broke the HashMap keys in releaseStringMap (changing key objects is evil)
* removed unused loggers

fixes #425