### PR TITLE
feat(component): on blur of new component name, show dialog of compon…

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -89,6 +89,7 @@ public class PortalConstants {
     //! Specialized keys for components
     public static final String COMPONENT_ID = "componentid";
     public static final String COMPONENT = "component";
+    public static final String COMPONENT_NAME = "componentname";
     public static final String ACTUAL_COMPONENT = "actual_component";
     public static final String COMPONENT_LIST = "componentList";
     public static final String TYPE_MASK = "typeMask";
@@ -265,6 +266,7 @@ public class PortalConstants {
     //component actions
     public static final String ADD_VENDOR = "add_vendor";
     public static final String VIEW_VENDOR = "view_vendor";
+    public static final String CHECK_COMPONENT_NAME = "check_component_name";
     public static final String DELETE_COMPONENT = "delete_component";
     public static final String DELETE_RELEASE = "delete_release";
     public static final String SUBSCRIBE = "subscribe";

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/editBasicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/editBasicInfo.jspf
@@ -25,6 +25,7 @@
             <img class="infopic" src="<%=request.getContextPath()%>/images/ic_info.png"
                  title="Name of the component"/>
         </td>
+
         <td width="33%">
             <sw360:DisplayUserEdit email="${component.createdBy}" id="<%=Component._Fields.CREATED_BY.toString()%>"
                                    description="Created by" multiUsers="false" readonly="true"/>
@@ -115,3 +116,18 @@
 
 <core_rt:set var="customMap" value="${component.roles}"/>
 <%@include file="/html/utils/includes/mapEdit.jspf" %>
+
+<!-- Adding similar component popup for new component case -->
+<script>
+    require([ 'modules/linkListDialog' ], function(linkListDialog) {
+        <portlet:resourceURL var="checkComponentNameUrl">
+            <portlet:param name="<%=PortalConstants.ACTION%>" value="<%=PortalConstants.CHECK_COMPONENT_NAME%>"/>
+        </portlet:resourceURL>
+
+        var checkComponentNameUrl = '${checkComponentNameUrl}',
+            checkComponentNameParamKey = '<portlet:namespace/><%=PortalConstants.COMPONENT_NAME%>',
+            openOnBlurOfElementId = '#comp_name';
+
+        linkListDialog.registerLinkListDialog(openOnBlurOfElementId, checkComponentNameUrl, checkComponentNameParamKey);
+    });
+</script>

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/mapEdit.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/mapEdit.jspf
@@ -8,10 +8,6 @@
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v10.html
   --%>
-
-<script src="<%=request.getContextPath()%>/webjars/jquery-validation/1.15.1/jquery.validate.min.js" type="text/javascript"></script>
-<script src="<%=request.getContextPath()%>/webjars/jquery-validation/1.15.1/additional-methods.min.js" type="text/javascript"></script>
-
 <table class="table info_table" id="mapEditTable">
     <thead>
     <tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/requirejs.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/requirejs.jspf
@@ -9,28 +9,26 @@
  ~ which accompanies this distribution, and is available at
  ~ http://www.eclipse.org/legal/epl-v10.html
  --%>
+<script src="<%=request.getContextPath()%>/webjars/requirejs/2.3.3/require.js"></script>
 <script type="text/javascript">
-var require = {
-    callback: function() {
-		requirejs.config({
-			"paths": {
-				"jquery":				[ "/sw360-portlet/webjars/jquery/1.12.4/jquery.min" ],
-				"jquery-ui": 			[ "/sw360-portlet/webjars/jquery-ui/1.12.1/jquery-ui.min" ],
-				"jquery-confirm":		[ "/sw360-portlet/webjars/github-com-craftpip-jquery-confirm/3.0.1/jquery-confirm.min" ],
-				"jquery-treetable": 	[ "/sw360-portlet/webjars/jquery-treetable/3.2.0/jquery.treetable" ],
-				"jquery-validation": 	[ "/sw360-portlet/webjars/jquery-validation/1.15.1/jquery.validate.min" ],
-				"datatables": 			[ "/sw360-portlet/webjars/datatables/1.10.7/js/jquery.dataTables.min" ],
-				"resumable": 			[ "/sw360-portlet/webjars/resumable.js/1.0.3/resumable" ],
-			},
-			"shim": {
-				// only for libraries that to not support RequireJS out of the box
-		        "jquery-confirm": [ "jquery" ],
-		        "jquery-treetable": [ "jquery" ],
-		        "resumable": [ "jquery" ],
-		    }
-		});
-		requirejs.config({ baseUrl: "<%=request.getContextPath()%>/js" });
-	}
-};
+    requirejs.config({
+        baseUrl: "<%=request.getContextPath()%>/js",
+        paths: {
+            "jquery":                [ "/sw360-portlet/webjars/jquery/1.12.4/jquery.min" ],
+            "jquery-ui":             [ "/sw360-portlet/webjars/jquery-ui/1.12.1/jquery-ui.min" ],
+            "jquery-confirm":        [ "/sw360-portlet/webjars/github-com-craftpip-jquery-confirm/3.0.1/jquery-confirm.min" ],
+            "jquery-treetable":      [ "/sw360-portlet/webjars/jquery-treetable/3.2.0/jquery.treetable" ],
+            /* Attention: validate needs .min as the dependency is referenced like that in additional-methods.min.js in webjars... */
+            "jquery.validate.min":   [ "/sw360-portlet/webjars/jquery-validation/1.15.1/jquery.validate.min" ],
+            "jquery.validate-addon": [ "/sw360-portlet/webjars/jquery-validation/1.15.1/additional-methods.min" ],
+            "datatables":            [ "/sw360-portlet/webjars/datatables/1.10.7/js/jquery.dataTables.min" ],
+            "resumable":             [ "/sw360-portlet/webjars/resumable.js/1.0.3/resumable" ],
+        },
+        shim: {
+            // only for libraries that do not support RequireJS out of the box
+            "jquery-confirm": [ "jquery" ],
+            "jquery-treetable": [ "jquery" ],
+            "resumable": [ "jquery" ],
+        }
+    });
 </script>
-<script src="<%=request.getContextPath()%>/webjars/requirejs/2.3.3/require.min.js"></script>

--- a/frontend/sw360-portlet/src/main/webapp/js/components/includes/vendors/addVendor.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/components/includes/vendors/addVendor.js
@@ -9,7 +9,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-define('components/includes/vendors/addVendor', ['jquery', /* jquery plugins: */ 'jquery-ui', 'jquery-validation'], function($) {
+define('components/includes/vendors/addVendor', ['jquery', /* jquery plugins: */ 'jquery-ui', 'jquery.validate.min'], function($) {
 
     function addVendor() {
         openDialog('add-vendor-form', 'addVendorFullName');

--- a/frontend/sw360-portlet/src/main/webapp/js/modules/linkListDialog.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/modules/linkListDialog.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright Siemens AG, 2017.
+ * Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+define('modules/linkListDialog', ['jquery', /* jquery-plugins: */ 'jquery-confirm' ], function($) {
+
+	/**
+	 * Method registers a blur event handler on elements matching given elementSelector. On blur a
+	 * confirmation dialog is opened, sending a post request to the given postUrl and adding a body with
+	 * param key postParamKey and the value of the blurred field as param value.
+	 * It expects a server side method listening on the url which return json in the format:
+	 * {
+	 *     "title": "Hello World!",
+	 *     "errors": [
+	 *              "Something happened"
+	 *          ],
+	 *     "links": [
+	 *             {
+	 *                 "target": "https://www.example.com/my-link1",
+	 *                 "text": "My Link 1"
+	 *             }
+	 *         ]
+	 * }
+	 * The title will be set as title of the opened jquery-confirm dialog while errors - if set - or links
+	 * otherwise are displayed as content of the dialog.
+	 *
+	 * @param {string} elementSelector a jquery selector matching optimally exactly one element on whose blur
+	 *                     the dialog should be opened and whose val() should be attached to the server call
+	 * @param {string} postUrl a string representing the url that should be posted to, to get a link list to
+	 *                     display
+	 * @param {string} postParamKey a string that is used as post param key in the post body with the value
+	 *                     of the matched field as param value
+	 */
+	function registerLinkListDialog(elementSelector, postUrl, postParamKey) {
+        $(elementSelector).blur(function() {
+            $.confirm({
+                title: 'Loading...',
+                content: function () {
+                    var self = this,
+                        postData = {};
+
+                    postData[postParamKey] = $(elementSelector).val();
+
+                    return $.ajax({
+                            type: 'POST',
+                            url: postUrl,
+                            dataType: 'json',
+                            data: postData
+                        }).done(function(data, textStatus, jqXHR) {
+                            self.setTitle(data.title, true);
+                            if (data.errors.length > 0) {
+                                self.setContentAppend('<div class="alert alert-error">Sorry, an error occured while looking for links:');
+                                data.errors.forEach(function(error) {
+                                    self.setContentAppend('<br />' + error);
+                                });
+                                self.setContentAppend('</div>');
+                            } else if (data.links.length === 0) {
+                                self.setContentAppend('<div class="alert alert-success">No reasonable links found!</div>');
+                                self.setContentAppend('<div class="link-list-dialog-links">');
+                                self.setContentAppend('    <ul>');
+                                self.setContentAppend('    </ul>');
+                                self.setContentAppend('</div>');
+                            } else {
+                                self.setContentAppend('<div class="link-list-dialog-links">');
+                                self.setContentAppend('    <ul>');
+                                data.links.forEach(function(link) {
+                                    self.setContentAppend('        <li><a target="_blank" href="' + link.target + '">' + link.text + '</a></li>');
+                                });
+                                self.setContentAppend('    </ul>');
+                                self.setContentAppend('</div>');
+                            }
+                        }).fail(function(jqXHR, textStatus, errorThrown) {
+                            self.setContentAppend('<div class="alert alert-error">');
+                            self.setContentAppend('    Sorry, communication to server failed! Please check your internet connection and try again:<br /><br />');
+                            self.setContentAppend('   ' + textStatus + ' - ' + errorThrown);
+                            self.setContentAppend('</div>');
+                        })
+                    ;
+                },
+                buttons: {
+                    close: {
+                        action: function () {}
+                    }
+                }
+            });
+        });
+    }
+
+    return {
+        'registerLinkListDialog': registerLinkListDialog
+    };
+});

--- a/frontend/sw360-portlet/src/main/webapp/js/modules/sw360Validate.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/modules/sw360Validate.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright Siemens AG, 2017.
+ * Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+define('modules/sw360Validate', ['jquery', /* jquery-plugins: */ 'jquery.validate-addon', /* legacy code */ 'main' ], function($) {
+	return {
+		validateWithInvalidHandler: function(selector) {
+			$(selector).validate({
+				invalidHandler: invalidHandlerShowErrorTab
+			});
+		}
+	};
+});


### PR DESCRIPTION
…ents with similar name

* added abstract require module that opens a $.confirm dialog displaying a link list requested at a given url
* added this new module to component name field in add AND edit component flow
* added server side that performs the search for similar components
** at the moment this search might be a bit too verbose as it uses the lucene view for components where not only name is searchable
* removed jquery-validation includes as they broke the pages and are already included before each usage of mapEdit
* removed unused local variable

closes #456