### PR TITLE
feat(projects): include subprojects' clearings in parent clearings in…

### DIFF
--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -25,7 +25,10 @@ import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.eclipse.sw360.datahandler.common.SW360Assert.*;
 
@@ -211,6 +214,12 @@ public class ProjectHandler implements ProjectService.Iface {
     @Override
     public List<Project> fillClearingStateSummary(List<Project> projects, User user) throws TException {
         return handler.fillClearingStateSummary(projects, user);
+    }
+
+    @Override
+    public List<Project> fillClearingStateSummaryIncludingSubprojects(List<Project> projects, User user)
+            throws TException {
+        return handler.fillClearingStateSummaryIncludingSubprojects(projects, user);
     }
 
     @Override

--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -305,6 +305,12 @@ input[readonly].clickable {
     color: #9de997 !important;
 }
 
+#projectsTable span.clearingstate {
+	display: inline-block;
+	width: 100%;
+	text-align: center;
+}
+
 #attachmentsDetail span.dataTableChildRowCell {
     display: inline-block;
 

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissions.java
@@ -16,11 +16,7 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
@@ -50,6 +46,21 @@ public abstract class DocumentPermissions<T> {
     protected abstract Set<String> getContributors();
 
     protected abstract Set<String> getModerators();
+
+    public boolean areActionsAllowed(List<RequestedAction> actions) {
+        boolean result = true;
+
+        if (actions != null) {
+            for (RequestedAction action : actions) {
+                if (!isActionAllowed(action)) {
+                    result = false;
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
 
     protected boolean isUserInEquivalentToOwnerGroup(){
         return true;

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -280,7 +280,14 @@ service ProjectService {
     map <string, list<string>> getDuplicateProjects();
 
     /**
-    * get the same list of projects back, but with filled release clearing state summaries
+     * get the same list of projects back, but with filled release clearing state summaries
      */
     list<Project> fillClearingStateSummary(1: list<Project> projects, 2: User user);
+
+    /**
+     * get the same list of projects back, but with filled release clearing state summaries where this
+     * clearing state summary contains the clearing states of releases of the complete subproject tree.
+     * Visibility of any of the projects in the tree for the given user is currently not considered.
+     */
+    list<Project> fillClearingStateSummaryIncludingSubprojects(1: list<Project> projects, 2: User user);
 }

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissionsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissionsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.datahandler.permissions;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.apache.commons.lang.NotImplementedException;
+import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(DataProviderRunner.class)
+public class DocumentPermissionsTest {
+
+    @DataProvider
+    public static Object[][] areActionsAllowedProvider() {
+        // @formatter:off
+        return new Object[][] {
+                { null, Arrays.asList(false), true},
+                { Arrays.asList(), Arrays.asList(false), true},
+                { Arrays.asList(RequestedAction.READ), Arrays.asList(true), true},
+                { Arrays.asList(RequestedAction.READ), Arrays.asList(false), false},
+                { Arrays.asList(RequestedAction.READ, RequestedAction.WRITE, RequestedAction.DELETE), Arrays.asList(true, true, true), true},
+                { Arrays.asList(RequestedAction.READ, RequestedAction.WRITE, RequestedAction.DELETE), Arrays.asList(true, true, false), false},
+                { Arrays.asList(RequestedAction.READ, RequestedAction.WRITE, RequestedAction.DELETE), Arrays.asList(true, false, true), false},
+                { Arrays.asList(RequestedAction.READ, RequestedAction.WRITE, RequestedAction.DELETE), Arrays.asList(false, true, true), false},
+        };
+        // @formatter:on
+    }
+
+    /**
+     * test uses knowledge about the implementation but at least I like it better
+     * that way than to write the same test for each implementing subclass with
+     * complex mock setups...
+     */
+    @Test
+    @UseDataProvider("areActionsAllowedProvider")
+    public void testAreActionsAllowed(List<RequestedAction> queriedPermissions, List<Boolean> singlePermissionResults,
+            boolean expected) {
+        // given
+        DocumentPermissions<Object> perm = new TestDocumentPermissions<>(singlePermissionResults);
+
+        // when
+        boolean actual = perm.areActionsAllowed(queriedPermissions);
+
+        // then
+        assertThat(actual, is(expected));
+    }
+
+    /**
+     * We use an internal subclass and not a mock so that we do not have to mock the
+     * unit under test (which we would have to do when we want to test an abstract
+     * class)
+     */
+    private class TestDocumentPermissions<T> extends DocumentPermissions<T> {
+
+        private List<Boolean> actionAllowedReturnValues;
+        private int actionAllowedCallCount;
+
+        protected TestDocumentPermissions(List<Boolean> actionAllowedReturnValues) {
+            super(null, null);
+
+            this.actionAllowedReturnValues = actionAllowedReturnValues;
+            this.actionAllowedCallCount = 0;
+        }
+
+        @Override
+        public boolean isActionAllowed(RequestedAction action) {
+            if (actionAllowedCallCount < actionAllowedReturnValues.size()) {
+                return actionAllowedReturnValues.get(actionAllowedCallCount++);
+            } else {
+                return actionAllowedReturnValues.get(actionAllowedReturnValues.size() - 1);
+            }
+        }
+
+        @Override
+        public void fillPermissions(T other, Map<RequestedAction, Boolean> permissions) {
+            throw new NotImplementedException("method not needed in test right now");
+        }
+
+        @Override
+        protected Set<String> getContributors() {
+            throw new NotImplementedException("method not needed in test right now");
+        }
+
+        @Override
+        protected Set<String> getModerators() {
+            throw new NotImplementedException("method not needed in test right now");
+        }
+    }
+}


### PR DESCRIPTION
… project table

* added thrift service to fill clearing summary for project list including subproject data
  * wrote own project tree traversal as existing methods seemed too complex
  * permission check is only prepared, not performed
  * relation follow / no-follow is subject to change
* changed portlet to use new service that includes subproject data
* added paged requests in gui, currently with a batch size of 10 (meaning clearing summary is queried per ajax for 10 projects in one request)
  * requests are triggered sequentially, so they are non blocking but a request is only started after a former one finishes
  * to be able to query the first visible projects, the client sorting has been duplicated on the server
* changed the way clearing summary is displayed to a more condensed version like 2/7 meaning 2 of 7 releases are cleared

closes sw360/sw360portal#446