### PR TITLE
feat(ui): Added component type to the listing of moderation requests

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ModerationRequestSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ModerationRequestSummary.java
@@ -35,6 +35,7 @@ public class ModerationRequestSummary extends DocumentSummary<ModerationRequest>
         copyField(document, copy, ModerationRequest._Fields.TIMESTAMP);
         copyField(document, copy, ModerationRequest._Fields.TIMESTAMP_OF_DECISION);
         copyField(document, copy, ModerationRequest._Fields.REQUESTING_USER_DEPARTMENT);
+        copyField(document, copy, ModerationRequest._Fields.COMPONENT_TYPE);
 
         return copy;
     }

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -178,6 +178,9 @@ public class ModerationDatabaseHandler {
         //Fill the request
         ModerationRequestGenerator generator = new ComponentModerationRequestGenerator();
         request = generator.setAdditionsAndDeletions(request, component, dbcomponent);
+        if(component.isSetComponentType()) {
+            request.setComponentType(component.getComponentType());
+        }
         addOrUpdate(request);
         return RequestStatus.SENT_TO_MODERATOR;
     }
@@ -207,6 +210,12 @@ public class ModerationDatabaseHandler {
         SW360Utils.setVendorId(dbrelease);
         ModerationRequestGenerator generator = new ReleaseModerationRequestGenerator();
         request = generator.setAdditionsAndDeletions(request, release, dbrelease);
+        try {
+            Component parentComponent = componentDatabaseHandler.getComponent(release.getComponentId(), user);
+            request.setComponentType(parentComponent.getComponentType());
+        } catch (SW360Exception e) {
+            log.error("Could not retrieve parent component type of release with ID=" + release.getId());
+        }
         addOrUpdate(request);
         return RequestStatus.SENT_TO_MODERATOR;
     }

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/components/delete.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/components/delete.jsp
@@ -39,6 +39,7 @@
 
 <div id="header"></div>
 <p class="pageHeader"><span class="pageHeaderBigSpan">Moderation Delete Component: ${component.name}</span>
+                      <span class="pageHeaderBigSpan" style="float:right">(<sw360:DisplayEnum value="${moderationRequest.componentType}"/>)</span>
 </p>
 <%@include file="/html/moderation/includes/moderationActionButtons.jspf"%>
 <%@include file="/html/moderation/includes/moderationInfo.jspf"%>

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/components/merge.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/components/merge.jsp
@@ -39,6 +39,7 @@
 
 <div id="header"></div>
 <p class="pageHeader"><span class="pageHeaderBigSpan">Moderation Change Component: ${component.name}</span>
+                      <span class="pageHeaderBigSpan" style="float:right">(<sw360:DisplayEnum value="${moderationRequest.componentType}"/>)</span>
 </p>
 <%@include file="/html/moderation/includes/moderationActionButtons.jspf"%>
 <%@include file="/html/moderation/includes/moderationInfo.jspf"%>

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/projects/merge.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/projects/merge.jsp
@@ -33,7 +33,7 @@
 <script src="<%=request.getContextPath()%>/webjars/jquery-ui/1.12.1/jquery-ui.min.js"></script>
 
 <div id="header"></div>
-<p class="pageHeader"><span class="pageHeaderBigSpan">Moderation Change Project:  <sw360:ProjectName project="${project}"/></span>
+<p class="pageHeader"><span class="pageHeaderBigSpan">Moderation Change Project:  <sw360:ProjectName project="${project}"/></span>z
 </p>
 <%@include file="/html/moderation/includes/moderationActionButtons.jspf"%>
 <%@include file="/html/moderation/includes/moderationInfo.jspf"%>

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/releases/delete.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/releases/delete.jsp
@@ -53,6 +53,7 @@
 
 <div id="header"></div>
 <p class="pageHeader"><span class="pageHeaderBigSpan">Moderation Delete Release: <sw360:ReleaseName release="${release}" /></span>
+                      <span class="pageHeaderBigSpan" style="float:right">(<sw360:DisplayEnum value="${moderationRequest.componentType}"/>)</span>
 </p>
 <%@include file="/html/moderation/includes/moderationActionButtons.jspf"%>
 <%@include file="/html/moderation/includes/moderationInfo.jspf"%>

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/releases/merge.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/releases/merge.jsp
@@ -54,8 +54,8 @@
 
 
 <div id="header"></div>
-<p class="pageHeader"><span class="pageHeaderBigSpan">Moderation Change Release: <sw360:ReleaseName
-        release="${release}"/></span>
+<p class="pageHeader"><span class="pageHeaderBigSpan">Moderation Change Release: <sw360:ReleaseName release="${release}"/></span>
+                      <span class="pageHeaderBigSpan" style="float:right">(<sw360:DisplayEnum value="${moderationRequest.componentType}"/>)</span>
 </p>
 <%@include file="/html/moderation/includes/moderationActionButtons.jspf"%>
 <%@include file="/html/moderation/includes/moderationInfo.jspf"%>

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
@@ -57,11 +57,11 @@
                     <table id="moderationsTable" cellpadding="0" cellspacing="0" border="0" class="display">
                         <colgroup>
                             <col style="width: 5%;" />
