### PR TITLE
fix(ui): Changing content of vendorNames to be vendor short names

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -358,10 +358,10 @@ public class ComponentDatabaseHandler {
                 component.setVendorNames(new HashSet<String>());
             }
             if (release.vendor != null)
-                component.vendorNames.add(release.vendor.getFullname());
+                component.vendorNames.add(release.vendor.getShortname());
             else if (!isNullOrEmpty(release.vendorId)) {
                 Vendor vendor = getVendor(release.vendorId);
-                component.vendorNames.add(vendor.getFullname());
+                component.vendorNames.add(vendor.getShortname());
             }
 
             if (!component.isSetMainLicenseIds()) component.setMainLicenseIds(new HashSet<String>());

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -678,7 +678,7 @@ public class ComponentDatabaseHandlerTest {
             Component component = handler.getComponent(componentId, user1);
             assertThat(component.languages, containsInAnyOrder("C", "C++"));
             assertThat(component.operatingSystems, containsInAnyOrder("Linux Ubuntu", "Linux Mint"));
-            assertThat(component.vendorNames, containsInAnyOrder(vendors.get("V1").getFullname()));
+            assertThat(component.vendorNames, containsInAnyOrder(vendors.get("V1").getShortname()));
         }
         Set<String> os2 = new HashSet<>();
         os2.add("Linux Debian");
@@ -698,7 +698,7 @@ public class ComponentDatabaseHandlerTest {
             Component component = handler.getComponent(componentId, user1);
             assertThat(component.languages, containsInAnyOrder("C", "C++", "C#"));
             assertThat(component.operatingSystems, containsInAnyOrder("Linux Ubuntu", "Linux Mint", "Linux Debian"));
-            assertThat(component.vendorNames, containsInAnyOrder(vendors.get("V1").getFullname(), vendors.get("V2").getFullname()));
+            assertThat(component.vendorNames, containsInAnyOrder(vendors.get("V1").getShortname(), vendors.get("V2").getShortname()));
         }
 
         handler.deleteRelease(id, user1);
@@ -707,7 +707,7 @@ public class ComponentDatabaseHandlerTest {
             Component component = handler.getComponent(componentId, user1);
             assertThat(component.languages, containsInAnyOrder("C++", "C#"));
             assertThat(component.operatingSystems, containsInAnyOrder("Linux Mint", "Linux Debian"));
-            assertThat(component.vendorNames, containsInAnyOrder(vendors.get("V2").getFullname()));
+            assertThat(component.vendorNames, containsInAnyOrder(vendors.get("V2").getShortname()));
         }
 
         handler.deleteRelease(id2, user1);

--- a/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
+++ b/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
@@ -64,6 +64,7 @@ public class VendorHandler implements VendorService.Iface {
         HashSet<String> vendorNames = new HashSet<>();
         for (Vendor vendor : getAllVendors()) {
             vendorNames.add(vendor.getFullname());
+            vendorNames.add(vendor.getShortname());
         }
         return vendorNames;
 

--- a/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentImportUtils.java
+++ b/libraries/importers/component-importer/src/main/java/org/eclipse/sw360/importer/ComponentImportUtils.java
@@ -469,9 +469,21 @@ public class ComponentImportUtils {
     private static Map<String, String> getVendorNameToVendorId(VendorService.Iface vendorClient) throws TException {
         Map<String, String> vendorNameToVendorId = new HashMap<>();
 
-        for (Vendor vendor : vendorClient.getAllVendors()) {
-            vendorNameToVendorId.put(vendor.getFullname(), vendor.getId());
-        }
+            for (Vendor vendor : vendorClient.getAllVendors()) {
+                if (!vendorNameToVendorId.containsKey(vendor.getShortname())) {
+                    vendorNameToVendorId.put(vendor.getShortname(), vendor.getId());
+                }
+                else {
+                    log.error("There is a clash between the shortname " + vendor.getShortname() + " and a name already present in the mapping.");
+                }
+                if (!vendorNameToVendorId.containsKey(vendor.getFullname())) {
+                    vendorNameToVendorId.put(vendor.getFullname(), vendor.getId());
+                }
+                else {
+                    log.error("There is a clash between the vendor fullname " + vendor.getFullname() + " and a name already present in the mapping.");
+                }
+            }
+
         return vendorNameToVendorId;
     }
 


### PR DESCRIPTION
Showing vendor short name rather than vendor long name in component listings by changing the content of the vendorNames field,

closes #355