### PR TITLE
refactor(attachments list): new look of list view for attachments

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayEllipsisString.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayEllipsisString.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Siemens AG, 2017.
+ * Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.portal.tags;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+
+import java.io.IOException;
+
+/**
+ * This tag renders a span-tag with a text node displaying the given value and
+ * setting it as title attribute. In addition the span receives the css class
+ * "ellipsis" which will take care of adding ellipses when necessary.
+ */
+public class DisplayEllipsisString extends SimpleTagSupport {
+
+    private String value;
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public void doTag() throws JspException, IOException {
+        getJspContext().getOut().print("<span class='ellipsis' title='" + TagUtils.escapeAttributeValue(value) + "'>"
+                + TagUtils.escapeAttributeValue(value) + "</span>");
+    }
+}

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayEnumShort.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayEnumShort.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Siemens AG, 2017.
+ * Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.portal.tags;
+
+import org.apache.thrift.TEnum;
+import org.eclipse.sw360.datahandler.common.ThriftEnumUtils;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+
+import java.io.IOException;
+
+/**
+ * This tag renders a span-tag with a text node displaying the short string of
+ * an enum according to {@link ThriftEnumUtils#enumToShortString(TEnum)}. The
+ * title of the span will be the normal string value according to
+ * {@link ThriftEnumUtils#enumToString(TEnum)}. So please make sure that your
+ * enum is handled correctly there.
+ */
+public class DisplayEnumShort extends SimpleTagSupport {
+
+    private TEnum value;
+
+    public void setValue(TEnum value) {
+        this.value = value;
+    }
+
+    public void doTag() throws JspException, IOException {
+        getJspContext().getOut().print("<span title='" + ThriftEnumUtils.enumToString(value) + "'>"
+                + ThriftEnumUtils.enumToShortString(value) + "</span>");
+    }
+}

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
@@ -99,6 +99,17 @@
         </attribute>
     </tag>
     <tag>
+        <name>DisplayEllipsisString</name>
+        <tag-class>org.eclipse.sw360.portal.tags.DisplayEllipsisString</tag-class>
+        <body-content>empty</body-content>
+        <attribute>
+            <name>value</name>
+            <required>true</required>
+            <type>java.lang.String</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+    </tag>
+    <tag>
         <name>DisplayEnum</name>
         <tag-class>org.eclipse.sw360.portal.tags.DisplayEnum</tag-class>
         <body-content>empty</body-content>
@@ -158,6 +169,17 @@
             <name>inQuotes</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+    </tag>
+    <tag>
+        <name>DisplayEnumShort</name>
+        <tag-class>org.eclipse.sw360.portal.tags.DisplayEnumShort</tag-class>
+        <body-content>empty</body-content>
+        <attribute>
+            <name>value</name>
+            <required>true</required>
+            <type>org.apache.thrift.TEnum</type>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
     </tag>

--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -293,31 +293,46 @@ input[readonly].clickable {
     z-index: 10000;
 }
 
-#attachmentDetail td {
-    border-right: 1px solid rgb(204, 204, 204);
-    height: 15px;
-    padding: 5px;
-    color: black !important;
+.foregroundAlert {
+    color: #e95850 !important;
 }
 
-#attachmentDetail img {
-    width: 15px;
-    padding: 0px;
+.foregroundOK {
+    color: #9de997 !important;
 }
 
-#attachmentDetail .attachmentTitle{
-    font-weight: bold;
+#attachmentsDetail span.dataTableChildRowCell {
+	display: inline-block;
+
+	box-sizing: border-box;
+
+	padding-left: 10px;
+	height: 100%;
+
+	vertical-align: top;
 }
 
-#attachmentDetail .lastAttachmentRow{
-    border-bottom: 2.5px solid rgb(204, 204, 204);
-    
+#attachmentsDetail td.details-control {
+    cursor: pointer;
 }
