### PR TITLE
feat(ui): Making external ids editable from release

### DIFF
--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestGenerator.java
@@ -26,6 +26,7 @@ import org.apache.thrift.protocol.TType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.datahandler.common.CommonUtils.add;
@@ -179,6 +180,32 @@ public abstract class ModerationRequestGenerator<U extends TFieldIdEnum, T exten
 
         documentAdditions.setFieldValue(field, addMap);
         documentDeletions.setFieldValue(field, deleteMap);
+    }
+
+    protected void dealWithStringtoStringMap(U field) {
+        Map<String, String> updateDocumentMap = CommonUtils.nullToEmptyMap(
+                (Map<String, String>) updateDocument.getFieldValue(field));
+        Map<String, String> actualDocumentMap = CommonUtils.nullToEmptyMap(
+                (Map<String, String>) actualDocument.getFieldValue(field));
+        if (updateDocumentMap.equals(actualDocumentMap)) {
+            return;
+        }
+
+        Map<String,String> addedMap = updateDocumentMap;
+        Map<String, String> deletedMap = actualDocumentMap;
+
+        Set<String> commonKeys = Sets.intersection(updateDocumentMap.keySet(), actualDocumentMap.keySet());
+        for(String id : commonKeys) {
+            String actual = actualDocumentMap.get(id);
+            String update = updateDocumentMap.get(id);
+            if(! Objects.equals(update, actual)) {
+                addedMap.put(id, update);
+                deletedMap.put(id, actual);
+            }
+        }
+
+        documentAdditions.setFieldValue(field, addedMap);
+        documentDeletions.setFieldValue(field, deletedMap);
     }
 
     protected void dealWithAttachments(U attachmentField){

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ReleaseModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ReleaseModerationRequestGenerator.java
@@ -73,6 +73,9 @@ public class ReleaseModerationRequestGenerator extends ModerationRequestGenerato
                     case ROLES:
                         dealWithCustomMap(Release._Fields.ROLES);
                         break;
+                    case EXTERNAL_IDS:
+                        dealWithStringtoStringMap(Release._Fields.EXTERNAL_IDS);
+                        break;
                     default:
                         dealWithBaseTypes(field, Release.metaDataMap.get(field));
                 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -105,6 +105,7 @@ public class PortalConstants {
     public static final String PAGENAME_EDIT_RELEASE = "editRelease";
     public static final String PAGENAME_DUPLICATE_RELEASE = "duplicateRelease";
     public static final String RELEASE_ROLES;
+    public static final String RELEASE_EXTERNAL_IDS;
 
     //! Specialized keys for vendors
     public static final String VENDOR = "vendor";
@@ -353,6 +354,8 @@ public class PortalConstants {
     //custom map keywords
     public static final String CUSTOM_MAP_KEY = "customMapKey";
     public static final String CUSTOM_MAP_VALUE = "customMapValue";
+    public static final String EXTERNAL_ID_KEY = "externalIdKey";
+    public static final String EXTERNAL_ID_VALUE = "externalIdValue";
 
     //! request status
     public static final String REQUEST_STATUS = "request_status";
@@ -380,6 +383,7 @@ public class PortalConstants {
         PROJECT_ROLES = props.getProperty("custommap.project.roles", "Stakeholder,Analyst,Contributor,Accountant,End user,Quality manager,Test manager,Technical writer,Key user");
         COMPONENT_ROLES = props.getProperty("custommap.component.roles", "Committer,Contributor,Expert");
         RELEASE_ROLES = props.getProperty("custommap.release.roles", "Committer,Contributor,Expert");
+        RELEASE_EXTERNAL_IDS = props.getProperty("custommap.release.externalIds", "[]");
         PROJECTIMPORT_HOSTS = props.getProperty("projectimport.hosts", "");
     }
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
@@ -370,18 +370,22 @@ public class PortletUtils {
     }
 
     public static Map<String,Set<String>> getCustomMapFromRequest(PortletRequest request) {
+        return getCustomMapFromRequest(request, PortalConstants.CUSTOM_MAP_KEY, PortalConstants.CUSTOM_MAP_VALUE);
+    }
+
+    public static Map<String,Set<String>> getCustomMapFromRequest(PortletRequest request, String mapKey, String mapValue) {
         Map<String, Set<String>> customMap = new HashMap<>();
         Enumeration<String> parameterNames = request.getParameterNames();
         List<String> keyAndValueParameterIds = Collections.list(parameterNames).stream()
-                .filter(p -> p.startsWith(PortalConstants.CUSTOM_MAP_KEY))
-                .map(s -> s.replace(PortalConstants.CUSTOM_MAP_KEY, ""))
+                .filter(p -> p.startsWith(mapKey))
+                .map(s -> s.replace(mapKey, ""))
                 .collect(Collectors.toList());
         for(String parameterId : keyAndValueParameterIds) {
-            String key = request.getParameter(PortalConstants.CUSTOM_MAP_KEY +parameterId);
+            String key = request.getParameter(mapKey +parameterId);
             if(isNullEmptyOrWhitespace(key)){
                 LOGGER.error("Empty map key found");
             } else {
-                String value = request.getParameter(PortalConstants.CUSTOM_MAP_VALUE + parameterId);
+                String value = request.getParameter(mapValue + parameterId);
                 if(!customMap.containsKey(key)){
                     customMap.put(key, new HashSet<>());
                 }
@@ -390,6 +394,16 @@ public class PortletUtils {
         }
         return customMap;
     }
+
+    public static Map<String,String> getExternalIdMapFromRequest(PortletRequest request) {
+        Map<String, Set<String>> customMap = getCustomMapFromRequest(request, PortalConstants.EXTERNAL_ID_KEY, PortalConstants.EXTERNAL_ID_VALUE);
+        return customMap.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        e -> e.getValue().stream()
+                                .findFirst()
+                                .orElse("")));
+    }
+
 
     private static com.liferay.portal.model.User getLiferayUser(PortletRequest request, User user) throws PortalException, SystemException {
         ThemeDisplay themeDisplay = (ThemeDisplay) request.getAttribute(WebKeys.THEME_DISPLAY);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortletUtils.java
@@ -77,13 +77,15 @@ public abstract class ComponentPortletUtils {
                 case RELEASE_ID_TO_RELATIONSHIP:
                     if (!release.isSetReleaseIdToRelationship())
                         release.setReleaseIdToRelationship(new HashMap<>());
-                    updateLinkedReleaesFromRequest(request, release.releaseIdToRelationship);
+                    updateLinkedReleaseFromRequest(request, release.releaseIdToRelationship);
                     break;
                 case CLEARING_STATE:
                     // skip setting CLEARING_STATE. it is supposed to be set only programmatically, never from user input.
                     break;
                 case ROLES:
                     release.setRoles(PortletUtils.getCustomMapFromRequest(request));
+                case EXTERNAL_IDS:
+                    release.setExternalIds(PortletUtils.getExternalIdMapFromRequest(request));
                 default:
                     setFieldValue(request, release, field);
             }
@@ -151,7 +153,7 @@ public abstract class ComponentPortletUtils {
         setFieldValue(request, vendor, Vendor._Fields.URL);
     }
 
-    private static void updateLinkedReleaesFromRequest(PortletRequest request, Map<String, ReleaseRelationship> linkedReleases) {
+    private static void updateLinkedReleaseFromRequest(PortletRequest request, Map<String, ReleaseRelationship> linkedReleases) {
         linkedReleases.clear();
         String[] ids = request.getParameterValues(Release._Fields.RELEASE_ID_TO_RELATIONSHIP.toString() + ReleaseLink._Fields.ID.toString());
         String[] relations = request.getParameterValues(Release._Fields.RELEASE_ID_TO_RELATIONSHIP.toString() + ReleaseLink._Fields.RELEASE_RELATIONSHIP.toString());

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/TagUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/TagUtils.java
@@ -228,8 +228,15 @@ public class TagUtils {
                     fieldDisplay = sb.toString();
                 }
                 break;
+            case TType.MAP:
+                Map<Object, Object> mapValue = (Map<Object, Object>)fieldValue;
+                HashMap <String, String> stringMapValue = new HashMap();
+                for (Map.Entry entry : mapValue.entrySet()) {
+                    stringMapValue.put(entry.getKey().toString(), entry.getValue().toString());
+                }
+                fieldDisplay = DisplayMap.getMapAsString(stringMapValue);
+                break;
             default:
-
                 fieldDisplay = fieldValue == null ? "" : fieldValue.toString();
         }
         return fieldDisplay;

--- a/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
@@ -112,9 +112,11 @@
                             <core_rt:set var="mapTitle" value="Additional Roles"/>
                             <core_rt:set var="inputType" value="email"/>
                             <core_rt:set var="inputSubtitle" value="Enter mail address"/>
-
                             <core_rt:set var="customMap" value="${release.roles}"/>
                             <%@include file="/html/utils/includes/mapEdit.jspf" %>
+
+                            <core_rt:set var="externalIdsSet" value="${release.externalIds.entrySet()}"/>
+                            <%@include file="/html/components/includes/releases/editExternalIds.jsp" %>
                             <%@include file="/html/components/includes/releases/editReleaseRepository.jspf" %>
                         </div>
                         <div id="tab-ReleaseLinks">
@@ -193,6 +195,20 @@
 
 	        $('#formSubmit').click(
 	            function() {
+                    var valid = true;
+                    $.each($('#externalIdsTable tr.bodyRow'), function (i, row) {
+                        var key = $('#'+row.id+' td input.keyClass').val();
+                        var value = $('#'+row.id+' td input.valueClass').val();
+                        var isOneEmpty = ((key !== '') && (value === '')) || ((key === '') && (value !== ''));
+                        if (isOneEmpty) {
+                            $.alert('There is a blank field in one or more of your external ids. Please correct this before updating the release.');
+                            valid = false;
+                            return false;
+                        }
+                    });
+                    if (!valid) {
+                        return;
+                    }
 	                <core_rt:choose>
 	                    <core_rt:when test="${addMode || release.permissions[WRITE]}">
 	                        $('#releaseEditForm').submit();

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editExternalIds.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editExternalIds.jsp
@@ -1,0 +1,59 @@
+<%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.components.Release" %>
+<script src="<%=request.getContextPath()%>/webjars/jquery-validation/1.15.1/jquery.validate.min.js" type="text/javascript"></script>
+<script src="<%=request.getContextPath()%>/webjars/jquery-validation/1.15.1/additional-methods.min.js" type="text/javascript"></script>
+<table class="table info_table" id="externalIdsTable">
+    <thead>
+    <tr>
+        <th colspan="3" class="headlabel">External Ids</th>
+    </tr>
+    </thead>
+</table>
+
+<input type="button" class="addButton" onclick="addRowToExternalIdsTable();" value="Click to add row to External Ids "/>
+<br/>
+<br/>
+
+<script>
+
+    function deleteIDItem(rowIdOne) {
+        function deleteMapItemInternal() {
+            $('#' + rowIdOne).remove();
+        };
+
+        deleteConfirmed("Do you really want to remove this item?", deleteMapItemInternal);
+    }
+
+    function addRowToExternalIdsTable(key, value, rowId) {
+        if (!rowId) {
+            var rowId = "externalIdsTableRow" + Date.now();
+        }
+        if ((!key) && (!value)) {
+                var key = "", value = "";
+            }
+        var newRowAsString =
+            '<tr id="' + rowId + '" class="bodyRow">' +
+            '<td width="46%">' +
+            '<input class="keyClass" id="<%=PortalConstants.EXTERNAL_ID_KEY%>' + rowId + '" name="<portlet:namespace/><%=PortalConstants.EXTERNAL_ID_KEY%>' + rowId + '" class="toplabelledInput" placeholder="Input name" title="Input name" value="' + key + '"/>' +
+            '</td>' +
+            '<td width="46%">' +
+            '<input class="valueClass" id="<%=PortalConstants.EXTERNAL_ID_VALUE%>' + rowId + '" name="<portlet:namespace/><%=PortalConstants.EXTERNAL_ID_VALUE%>' + rowId + '" class="toplabelledInput" placeholder="Input id" title="Input id" value="' + value + '"/>' +
+            '</td>' +
+            '<td class="deletor" width="8%">' +
+            '<img src="<%=request.getContextPath()%>/images/Trash.png" onclick="deleteMapItem(\'' + rowId + '\')" alt="Delete">' +
+            '</td>' +
+            '</tr>';
+        $('#externalIdsTable tr:last').after(newRowAsString);
+    }
+
+    function createExternalIdsTable() {
+        <core_rt:forEach items="${externalIdsSet}" var="tableEntry" varStatus="loop">
+        addRowToExternalIdsTable('<sw360:out value="${tableEntry.key}"/>', '<sw360:out value="${tableEntry.value}"/>', 'externalIdsTableRow${loop.count}');
+        </core_rt:forEach>
+    }
+
+    $(window).load(function () {
+        createExternalIdsTable();
+    });
+
+</script>

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/mapEdit.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/mapEdit.jspf
@@ -37,7 +37,7 @@
 
                     <td class="deletor">
                         <img src="<%=request.getContextPath()%>/images/Trash.png"
-                             onclick="deleteMapItem('mapEditTableRow${loop1.count}_${loop2.count}')"
+                             onclick="deleteMapItem('mapEditTableRow${loop1.count}_${loop2.count}');"
                              alt="Delete">
                     </td>
                 </tr>

--- a/frontend/sw360-portlet/src/main/webapp/js/main.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/main.js
@@ -244,7 +244,7 @@ function deleteConfirmed(confirmMessage, confirmCallback) {
             },
             cancel: function () {
                 //close
-            },
+            }
        }
     });
 }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/Moderator.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/Moderator.java
@@ -90,7 +90,7 @@ public abstract class Moderator<U extends TFieldIdEnum, T extends TBase<T, U>> {
                                     (Map<String, Set<String>>) documentAdditions.getFieldValue(field),
                                     (Map<String, Set<String>>) documentDeletions.getFieldValue(field)));
                 } else {
-                    log.error("Unknown field in Moderator: " + field.getFieldName());
+                        document.setFieldValue(field, documentAdditions.getFieldValue(field));
                 }
                 break;
             default:


### PR DESCRIPTION
- Creates new editable table to represent external Ids in edit release view, which can be used to update the external ids.
![screenshot from 2017-08-18 11-58-19](https://user-images.githubusercontent.com/30042647/29454203-950198fc-840c-11e7-816c-878e9b215aa2.png)
- Modifies the getCustomMapFromRequest method in PortletUtils so that it can be used for external id map.

Edit: Updating branch so it is up-to-date with master

Closes sw360/sw360portal#436