### PR TITLE
chore(ui): add release name and version in remove link confirmation

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedReleasesAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedReleasesAjax.jsp
@@ -61,7 +61,7 @@
         </td>
 
         <td class="deletor">
-            <img src="<%=request.getContextPath()%>/images/Trash.png" onclick="deleteReleaseLink('releaseLinkRow${loop.count}')" alt="Delete">
+            <img src="<%=request.getContextPath()%>/images/Trash.png" onclick="deleteReleaseLink('releaseLinkRow${loop.count}','<sw360:out value='${releaseLink.longName}' jsQuoting="'"/>')" alt="Delete">
         </td>
 
     </tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/linkedReleaseDelete.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/linkedReleaseDelete.jspf
@@ -11,12 +11,12 @@
 <link rel="stylesheet" href="<%=request.getContextPath()%>/webjars/github-com-craftpip-jquery-confirm/3.0.1/jquery-confirm.min.css">
 <script src="<%=request.getContextPath()%>/webjars/github-com-craftpip-jquery-confirm/3.0.1/jquery-confirm.min.js" type="text/javascript"></script>
 <script>
-    function deleteReleaseLink(rowId) {
+    function deleteReleaseLink(rowId, longName) {
 
         function deleteReleaseLinkInternal() {
             $('#' + rowId).remove();
         }
 
-        deleteConfirmed("Do you really want to remove the link to this release?", deleteReleaseLinkInternal);
+        deleteConfirmed("Do you really want to remove the link to release " + longName + "?", deleteReleaseLinkInternal);
     }
 </script>


### PR DESCRIPTION
- Add the release name and version (also vendor) to the confirmation message in case of deletion the release link from a project.
- fix issue #442 