### PR TITLE
fix(bug): Adding cancel button while editing license whitelist

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/detail.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/detail.jsp
@@ -80,10 +80,17 @@
             }
     );
 
+    function cancelEditWhitelist() {
+        $(':checkbox').prop('checked', true);
+        Y.all('table.todosFromModerationRequest').hide();
+        Y.all('table.db_table').show();
+    }
+
     function showWhiteListOptions() {
         Y.all('table.todosFromModerationRequest').show();
         Y.all('table.db_table').hide();
     }
+
     function editLicense() {
         window.location = '<portlet:renderURL >'
                              +'<portlet:param name="<%=PortalConstants.LICENSE_ID%>" value="${licenseDetail.id}"/>'

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailTodos.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailTodos.jspf
@@ -75,11 +75,12 @@
     <tr>
         <th colspan="8">Todos and Obligations Details:
             <core_rt:if test="${editMode}">
-                                    <span class="pull-right">
-                                        <core_rt:if test="${not empty moderationLicenseDetail.todos || not empty added_todos_from_moderation_request}">
-                                            <input type="button" id="SubmitWhitelist" value="Submit" onclick="submitFormWhiteList()">
-                                        </core_rt:if>
-                                    </span>
+                <span class="pull-right">
+                    <core_rt:if test="${not empty moderationLicenseDetail.todos || not empty added_todos_from_moderation_request}">
+                        <input type="button" class="addButton" id="SubmitWhitelist" value="Submit" onclick="submitFormWhiteList()">
+                        <input type="button" class="addButton" id="cancelEditWhitelistButton" value="Cancel" onclick="cancelEditWhitelist()">
+                    </core_rt:if>
+                </span>
             </core_rt:if>
         </th>
     </tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/licenses/merge.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/licenses/merge.jsp
@@ -97,9 +97,9 @@
         Y.all('td.addToWhiteListCheckboxesPlaceholder').hide();
         Y.all('tr.dependentOnWhiteList').show();
         Y.one('#EditWhitelist').hide();
+        Y.one('#cancelEditWhitelistButton').show();
         Y.one('#SubmitWhitelist').show();
     }
-
 
     function getBaseURL(){
         var baseUrl = '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>';


### PR DESCRIPTION
Adds a cancel button that resets checkboxes and cancels edit mode,

![screenshot from 2017-09-06 10-49-52](https://user-images.githubusercontent.com/30042647/30102837-21a71d7a-92f1-11e7-9b56-b2f65b3d10ed.png)

fixes #267