### PR TITLE
fix(ui): Fixed deletion of wrongly linked releases

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/projects/ajax/linkedProjectsAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/ajax/linkedProjectsAjax.jsp
@@ -25,7 +25,8 @@
 
 
 <core_rt:forEach items="${projectList}" var="projectLink" varStatus="loop">
-    <tr id="projectLinkRow${loop.count}" >
+    <core_rt:set var="uuid" value="${projectLink.id}"/>
+    <tr id="projectLinkRow${uuid}" >
         <td width="32%">
             <input type="hidden" value="${projectLink.id}" name="<portlet:namespace/><%=Project._Fields.LINKED_PROJECTS%><%=ProjectLink._Fields.ID%>">
             <label class="textlabel stackedLabel" for="projectName">Project name</label>
@@ -49,7 +50,7 @@
         </td>
 
         <td class="deletor">
-            <img src="<%=request.getContextPath()%>/images/Trash.png" onclick="deleteProjectLink('projectLinkRow${loop.count}')" alt="Delete">
+            <img src="<%=request.getContextPath()%>/images/Trash.png" onclick="deleteProjectLink('projectLinkRow${uuid}')" alt="Delete">
         </td>
 
     </tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/searchProjects.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/searchProjects.jsp
@@ -95,9 +95,11 @@
         function showProjectDialog() {
             openDialog('search-project-form', 'searchproject');
             if (firstRunForProjectsTable) {
-                toggleProjectSearchNotification();
                 makeProjectsDataTable();
                 firstRunForProjectsTable = false;
+            }
+            if ($('#searchbuttonproject').attr('disabled') == 'disabled') {
+                toggleProjectSearchNotification();
             }
         }
 

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedReleasesAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedReleasesAjax.jsp
@@ -24,7 +24,8 @@
 
 <jsp:useBean id="releaseList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.components.ReleaseLink>"  scope="request"/>
 <core_rt:forEach items="${releaseList}" var="releaseLink" varStatus="loop">
-    <tr id="releaseLinkRow${loop.count}" >
+    <core_rt:set var="uuid" value="${releaseLink.id}"/>
+    <tr id="releaseLinkRow${uuid}" >
         <td>
             <label class="textlabel stackedLabel" for="releaseVendor">Vendor name</label>
             <input id="releaseVendor" type="text" class="toplabelledInput" placeholder="No vendor"
@@ -61,7 +62,7 @@
         </td>
 
         <td class="deletor">
-            <img src="<%=request.getContextPath()%>/images/Trash.png" onclick="deleteReleaseLink('releaseLinkRow${loop.count}','<sw360:out value='${releaseLink.longName}' jsQuoting="'"/>')" alt="Delete">
+            <img src="<%=request.getContextPath()%>/images/Trash.png" onclick="deleteReleaseLink('releaseLinkRow${uuid}','<sw360:out value='${releaseLink.longName}' jsQuoting="'"/>')" alt="Delete">
         </td>
 
     </tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedReleasesRelationAjax.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/ajax/linkedReleasesRelationAjax.jsp
@@ -20,7 +20,8 @@
 <jsp:useBean id="releaseList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.components.ReleaseLink>"  scope="request"/>
 
 <core_rt:forEach items="${releaseList}" var="releaseLink" varStatus="loop">
-    <tr id="releaseLinkRow${loop.count}" >
+    <core_rt:set var="uuid" value="${releaseLink.id}"/>
+    <tr id="releaseLinkRow${uuid}" >
         <td width="23%">
             <label class="textlabel stackedLabel" for="releaseVendor">Vendor name</label>
             <input id="releaseVendor" type="text" class="toplabelledInput" placeholder="Enter vendor"
@@ -48,7 +49,7 @@
             </select>
         </td>
         <td class="deletor">
-            <img src="<%=request.getContextPath()%>/images/Trash.png" onclick="deleteReleaseLink('releaseLinkRow${loop.count}')" alt="Delete">
+            <img src="<%=request.getContextPath()%>/images/Trash.png" onclick="deleteReleaseLink('releaseLinkRow${uuid}')" alt="Delete">
         </td>
 
     </tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchReleases.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchReleases.jsp
@@ -104,9 +104,11 @@
         function showReleaseDialog() {
             openDialog('search-release-form', 'searchrelease');
             if (firstRunForReleasesTable) {
-                toggleReleasesSearchNotification();
                 makeReleaseDataTable();
                 firstRunForReleasesTable = false;
+            }
+            if ($('#releaseSearchButton').attr('disabled') == 'disabled') {
+                toggleReleasesSearchNotification();
             }
         }
 


### PR DESCRIPTION
* For linking releases and projects to projects changed the id for the rows in the Linked Releases and Projects-Table in the project edit view.
* At the same time also fixed an error in the projects and releases search dialogs

Closes sw360/sw360portal#541