### PR TITLE
feat(exports): add component type to release row in spreadsheet exports

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -213,10 +213,13 @@ public class ComponentPortlet extends FossologyAwarePortlet {
     }
 
     private void exportExcel(ResourceRequest request, ResourceResponse response) {
+        final User user = UserCacheHolder.getUserFromRequest(request);
+
         try {
             boolean extendedByReleases = Boolean.valueOf(request.getParameter(PortalConstants.EXTENDED_EXCEL_EXPORT));
             List<Component> components = getFilteredComponentList(request);
-            ComponentExporter exporter = new ComponentExporter(thriftClients.makeComponentClient(), components, extendedByReleases);
+            ComponentExporter exporter = new ComponentExporter(thriftClients.makeComponentClient(), components, user,
+                    extendedByReleases);
             PortletResponseUtil.sendFile(request, response, "Components.xlsx", exporter.makeExcelExport(components),
                     CONTENT_TYPE_OPENXML_SPREADSHEET);
         } catch (IOException | SW360Exception e) {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.model.Organization;
-import org.apache.commons.lang.enums.EnumUtils;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
@@ -303,7 +302,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                         project, user);
                 List<Release> releases = releaseStringMap.keySet().stream().sorted(Comparator.comparing(SW360Utils::printFullname)).collect(Collectors.toList());
                 ReleaseExporter exporter = new ReleaseExporter(thriftClients.makeComponentClient(), releases,
-                        releaseStringMap);
+                        user, releaseStringMap);
 
                 PortletResponseUtil.sendFile(request, response,
                         String.format("releases-%s-%s-%s.xlsx", project.getName(), project.getVersion(), SW360Utils.getCreatedOn()),

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -169,7 +169,7 @@
             <option value="false">Projects only</option>
             <option value="true">Projects with linked releases</option>
         </select>
-        <input type="button" class="addButton" id="exportSpreadsheetButton" value="Export Spreadsheet" class="addButton" onclick="exportSpreadsheet()"/>
+        <input type="button" class="addButton" id="exportSpreadsheetButton" value="Export Spreadsheet" class="addButton" />
 </span>
 
 

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentExporter.java
@@ -17,6 +17,7 @@ import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -64,12 +65,14 @@ public class ComponentExporter extends ExcelExporter<Component, ComponentHelper>
 
     static List<String> HEADERS_EXTENDED_BY_RELEASES = ExporterHelper.addSubheadersWithPrefixesAsNeeded(HEADERS, ReleaseExporter.HEADERS, "release: ");
 
-    public ComponentExporter(ComponentService.Iface componentClient, List<Component> components, boolean extendedByReleases) throws SW360Exception {
-        super(new ComponentHelper(extendedByReleases, new ReleaseHelper(componentClient)));
-        preloadLinkedReleasesFor(components);
+    public ComponentExporter(ComponentService.Iface componentClient, List<Component> components, User user,
+            boolean extendedByReleases) throws SW360Exception {
+        super(new ComponentHelper(extendedByReleases, new ReleaseHelper(componentClient, user)));
+        preloadLinkedReleasesFor(components, extendedByReleases);
     }
 
-    private void preloadLinkedReleasesFor(List<Component> components) throws SW360Exception {
+    private void preloadLinkedReleasesFor(List<Component> components, boolean extendedByReleases)
+            throws SW360Exception {
         Set<String> linkedReleaseIds = components
                 .stream()
                 .map(Component::getReleaseIds)
@@ -78,6 +81,6 @@ public class ComponentExporter extends ExcelExporter<Component, ComponentHelper>
                 .collect(Collectors.toSet());
 
         Map<String, Release> releasesById = ThriftUtils.getIdMap(helper.getReleases(linkedReleaseIds));
-        helper.setPreloadedLinkedReleases(releasesById);
+        helper.setPreloadedLinkedReleases(releasesById, extendedByReleases);
     }
 }

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentHelper.java
@@ -109,7 +109,8 @@ class ComponentHelper implements ExporterHelper<Component> {
         return releaseHelper.getReleases(ids);
     }
 
-    public void setPreloadedLinkedReleases(Map<String, Release> preloadedLinkedReleases) throws SW360Exception {
-        releaseHelper.setPreloadedLinkedReleases(preloadedLinkedReleases);
+    public void setPreloadedLinkedReleases(Map<String, Release> preloadedLinkedReleases, boolean componentsNeeded)
+            throws SW360Exception {
+        releaseHelper.setPreloadedLinkedReleases(preloadedLinkedReleases, componentsNeeded);
     }
 }

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
@@ -81,7 +81,7 @@ public class ProjectExporter extends ExcelExporter<Project, ProjectHelper> {
     static List<String> HEADERS_EXTENDED_BY_RELEASES = ExporterHelper.addSubheadersWithPrefixesAsNeeded(HEADERS, ReleaseExporter.HEADERS, "release: ");
 
     public ProjectExporter(ComponentService.Iface componentClient, ProjectService.Iface projectClient, User user, List<Project> projects, boolean extendedByReleases) throws SW360Exception {
-        super(new ProjectHelper(projectClient, user, extendedByReleases, new ReleaseHelper(componentClient)));
+        super(new ProjectHelper(projectClient, user, extendedByReleases, new ReleaseHelper(componentClient, user)));
         preloadRelatedDataFor(projects, extendedByReleases, user);
     }
 
@@ -120,7 +120,7 @@ public class ProjectExporter extends ExcelExporter<Project, ProjectHelper> {
             joinedMap.putAll(linkedOfLinkedReleasesById);
             releasesById = joinedMap;
         }
-        helper.setPreloadedLinkedReleases(releasesById);
+        helper.setPreloadedLinkedReleases(releasesById, withLinkedOfLinked);
     }
 
 }

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectHelper.java
@@ -118,8 +118,9 @@ class ProjectHelper implements ExporterHelper<Project> {
         return new SubTable(makeRowForProject(project));
     }
 
-    public void setPreloadedLinkedReleases(Map<String, Release> preloadedLinkedReleases) throws SW360Exception {
-        releaseHelper.setPreloadedLinkedReleases(preloadedLinkedReleases);
+    public void setPreloadedLinkedReleases(Map<String, Release> preloadedLinkedReleases, boolean componentsNeeded)
+            throws SW360Exception {
+        releaseHelper.setPreloadedLinkedReleases(preloadedLinkedReleases, componentsNeeded);
     }
 
     List<Release> getReleases(Project project) throws SW360Exception {


### PR DESCRIPTION
* added component type to every row that ReleaseHelper creates
  * therefore has to batch load parent components of releases in more cases
  * has been part of additional data only for clearing status exports
  * now this additional data is only the project origin

closes sw360/sw360portal#326