-
-#attachmentDetail .lessPadding{
-    padding: 0.5px !important;
+#attachmentsDetail td.details-control:before {
+    content: '\25BA';
 }
+#attachmentsDetail tr.shown td.details-control:before {
+    content: '\25BC';
+}
+#attachmentsDetail tr.shown, #attachmentsDetail tr.shown td {
+	border-bottom: none;
+}
+#attachmentsDetail tr.shown + tr {
+	border-top: none;
+}
+#attachmentsDetail tr.shown + tr td {
+	border-top: none;
 
+	padding-left: 0px;
+	padding-right: 0px;
+}
 
 .sw360modal button:last-of-type {
     float: right;
@@ -463,4 +478,11 @@ input[readonly].clickable {
 
 .numberOfVulnerabilitiesNeedUpdate {
     font-size:16px;
+}
+
+.ellipsis {
+    display: block;
+    overflow:hidden;
+    white-space:nowrap;
+    text-overflow: ellipsis;
 }

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsDetail.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/attachmentsDetail.jsp
@@ -8,95 +8,169 @@
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v10.html
   --%>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@include file="/html/init.jsp" %>
 
+<%@ page import="org.eclipse.sw360.portal.common.PortalConstants"%>
 
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 
-<portlet:defineObjects/>
-<liferay-theme:defineObjects/>
+<%@include file="/html/init.jsp"%>
+
+<portlet:defineObjects />
+<liferay-theme:defineObjects />
 
 <c:catch var="attributeNotFoundException">
-    <jsp:useBean id="attachments" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.attachments.Attachment>" scope="request"/>
-    <jsp:useBean id="documentType" type="java.lang.String" scope="request"/>
-    <jsp:useBean id="documentID" class="java.lang.String" scope="request"/>
+    <jsp:useBean id="attachments" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.attachments.Attachment>" scope="request" />
+    <jsp:useBean id="documentType" type="java.lang.String" scope="request" />
+    <jsp:useBean id="documentID" class="java.lang.String" scope="request" />
 </c:catch>
+
 <core_rt:if test="${empty attributeNotFoundException}">
-<table class="table info_table " id="attachmentDetail" title="Attachment Information">
-    <thead>
-    <tr>
-        <th colspan="8" class="headlabel">
-            Attachments
-            <core_rt:if test="${not empty attachments}">
-                <sw360:DisplayDownloadAttachmentBundle name="AttachmentBundle.zip"
-													   attachments="${attachments}"
-                                                       contextType="${documentType}"
-                                                       contextId="${documentID}"/>
-            </core_rt:if>
-        </th>
-    </tr>
-    </thead>
-    <tbody>
-    <core_rt:if test="${not empty attachments}">
-        <core_rt:forEach items="${attachments}" var="attachment" varStatus="loop">
-            <tr id="attachmentRow1${loop.count}">
-                <td colspan="8" class="attachmentTitle">
-                    <sw360:DisplayDownloadAttachmentFile attachment="${attachment}"
-                                                         contextType="${documentType}"
-                                                         contextId="${documentID}"/>
-                    "<sw360:out value="${attachment.filename}"/>"
-                </td>
-            </tr>
-            <tr id="attachmentRow2${loop.count}" >
-                <td colspan="3" rowspan="2" class="lessPadding">
-                    Type: <sw360:DisplayEnum value="${attachment.attachmentType}"/> <br/>
-                    Status: <sw360:DisplayEnum value="${attachment.checkStatus}"/> <br/>
-                    SHA1-Checksum: <span class="hashvalue">${attachment.sha1}</span>
-                </td>
-                <td>Uploader:</td>
-                <td colspan="4">
-                    <sw360:out value="${attachment.createdBy}"/>,
-                    <sw360:out value="${attachment.createdTeam}"/>,
-                    <sw360:out value="${attachment.createdOn}"/>
-                    <br/>
-                    Comment:
-                    <core_rt:if test="${not empty attachment.createdComment}">
-                        "<sw360:out value="${attachment.createdComment}"/>"
-                    </core_rt:if>
-                    <core_rt:if test="${empty attachment.createdComment}">
-                        -
-                    </core_rt:if>
-                </td>
-            </tr>
-            <tr id="attachmentRow3${loop.count}" >
-                <td>Approver:</td>
-                <td colspan="4">
-                    <core_rt:if test="${not empty attachment.checkedBy}">
-                        <sw360:out value="${attachment.checkedBy}"/>, <sw360:out value="${attachment.checkedTeam}"/>, <sw360:out value="${attachment.checkedOn}"/>
-                        <br/>
-                        Comment:
-                        <core_rt:if test="${not empty attachment.checkedComment}">
-                            "<sw360:out value="${attachment.checkedComment}"/>"
-                        </core_rt:if>
-                        <core_rt:if test="${empty attachment.checkedComment}">
-                            -
-                        </core_rt:if>
-                    </core_rt:if>
-                    <core_rt:if test="${empty attachment.checkedBy}">
-                        Not yet approved.
-                    </core_rt:if>
-                </td>
-            </tr>
-            <tr id="attachmentRow4${loop.count}" class="lastAttachmentRow">
-            </tr>
-        </core_rt:forEach>
-    </core_rt:if>
 
     <core_rt:if test="${empty attachments}">
-        <tr id="noAttachmentsRow">
-            <td colspan="6">No attachments yet.</td>
-        </tr>
+        <span>No attachments yet.</span>
     </core_rt:if>
-    </tbody>
-</table>
+
+    <core_rt:if test="${not empty attachments}">
+        <!-- jQuery is already available on every page, but needs be added when require is finally here
+        <script src="<%=request.getContextPath()%>/webjars/jquery/1.12.4/jquery.min.js"></script>
+         -->
+        <script src="<%=request.getContextPath()%>/webjars/datatables/1.10.7/js/jquery.dataTables.min.js"></script>
+
+        <table id="attachmentsDetail" class="table info_table" title="Attachment Information">
+            <colgroup>
+                <col style="width: 4%;" />
+                <col style="width: 20%;" />
+                <col style="width: 10%;" />
+                <col style="width: 6%;" />
+                <col style="width: 6%;" />
+                <col style="width: 16%;" />
+                <col style="width: 6%;" />
+                <col style="width: 16%;" />
+                <col style="width: 6%;" />
+                <col style="width: 10%;" />
+            </colgroup>
+            <thead>
+                <tr>
+                    <th><sw360:DisplayDownloadAttachmentBundle attachments="${attachments}" 
+                                name="AttachmentBundle.zip"
+                                contextType="${documentType}"
+                                contextId="${documentID}" />
+                    </th>
+                    <th>File name</th>
+                    <th>Size</th>
+                    <th>Type</th>
+                    <th>Group</th>
+                    <th>Uploaded by</th>
+                    <th>Group</th>
+                    <th>Checked by</th>
+                    <th>Usage</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+            </tbody>
+        </table>
+
+        <script>
+            var attachmentJSON = [];
+
+            /* Print all attachment table data as array into the html page */
+            <core_rt:forEach items="${attachments}" var="attachment">
+                attachmentJSON.push({
+                    "fileName": "${attachment.filename}",
+                    "size": "n/a",
+                    "type": "<sw360:DisplayEnumShort value="${attachment.attachmentType}"/>",
+                    "uploadedTeam": "<sw360:DisplayEllipsisString value="${attachment.createdTeam}"/>",
+                    "uploadedBy": "<sw360:DisplayEllipsisString value="${attachment.createdBy}"/>",
+                    "checkedTeam":  "<sw360:DisplayEllipsisString value="${attachment.checkedTeam}"/>",
+                    "checkedBy":  "<sw360:DisplayEllipsisString value="${attachment.checkedBy}"/>",
+                    "usage":  "n/a",
+                    "actions":     "<sw360:DisplayDownloadAttachmentFile attachment="${attachment}" contextType="${documentType}" contextId="${documentID}"/>",
+
+                    "sha1": "${attachment.sha1}",
+                    "uploadedOn": "${attachment.createdOn}",
+                    "uploadedComment": "<core_rt:if test="${not empty attachment.createdComment}">Comment: <sw360:DisplayEllipsisString value="${attachment.createdComment}"/></core_rt:if>",
+                    "checkedOn": "${attachment.checkedOn}",
+                    "checkedComment": "<core_rt:if test="${not empty attachment.checkedComment}">Comment: <sw360:DisplayEllipsisString value="${attachment.checkedComment}"/></core_rt:if>",
+
+                    "checkStatus": "${attachment.checkStatus}"
+                });
+            </core_rt:forEach>
+
+            /* Define function for child row creation, which will contain additional data for a clicked table row */
+            function createChildRow(rowData) {
+                var childHtmlString = '' +
+                        '<div>' +
+                            '<span class="dataTableChildRowCell" style="padding-right: 10px; width:  4%;"/>' +
+                            '<span class="dataTableChildRowCell" style="padding-right: 50px; width: 36%;">' + rowData.sha1 + '</span>' +
+                            '<span class="dataTableChildRowCell" style="padding-right: 30px; width: 22%;">' + rowData.uploadedOn + ' ' + rowData.uploadedComment + '</span>';
+                if (rowData.checkStatus === 'ACCEPTED') {
+                    childHtmlString += '' +
+                            '<span class="dataTableChildRowCell foregroundOK" style="padding-right: 30px; width: 22%;">' + rowData.checkedOn + ' ' + rowData.checkedComment + '</span>';
+                } else if (rowData.checkStatus === 'REJECTED') {
+                    childHtmlString += '' +
+                            '<span class="dataTableChildRowCell foregroundAlert" style="padding-right: 30px; width: 22%;">' + rowData.checkedOn + ' ' + rowData.checkedComment + '</span>';
+                } else {
+                    childHtmlString += '' +
+                            '<span class="dataTableChildRowCell" style="padding-right: 30px; width: 22%;">' + rowData.checkedOn + ' ' + rowData.checkedComment + '</span>';
+                }
+                childHtmlString += '' +
+                            '<span class="dataTableChildRowCell" style="padding-right: 30px; width: 16%;"/>'+
+                        '</div>';
+                return childHtmlString;
+            }
+
+            /* Generate the table itself as jQuery DataTable */
+            $(document).ready(function() {
+                var table = $('#attachmentsDetail').DataTable( {
+                    "data": attachmentJSON,
+                    "columns": [
+                        {
+                            "className":      'details-control',
+                            "orderable":      false,
+                            "data":           null,
+                            "defaultContent": ''
+                        },
+                        { "data": "fileName" },
+                        { "data": "size" },
+                        { "data": "type" },
+                        { "data": "uploadedTeam" },
+                        { "data": "uploadedBy" },
+                        { "data": "checkedTeam" },
+                        { "data": "checkedBy" },
+                        { "data": "usage" },
+                        { "data": "actions" }
+                    ],
+                    "columnDefs": [
+                        {
+                            "targets": [ 6, 7 ],
+                            "createdCell": function (td, cellData, rowData, row, col) {
+                                if (rowData.checkStatus === 'REJECTED') {
+                                    $(td).addClass('foregroundAlert');
+                                } else if (rowData.checkStatus === 'ACCEPTED') {
+                                    $(td).addClass('foregroundOK');
+                                }
+                            }
+                        }
+                    ],
+                    "order": [[1, 'asc']],
+                    "deferRender": true
+                } );
+
+                /* Add event listener for opening and closing details as child row */
+                $('#attachmentsDetail tbody').on('click', 'td.details-control', function () {
+                    var tr = $(this).closest('tr');
+                    var row = table.row( tr );
+
+                    if ( row.child.isShown() ) {
+                        row.child.hide();
+                        tr.removeClass('shown');
+                    } else {
+                        row.child( createChildRow(row.data()) ).show();
+                        tr.addClass('shown');
+                    }
+                } );
+            } );
+        </script>
+    </core_rt:if>
 </core_rt:if>

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
@@ -83,6 +83,29 @@ public class ThriftEnumUtils {
             .put(AttachmentType.OTHER, "Other")
             .build();
 
+    // @formatter:off
+    public static final ImmutableMap<AttachmentType, String>
+            MAP_ATTACHMENT_TYPE_SHORT_STRING = ImmutableMap.<AttachmentType, String>builder()
+            .put(AttachmentType.DOCUMENT, "DOC")
+            .put(AttachmentType.SOURCE, "SRC")
+            .put(AttachmentType.DESIGN, "DSN")
+            .put(AttachmentType.REQUIREMENT, "RDT")
+            .put(AttachmentType.CLEARING_REPORT, "CRT")
+            .put(AttachmentType.COMPONENT_LICENSE_INFO_XML, "CLX")
+            .put(AttachmentType.COMPONENT_LICENSE_INFO_COMBINED, "CLI")
+            .put(AttachmentType.SCAN_RESULT_REPORT, "SRR")
+            .put(AttachmentType.SCAN_RESULT_REPORT_XML, "SRX")
+            .put(AttachmentType.SOURCE_SELF, "SRS")
+            .put(AttachmentType.BINARY, "BIN")
+            .put(AttachmentType.BINARY_SELF, "BIS")
+            .put(AttachmentType.DECISION_REPORT, "DRT")
+            .put(AttachmentType.LEGAL_EVALUATION, "LRT")
+            .put(AttachmentType.LICENSE_AGREEMENT, "LAT")
+            .put(AttachmentType.SCREENSHOT, "SCR")
+            .put(AttachmentType.OTHER, "OTH")
+            .build();
+    // @formatter:on
+
     private static final ImmutableMap<ClearingState, String> MAP_CLEARING_STATUS_STRING = ImmutableMap.of(
             ClearingState.NEW_CLEARING, "New",
             ClearingState.SENT_TO_FOSSOLOGY, "Sent to Fossology",
@@ -259,6 +282,30 @@ public class ThriftEnumUtils {
             if(map.get(t).equals(in)) return t;
         }
 
+        return null;
+    }
+
+    // @formatter:off
+    public static final ImmutableMap<Class<? extends TEnum>, Map<? extends TEnum, String>>
+            MAP_ENUMTYPE_SHORT_STRING_MAP = ImmutableMap.<Class<? extends TEnum>, Map<? extends TEnum, String>>builder()
+            .put(AttachmentType.class, MAP_ATTACHMENT_TYPE_SHORT_STRING)
+            .build();
+    // @formatter:on
+
+    public static String enumToShortString(TEnum value) {
+        String out = "";
+        if (value != null) {
+            out = MAP_ENUMTYPE_SHORT_STRING_MAP.get(value.getClass()).get(value);
+        }
+        return out;
+    }
+
+    public static <T extends Enum<T>> T enumByShortString(String in, Class<T> clazz) {
+        Map<? extends TEnum, String> map = MAP_ENUMTYPE_SHORT_STRING_MAP.get(clazz);
+        for (T t : clazz.getEnumConstants()) {
+            if (map.get(t).equals(in))
+                return t;
+        }
         return null;
     }
 


### PR DESCRIPTION
* removed old attachmentsDetail.jsp code including its css in sw360.css
* added new attachment list view based on jquery datatable plugin with child rows
** added data generation as writing javascript array into the html via jsp
** added js code to generate table from data and dynamically add child rows for details
** added css partly to jsp (different size adjustments) and mainly to sw360.css
** added two new tags for type shortnames and too long text with ellipses
** added idea of shortnames for enum types to ThriftEnumUtils
* not yet done - needs further ticket:
** size and usage data, just n/a is printed in table cell
** edit and delete actions

closes #454