-                            <col style="width: 15%;" />
+                            <col style="width: 10%;" />
                             <col style="width: 20%;" />
-                            <col style="width: 10%;" />
+                            <col style="width: 15%;" />
+                            <col style="width: 15%;" />
                             <col style="width: 30%;" />
-                            <col style="width: 10%;" />
                             <col style="width: 5%;" />
                         </colgroup>
                         <tfoot>
@@ -75,11 +75,11 @@
                     <table id="closedModerationsTable" cellpadding="0" cellspacing="0" border="0" class="display">
                         <colgroup>
                             <col style="width: 5%;" />
-                            <col style="width: 15%;" />
+                            <col style="width: 10%;" />
                             <col style="width: 20%;" />
-                            <col style="width: 10%;" />
+                            <col style="width: 15%;" />
+                            <col style="width: 15%;" />
                             <col style="width: 30%;" />
-                            <col style="width: 10%;" />
                             <col style="width: 5%;" />
                         </colgroup>
                         <tfoot>
@@ -139,12 +139,13 @@
             result.push({
                 "DT_RowId": "${moderation.id}",
                 "0": '<sw360:out value="${moderation.timestamp}"/>',
-                "1": "<sw360:DisplayModerationRequestLink moderationRequest="${moderation}"/>",
-                "2": '<sw360:DisplayUserEmail email="${moderation.requestingUser}" bare="true"/>',
-                "3": '<sw360:out value="${moderation.requestingUserDepartment}"/>',
-                "4": '<sw360:DisplayUserEmailCollection value="${moderation.moderators}" bare="true"/>',
-                "5": '<sw360:DisplayEnum value="${moderation.moderationState}"/>',
-                "6": ''
+                "1": '<sw360:DisplayEnum value="${moderation.componentType}"/>',
+                "2": "<sw360:DisplayModerationRequestLink moderationRequest="${moderation}"/>",
+                "3": '<sw360:DisplayUserEmail email="${moderation.requestingUser}" bare="true"/>',
+                "4": '<sw360:out value="${moderation.requestingUserDepartment}"/>',
+                "5": '<sw360:DisplayUserEmailCollection value="${moderation.moderators}" bare="true"/>',
+                "6": '<sw360:DisplayEnum value="${moderation.moderationState}"/>',
+                "7": ''
             });
         </core_rt:forEach>
         return result;
@@ -156,16 +157,17 @@
             result.push({
                 "DT_RowId": "${moderation.id}",
                 "0": '<sw360:out value="${moderation.timestamp}"/>',
-                "1": "<sw360:DisplayModerationRequestLink moderationRequest="${moderation}"/>",
-                "2": '<sw360:DisplayUserEmail email="${moderation.requestingUser}" bare="true"/>',
-                "3": '<sw360:out value="${moderation.requestingUserDepartment}"/>',
-                "4": '<sw360:DisplayUserEmailCollection value="${moderation.moderators}" bare="true"/>',
-                "5": '<sw360:DisplayEnum value="${moderation.moderationState}"/>',
+                "1": '<sw360:DisplayEnum value="${moderation.componentType}"/>',
+                "2": "<sw360:DisplayModerationRequestLink moderationRequest="${moderation}"/>",
+                "3": '<sw360:DisplayUserEmail email="${moderation.requestingUser}" bare="true"/>',
+                "4": '<sw360:out value="${moderation.requestingUserDepartment}"/>',
+                "5": '<sw360:DisplayUserEmailCollection value="${moderation.moderators}" bare="true"/>',
+                "6": '<sw360:DisplayEnum value="${moderation.moderationState}"/>',
                 <core_rt:if test="${isUserAtLeastClearingAdmin == 'Yes'}">
-                "6": "<img class='delete' src='<%=request.getContextPath()%>/images/Trash.png' onclick=\"deleteModerationRequest('${moderation.id}','<b>${moderation.documentName}</b>')\"  alt='Delete' title='Delete'>"
+                "7": "<img class='delete' src='<%=request.getContextPath()%>/images/Trash.png' onclick=\"deleteModerationRequest('${moderation.id}','<b>${moderation.documentName}</b>')\"  alt='Delete' title='Delete'>"
                 </core_rt:if>
                 <core_rt:if test="${isUserAtLeastClearingAdmin != 'Yes'}">
-                "6": "READY"
+                "7": "READY"
                 </core_rt:if>
 
                 });
