### PR TITLE
feat(ui): provide friendly URLs in liferay

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -55,7 +55,6 @@ public class PortalConstants {
     public static final String PAGENAME = "pagename";
     public static final String PAGENAME_DETAIL = "detail";
     public static final String PAGENAME_VIEW = "view";
-
     public static final String PAGENAME_IMPORT = "import";
     public static final String PAGENAME_EDIT = "edit";
     public static final String PAGENAME_ACTION = "action";
@@ -352,6 +351,12 @@ public class PortalConstants {
 
     //! request status
     public static final String REQUEST_STATUS = "request_status";
+
+    // friendly url placeholder values
+    public static final String FRIENDLY_URL_PREFIX = "friendlyUrl";
+    public static final String FRIENDLY_URL_PLACEHOLDER_PAGENAME = FRIENDLY_URL_PREFIX + "Pagename";
+    public static final String FRIENDLY_URL_PLACEHOLDER_PROJECT_ID = FRIENDLY_URL_PREFIX + "ProjectId";
+    public static final String FRIENDLY_URL_PLACEHOLDER_COMPONENT_ID = FRIENDLY_URL_PREFIX + "ComponentId";
 
     //
     public static String PROJECTIMPORT_HOSTS;

--- a/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/component-friendly-url-routes.xml
+++ b/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/component-friendly-url-routes.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  -->
+<!DOCTYPE routes PUBLIC "-//Liferay//DTD Friendly URL Routes 6.2.0//EN"
+        "http://www.liferay.com/dtd/liferay-friendly-url-routes_6_2_0.dtd">
+
+<routes>
+    <route>
+        <pattern>/release/{page}/{id}/{releaseId}</pattern>
+        <generated-parameter name="pagename">{page}</generated-parameter>
+        <generated-parameter name="componentid">{id}</generated-parameter>
+        <generated-parameter name="releaseId">{releaseId}</generated-parameter>
+        <implicit-parameter name="p_p_id">components_WAR_sw360portlet</implicit-parameter>
+    </route>
+    <route>
+        <pattern>/{page}/{id}</pattern>
+        <generated-parameter name="pagename">{page}</generated-parameter>
+        <generated-parameter name="componentid">{id}</generated-parameter>
+        <implicit-parameter name="p_p_id">components_WAR_sw360portlet</implicit-parameter>
+    </route>
+    <route>
+        <pattern>/release/{page}/{releaseId}</pattern>
+        <generated-parameter name="pagename">{page}</generated-parameter>
+        <generated-parameter name="releaseId">{releaseId}</generated-parameter>
+        <implicit-parameter name="p_p_id">components_WAR_sw360portlet</implicit-parameter>
+    </route>
+    <route>
+        <pattern>/add</pattern>
+        <implicit-parameter name="p_p_id">components_WAR_sw360portlet</implicit-parameter>
+        <implicit-parameter name="pagename">edit</implicit-parameter>
+    </route>
+</routes>

--- a/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/license-friendly-url-routes.xml
+++ b/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/license-friendly-url-routes.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  -->
+<!DOCTYPE routes PUBLIC "-//Liferay//DTD Friendly URL Routes 6.2.0//EN"
+        "http://www.liferay.com/dtd/liferay-friendly-url-routes_6_2_0.dtd">
+
+<routes>
+    <route>
+        <pattern>/{page}/{id}</pattern>
+        <generated-parameter name="pagename">{page}</generated-parameter>
+        <generated-parameter name="licenseid">{id}</generated-parameter>
+        <implicit-parameter name="p_p_id">licenses_WAR_sw360portlet</implicit-parameter>
+    </route>
+    <route>
+        <pattern>/add</pattern>
+        <implicit-parameter name="p_p_id">licenses_WAR_sw360portlet</implicit-parameter>
+        <implicit-parameter name="pagename">edit</implicit-parameter>
+    </route>
+</routes>

--- a/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/moderation-friendly-url-routes.xml
+++ b/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/moderation-friendly-url-routes.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  -->
+<!DOCTYPE routes PUBLIC "-//Liferay//DTD Friendly URL Routes 6.2.0//EN"
+        "http://www.liferay.com/dtd/liferay-friendly-url-routes_6_2_0.dtd">
+
+<routes>
+    <route>
+        <pattern>/{page}/{id}</pattern>
+        <generated-parameter name="pagename">{page}</generated-parameter>
+        <generated-parameter name="moderationId">{id}</generated-parameter>
+        <implicit-parameter name="p_p_id">moderation_WAR_sw360portlet</implicit-parameter>
+    </route>
+</routes>

--- a/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/project-friendly-url-routes.xml
+++ b/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/project-friendly-url-routes.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  -->
+<!DOCTYPE routes PUBLIC "-//Liferay//DTD Friendly URL Routes 6.2.0//EN"
+        "http://www.liferay.com/dtd/liferay-friendly-url-routes_6_2_0.dtd">
+
+<routes>
+    <route>
+        <pattern>/{page}/{id}</pattern>
+        <generated-parameter name="pagename">{page}</generated-parameter>
+        <generated-parameter name="projectid">{id}</generated-parameter>
+        <implicit-parameter name="p_p_id">projects_WAR_sw360portlet</implicit-parameter>
+    </route>
+    <route>
+        <pattern>/add</pattern>
+        <implicit-parameter name="p_p_id">projects_WAR_sw360portlet</implicit-parameter>
+        <implicit-parameter name="pagename">edit</implicit-parameter>
+    </route>
+</routes>

--- a/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/search-friendly-url-routes.xml
+++ b/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/search-friendly-url-routes.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  -->
+<!DOCTYPE routes PUBLIC "-//Liferay//DTD Friendly URL Routes 6.2.0//EN"
+        "http://www.liferay.com/dtd/liferay-friendly-url-routes_6_2_0.dtd">
+
+<routes>
+    <route>
+        <pattern>/result</pattern>
+        <implicit-parameter name="p_p_id">search_WAR_sw360portlet</implicit-parameter>
+    </route>
+</routes>

--- a/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/vulnerability-friendly-url-routes.xml
+++ b/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/vulnerability-friendly-url-routes.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  -->
+<!DOCTYPE routes PUBLIC "-//Liferay//DTD Friendly URL Routes 6.2.0//EN"
+        "http://www.liferay.com/dtd/liferay-friendly-url-routes_6_2_0.dtd">
+
+<routes>
+    <route>
+        <pattern>/{page}/{id}</pattern>
+        <generated-parameter name="pagename">{page}</generated-parameter>
+        <generated-parameter name="vulnerabilityId">{id}</generated-parameter>
+        <implicit-parameter name="p_p_id">vulnerability_WAR_sw360portlet</implicit-parameter>
+    </route>
+</routes>

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/liferay-portlet.xml
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/liferay-portlet.xml
@@ -18,10 +18,9 @@
     <portlet>
         <portlet-name>licenses</portlet-name>
         <icon>/icon.png</icon>
-        <!--<friendly-url-mapper-class>com.liferay.portal.kernel.portlet.DefaultFriendlyURLMapper</friendly-url-mapper-class>-->
-        <!--<friendly-url-mapping>licenses</friendly-url-mapping>-->
-        <!--<friendly-url-routes>com/siemens/sw360/portal/portlets/licenses-friendly-url-routes.xml</friendly-url-routes>-->
-
+        <friendly-url-mapper-class>com.liferay.portal.kernel.portlet.DefaultFriendlyURLMapper</friendly-url-mapper-class>
+        <friendly-url-mapping>license</friendly-url-mapping>
+        <friendly-url-routes>org/eclipse/sw360/portal/mapper/license-friendly-url-routes.xml</friendly-url-routes>
         <instanceable>false</instanceable>
 
         <private-request-attributes>false</private-request-attributes>
@@ -38,9 +37,10 @@
     <portlet>
         <portlet-name>search</portlet-name>
         <icon>/icon.png</icon>
-
+        <friendly-url-mapper-class>com.liferay.portal.kernel.portlet.DefaultFriendlyURLMapper</friendly-url-mapper-class>
+        <friendly-url-mapping>search</friendly-url-mapping>
+        <friendly-url-routes>org/eclipse/sw360/portal/mapper/search-friendly-url-routes.xml</friendly-url-routes>
         <instanceable>false</instanceable>
-
         <header-portlet-css>/css/main.css</header-portlet-css>
         <!--<header-portlet-javascript>/js/main.js</header-portlet-javascript>-->
         <header-portlet-javascript>/js/main.js</header-portlet-javascript>
@@ -71,7 +71,9 @@
     <portlet>
         <portlet-name>components</portlet-name>
         <icon>/icon.png</icon>
-
+        <friendly-url-mapper-class>com.liferay.portal.kernel.portlet.DefaultFriendlyURLMapper</friendly-url-mapper-class>
+        <friendly-url-mapping>component</friendly-url-mapping>
+        <friendly-url-routes>org/eclipse/sw360/portal/mapper/component-friendly-url-routes.xml</friendly-url-routes>
         <instanceable>false</instanceable>
         <private-request-attributes>false</private-request-attributes>
         <header-portlet-css>/css/main.css</header-portlet-css>
@@ -81,7 +83,9 @@
     <portlet>
         <portlet-name>moderation</portlet-name>
         <icon>/icon.png</icon>
-
+        <friendly-url-mapper-class>com.liferay.portal.kernel.portlet.DefaultFriendlyURLMapper</friendly-url-mapper-class>
+        <friendly-url-mapping>moderation</friendly-url-mapping>
+        <friendly-url-routes>org/eclipse/sw360/portal/mapper/moderation-friendly-url-routes.xml</friendly-url-routes>
         <instanceable>false</instanceable>
         <private-request-attributes>false</private-request-attributes>
         <header-portlet-css>/css/main.css</header-portlet-css>
@@ -101,7 +105,9 @@
     <portlet>
         <portlet-name>projects</portlet-name>
         <icon>/icon.png</icon>
-
+        <friendly-url-mapper-class>com.liferay.portal.kernel.portlet.DefaultFriendlyURLMapper</friendly-url-mapper-class>
+        <friendly-url-mapping>project</friendly-url-mapping>
+        <friendly-url-routes>org/eclipse/sw360/portal/mapper/project-friendly-url-routes.xml</friendly-url-routes>
         <instanceable>false</instanceable>
         <private-request-attributes>false</private-request-attributes>
         <header-portlet-css>/css/main.css</header-portlet-css>
@@ -236,7 +242,7 @@
         <header-portlet-javascript>/js/main.js</header-portlet-javascript>
          <header-portlet-javascript>/webjars/jquery/1.12.4/jquery.min.js</header-portlet-javascript>
     </portlet>
-    
+
     <portlet>
         <portlet-name>databaseSanitation</portlet-name>
         <icon>/icon.png</icon>
@@ -285,6 +291,9 @@
     <portlet>
         <portlet-name>vulnerabilities</portlet-name>
         <icon>/icon.png</icon>
+        <friendly-url-mapper-class>com.liferay.portal.kernel.portlet.DefaultFriendlyURLMapper</friendly-url-mapper-class>
+        <friendly-url-mapping>vulnerability</friendly-url-mapping>
+        <friendly-url-routes>org/eclipse/sw360/portal/mapper/vulnerability-friendly-url-routes.xml</friendly-url-routes>
         <instanceable>false</instanceable>
         <header-portlet-css>/css/main.css</header-portlet-css>
         <header-portlet-javascript>/js/main.js</header-portlet-javascript>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/view.jsp
@@ -47,6 +47,11 @@
     <portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.PAGENAME_EDIT%>"/>
 </portlet:renderURL>
 
+<portlet:renderURL var="friendlyComponentURL">
+    <portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_PAGENAME%>"/>
+    <portlet:param name="<%=PortalConstants.COMPONENT_ID%>" value="<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_COMPONENT_ID%>"/>
+</portlet:renderURL>
+
 <portlet:resourceURL var="deleteAjaxURL">
     <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.DELETE_COMPONENT%>'/>
 </portlet:resourceURL>
@@ -315,7 +320,14 @@
             }
 
             function renderComponentNameLink(name, type, row) {
-                return renderLinkTo(makeComponentUrl(row.id, '<%=PortalConstants.PAGENAME_DETAIL%>'), name);
+                return renderLinkTo(makeComponentFriendlyUrl(row.id, '<%=PortalConstants.PAGENAME_DETAIL%>'), name);
+            }
+
+            function makeComponentFriendlyUrl(componentId, page) {
+                var portletURL = '<%=friendlyComponentURL%>'
+                    .replace('<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_PAGENAME%>', page)
+                    .replace('<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_COMPONENT_ID%>', componentId);
+                return portletURL;
             }
 
             function makeComponentUrl(componentId, page) {

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -52,6 +52,11 @@
     <portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.PAGENAME_EDIT%>"/>
 </portlet:renderURL>
 
+<portlet:renderURL var="friendlyProjectURL">
+    <portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_PAGENAME%>"/>
+    <portlet:param name="<%=PortalConstants.PROJECT_ID%>" value="<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_PROJECT_ID%>"/>
+</portlet:renderURL>
+
 <portlet:resourceURL var="projectReleasesAjaxURL">
     <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.FOSSOLOGY_GET_SENDABLE%>'/>
 </portlet:resourceURL>
@@ -235,6 +240,13 @@
 		        return portletURL.toString();
 		    }
 
+            function makeProjectFriendlyUrl(projectId, page) {
+                var portletURL = '<%=friendlyProjectURL%>'
+                    .replace('<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_PAGENAME%>', page)
+                    .replace('<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_PROJECT_ID%>', projectId);
+                return portletURL;
+            }
+
 		    function renderProjectActions(id, type, row) {
 		        <%--TODO most of this can be simplified to CSS properties --%>
 		        return "<img class='clearing' src='<%=request.getContextPath()%>/images/fossology-logo-24.gif'" +
@@ -253,7 +265,7 @@
 		    }
 
 		    function renderProjectNameLink(name, type, row) {
-		        return renderLinkTo(makeProjectUrl(row.id, '<%=PortalConstants.PAGENAME_DETAIL%>'), name);
+		        return renderLinkTo(makeProjectFriendlyUrl(row.id, '<%=PortalConstants.PAGENAME_DETAIL%>'), name);
 		    }
 
 		    function load() {


### PR DESCRIPTION
Activated liferay friendly mapper functionality for the following portlets:
- projects
- components (releases included)
- licenses
- moderations
- vulnerabilities
- search

The structure for all friendly links is:
https://localhost:8443/group/guest/{portlet]/-/{porlet}/{page}/{id}

feat(ui): provide friendly URLs in liferay
Closes sw360/sw360portal#28