### PR TITLE
fix(ui): preventing release from linking to itself

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchReleasesFromRelease.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchReleasesFromRelease.jsp
@@ -73,9 +73,14 @@
         var releaseIds = [];
 
         $('#releaseSearchResultsTable').find(':checked').each(
-                function() {
+            function() {
+                var currentRelease = "<sw360:out value="${release.id}"/>";
+                if (currentRelease !== this.value) {
                     releaseIds.push(this.value);
+                } else {
+                    $.alert("Releases should not link to themselves.");
                 }
+            }
         );
         addReleaseInfo(releaseIds);
 


### PR DESCRIPTION
Stops current release from being selected from the table of possible releases,

this closes #444