@@ -182,6 +184,7 @@
             autowidth: false,
             columns: [
                 {title: "Date", render: {display: renderTimeToReadableFormat}},
+                {title: "Type"},
                 {title: "Document Name"},
                 {title: "Requesting User"},
                 {title: "Department"},

--- a/libraries/lib-datahandler/src/main/thrift/moderation.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/moderation.thrift
@@ -28,6 +28,7 @@ typedef projects.Project Project
 typedef users.User User
 typedef licenses.License License
 typedef licenses.Todo Todo
+typedef components.ComponentType ComponentType
 
 enum DocumentType {
     COMPONENT = 1,
@@ -56,9 +57,9 @@ struct ModerationRequest {
     17: optional string reviewer,
     18: required bool requestDocumentDelete,
     19: optional string requestingUserDepartment,
+    40: optional ComponentType componentType, // only relevant if the request is about components or releases
     34: optional string commentRequestingUser,
     35: optional string commentDecisionModerator,
-
     // Underlying objects
     20: optional Component componentAdditions,
     21: optional Release releaseAdditions,

--- a/scripts/migrations/008_add_component_type_to_moderation_requests.py
+++ b/scripts/migrations/008_add_component_type_to_moderation_requests.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python
+# -----------------------------------------------------------------------------
+# Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+#
+# All rights reserved.   This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# This is a manual database migration script. It is assumed that a
+# dedicated framework for automatic migration will be written in the
+# future. When that happens, this script should be refactored to conform
+# to the framework's prerequisites to be run by the framework. For
+# example, server address and db name should be parametrized, the code
+# reorganized into a single class or function, etc.
+#
+# initial author: christoph.niehoff@tngtech.com
+#
+# -----------------------------------------------------------------------------
+import couchdb
+
+# Constants
+TYPE = 'type'
+
+DOCUMENT_TYPE_RELEASE = 'release'
+DOCUMENT_TYPE_COMPONENT = 'component'
+DOCUMENT_TYPE_MODERATION = 'moderation'
+
+PARENT_COMPONENT_ID = 'componentId'
+
+COMPONENT = 'COMPONENT'
+RELEASE = 'RELEASE'
+
+COMPONENT_TYPE = 'componentType'
+MODERATION_TYPE = 'documentType'
+
+COMPONENT_ID = 'documentId'
+RELEASE_ID = 'documentId'
+
+
+# Set up connection to CouchDB
+COUCHSERVER = "http://localhost:5984/"
+DBNAME      = 'sw360db'
+couch = couchdb.Server(COUCHSERVER)
+db    = couch[DBNAME]
+
+
+# Define functions
+def updateDocument(db, doc, newDict):
+    doc.update(newDict)
+    db.save(doc)
+
+# Get Lists of Components, Releases and Moderations
+get_all_components_fun = '''function(doc){
+        if (doc.type=='component') {
+            emit(doc._id, doc)
+        }
+    }'''
+
+get_all_releases_fun = '''function(doc){
+        if (doc.type=='release') {
+            emit(doc._id, doc)
+        }
+    }'''
+
+get_all_moderation_requests_fun = '''function(doc){
+        if (doc.type=='moderation') {
+            emit(doc._id, doc)
+        }
+    }'''
+
+allComponents         = db.query(get_all_components_fun)
+allReleases           = db.query(get_all_releases_fun)
+allModerationRequests = db.query(get_all_moderation_requests_fun)
+
+
+print "Retrieve component and release data"
+# Create dict for Component data
+componentData = {}
+for component in allComponents:
+    document = component.value
+    if COMPONENT_TYPE in document.keys():
+        componentData[component.id] = document[COMPONENT_TYPE]
+
+# Create dict for Release data
+releaseData = {}
+for release in allReleases:
+    document = release.value
+    if PARENT_COMPONENT_ID in document.keys():
+        releaseData[release.id] = componentData[document[PARENT_COMPONENT_ID]]
+
+
+print "add component types to moderation requests in the database"
+for request in allModerationRequests:
+    document = request.value
+    if not COMPONENT_TYPE in document.keys():
+        if MODERATION_TYPE in document.keys():
+
+            if (document[MODERATION_TYPE] == COMPONENT) and (COMPONENT_ID in document.keys()):
+                componentID = document[COMPONENT_ID]
+                componentType = componentData[componentID]
+                updateDocument(db, document, {COMPONENT_TYPE: componentType})
+
+            elif (document[MODERATION_TYPE] == RELEASE) and (RELEASE_ID in document.keys()):
+                releaseID = document[RELEASE_ID]
+                componentType = releaseData[releaseID]
+                updateDocument(db, document, {COMPONENT_TYPE: componentType})
+
+print "done."
+

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -25,8 +25,9 @@ To migrate it is recommended to do this in the following order:
 - `006_convert_project_release_relationship_to_enums.py`
 ### 2.0.0 -> 2.2.0
 ### 2.2.0 -> 3.0.0
-- `007_add_submitters_usergroup_to_moderation_request.py
-`
+- `007_add_submitters_usergroup_to_moderation_request.py`
+- `008_add_component_type_to_moderation_requests.py`
+
 ## Run the scripts for a database not running on localhost
 tbd.
 


### PR DESCRIPTION
- Added `ComponentType` to `moderation.thrift`
- For components and releases this is automatically set. For releases the type of the parent component is chosen. For other moderation requests (e.g. for projects) this field is not set.
- The moderation request listing now contains an additional column displaying the component type.

Closes sw360/sw360portal#459