### PR TITLE
feat(projects): add sanity check on project update to prevent deletin…

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
@@ -37,13 +37,14 @@ public class ErrorMessages {
     public static final String EXTERNAL_ID_CANNOT_BE_EMPTY = "External ID cannot be empty.";
     public static final String PASSWORD_CANNOT_BE_EMPTY = "Password cannot be empty.";
     public static final String PASSWORDS_DONT_MATCH = "Password do not match.";
-    public static final String COULD_NOT_CREATE_USER_MODERATION_REQUEST = "Could not create user moderation request";
+    public static final String COULD_NOT_CREATE_USER_MODERATION_REQUEST = "Could not create user moderation request.";
     public static final String EMAIL_ALREADY_EXISTS = "Email already exists.";
     public static final String FULL_NAME_ALREADY_EXISTS = "Full name already exists.";
     public static final String EXTERNAL_ID_ALREADY_EXISTS = "External id already exists.";
     public static final String DEFAULT_ERROR_MESSAGE = "Request could not be processed.";
     public static final String DOCUMENT_NOT_AVAILABLE = "The requested document is not available.";
     public static final String LICENSE_SHORTNAME_TAKEN = "License shortname is already taken.";
+    public static final String UPDATE_FAILED_SANITY_CHECK = "Document update has been rejected; cannot delete all linked releases or projects at once.";
 
     //this map is used in errorKeyToMessage.jspf to generate key-value pairs for the liferay-ui error tag
     public static final ImmutableList<String> allErrorMessages = ImmutableList.<String>builder()
@@ -74,6 +75,7 @@ public class ErrorMessages {
             .add(ERROR_GETTING_RELEASE)
             .add(ERROR_GETTING_LICENSE)
             .add(LICENSE_SHORTNAME_TAKEN)
+            .add(UPDATE_FAILED_SANITY_CHECK)
             .build();
 
     private ErrorMessages() {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
@@ -264,6 +264,9 @@ abstract public class Sw360Portlet extends MVCPortlet {
                     setSW360SessionError(request, ErrorMessages.DOCUMENT_USED_BY_PROJECT_OR_RELEASE);
                 }
                 break;
+            case FAILED_SANITY_CHECK:
+                setSW360SessionError(request, ErrorMessages.UPDATE_FAILED_SANITY_CHECK);
+                break;
             default:
                 throw new PortletException("Unknown request status");
         }

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -24,6 +24,7 @@ enum RequestStatus {
     SENT_TO_MODERATOR = 1,
     FAILURE = 2,
     IN_USE=3,
+    FAILED_SANITY_CHECK = 4,
 }
 
 enum RemoveModeratorRequestStatus {


### PR DESCRIPTION
…g all linked releases or all linked projects at once

- add new RequestStatus `FAILED_SANITY_CHECK` for thrift calls
- when a project update intends to delete all release links or all project links and there are more than 5 of them, cancel the update and return the status `FAILED_SANITY_CHECK`. This should prevent erroneous accidental deletion of all links, which was reported by users in the last weeks. 
- When update fails with status `FAILED_SANITY_CHECK` show corresponding error message to the user