### PR TITLE
fix(search): use sw360users db for user search

### DIFF
--- a/backend/src/src-search/src/main/java/org/eclipse/sw360/search/Sw360usersDatabaseSearchHandler.java
+++ b/backend/src/src-search/src/main/java/org/eclipse/sw360/search/Sw360usersDatabaseSearchHandler.java
@@ -1,0 +1,21 @@
+package org.eclipse.sw360.search;
+
+import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.thrift.search.SearchResult;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.search.db.AbstractDatabaseSearchHandler;
+
+import java.io.IOException;
+
+public class Sw360usersDatabaseSearchHandler extends AbstractDatabaseSearchHandler {
+
+    public Sw360usersDatabaseSearchHandler() throws IOException {
+        super(DatabaseSettings.COUCH_DB_USERS);
+    }
+
+    @Override
+    protected boolean isVisibleToUser(SearchResult result, User user) {
+        return true;
+    }
+
+}

--- a/backend/src/src-search/src/main/java/org/eclipse/sw360/search/db/Sw360dbDatabaseSearchHandler.java
+++ b/backend/src/src-search/src/main/java/org/eclipse/sw360/search/db/Sw360dbDatabaseSearchHandler.java
@@ -1,0 +1,31 @@
+package org.eclipse.sw360.search.db;
+
+import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
+import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
+import org.eclipse.sw360.datahandler.db.ProjectRepository;
+import org.eclipse.sw360.datahandler.permissions.ProjectPermissions;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.search.SearchResult;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+
+import java.io.IOException;
+
+public class Sw360dbDatabaseSearchHandler extends AbstractDatabaseSearchHandler {
+
+    private final ProjectRepository projectRepository;
+
+    public Sw360dbDatabaseSearchHandler() throws IOException {
+        super(DatabaseSettings.COUCH_DB_DATABASE);
+        projectRepository = new ProjectRepository(
+                new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE));
+    }
+
+    protected boolean isVisibleToUser(SearchResult result, User user) {
+        if (!result.type.equals(SW360Constants.TYPE_PROJECT)) {
+            return true;
+        }
+        Project project = projectRepository.get(result.id);
+        return ProjectPermissions.isVisible(user).test(project);
+    }
+}


### PR DESCRIPTION
* added DatabaseSearchHandler for sw360users which means that a lucene all view gets generated there as well
* changed SearchHandler to use two different DatabaseSearchHandlers in case that users and another entity type is searched - the results of both get aggregated

fixes sw360/sw360portal#428