### PR TITLE
fix(bug): Some fixes in LicenseInfo DOCX generation

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
@@ -24,6 +24,8 @@ import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyString
 
 public class DocxUtils {
 
+    private static final int FONT_SIZE = 12;
+
     private DocxUtils() {
         //only static members
     }
@@ -50,7 +52,7 @@ public class DocxUtils {
             styleTableHeaderParagraph(paragraph);
 
             XWPFRun run = paragraph.createRun();
-            addFormattedText(run, headers[headerCount], 12, true);
+            addFormattedText(run, headers[headerCount], FONT_SIZE, true);
 
             paragraph.setWordWrap(true);
         }
@@ -95,12 +97,12 @@ public class DocxUtils {
         XWPFParagraph currentParagraph = row.getCell(0).getParagraphs().get(0);
         styleTableHeaderParagraph(currentParagraph);
         XWPFRun currentRun = currentParagraph.createRun();
-        addFormattedText(currentRun, releaseName, 12);
+        addFormattedText(currentRun, releaseName, FONT_SIZE);
 
         currentParagraph = row.getCell(1).getParagraphs().get(0);
         styleTableHeaderParagraph(currentParagraph);
         currentRun = currentParagraph.createRun();
-        addFormattedText(currentRun, version, 12);
+        addFormattedText(currentRun, version, FONT_SIZE);
 
         currentParagraph = row.getCell(2).getParagraphs().get(0);
         styleTableHeaderParagraph(currentParagraph);
@@ -109,7 +111,7 @@ public class DocxUtils {
             String licenseName = licenseNameWithText.isSetLicenseName()
                     ? licenseNameWithText.getLicenseName()
                     : "Unknown license name";
-            addFormattedText(currentRun, licenseName, 12);
+            addFormattedText(currentRun, licenseName, FONT_SIZE);
             addNewLines(currentRun, 1);
         }
 
@@ -117,14 +119,14 @@ public class DocxUtils {
         styleTableHeaderParagraph(currentParagraph);
         currentRun = currentParagraph.createRun();
         for (String ack : acknowledgements) {
-            addFormattedText(currentRun, ack, 12);
+            addFormattedText(currentRun, ack, FONT_SIZE);
             addNewLines(currentRun, 1);
         }
         currentParagraph = row.getCell(4).getParagraphs().get(0);
         styleTableHeaderParagraph(currentParagraph);
         currentRun = currentParagraph.createRun();
         for (String copyright : copyrights) {
-            addFormattedText(currentRun, copyright, 12);
+            addFormattedText(currentRun, copyright, FONT_SIZE);
             addNewLines(currentRun, 1);
         }
     }
@@ -160,7 +162,7 @@ public class DocxUtils {
 
             XWPFParagraph licenseTextParagraph = document.createParagraph();
             XWPFRun licenseTextRun = licenseTextParagraph.createRun();
-            addFormattedText(licenseTextRun, nullToEmptyString(lt.getLicenseText()), 12);
+            addFormattedText(licenseTextRun, nullToEmptyString(lt.getLicenseText()), FONT_SIZE);
             addNewLines(licenseTextRun, 1);
         });
     }

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
@@ -118,7 +118,7 @@ public abstract class OutputGenerator<T> {
     }
 
     @NotNull
-    protected List<LicenseNameWithText> getSortedLicenseNameWithTexts(Collection<LicenseInfoParsingResult> projectLicenseInfoResults) {
+    protected static List<LicenseNameWithText> getSortedLicenseNameWithTexts(Collection<LicenseInfoParsingResult> projectLicenseInfoResults) {
         Set<LicenseNameWithText> licenseNamesWithText = projectLicenseInfoResults.stream()
                 .map(LicenseInfoParsingResult::getLicenseInfo)
                 .filter(Objects::nonNull)
@@ -126,11 +126,11 @@ public abstract class OutputGenerator<T> {
                 .filter(Objects::nonNull)
                 .reduce(Sets::union)
                 .orElse(Collections.emptySet());
-        List<LicenseNameWithText> lnwtsList = licenseNamesWithText.stream().filter(licenseNameWithText -> {
-            return !LicenseNameWithTextUtils.isEmpty(licenseNameWithText);
-        }).collect(Collectors.toList());
-        lnwtsList.sort(Comparator.comparing(LicenseNameWithText::getLicenseName, String.CASE_INSENSITIVE_ORDER));
-        return lnwtsList;
+
+        return licenseNamesWithText.stream()
+                .filter(licenseNameWithText -> !LicenseNameWithTextUtils.isEmpty(licenseNameWithText))
+                .sorted(Comparator.comparing(LicenseNameWithText::getLicenseName, String.CASE_INSENSITIVE_ORDER))
+                .collect(Collectors.toList());
     }
 
     private static <U> SortedMap<String, U> sortStringKeyedMap(Map<String, U> unsorted){

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
@@ -35,16 +35,20 @@ public class SPDXParserTools {
 
     private static final Logger log = Logger.getLogger(SPDXParserTools.class);
 
+    private static final String LICENSE_REF_PREFIX = "LicenseRef-";
+
     private static String extractLicenseName(AnyLicenseInfo licenseConcluded) {
         return licenseConcluded.getResource().getLocalName();
     }
 
-    private static String extractLicenseName(ExtractedLicenseInfo extractedLicenseInfo){
-        return ! isNullEmptyOrWhitespace(extractedLicenseInfo.getName()) ? extractedLicenseInfo.getName() : extractedLicenseInfo.getLicenseId();
+    private static String extractLicenseName(ExtractedLicenseInfo extractedLicenseInfo) {
+        return !isNullEmptyOrWhitespace(extractedLicenseInfo.getName())
+                ? extractedLicenseInfo.getName()
+                : extractedLicenseInfo.getLicenseId().replaceAll(LICENSE_REF_PREFIX, "");
     }
 
 
-    protected static Stream<LicenseNameWithText> getAllLicenseTextsFromInfo(AnyLicenseInfo spdxLicenseInfo) {
+    private static Stream<LicenseNameWithText> getAllLicenseTextsFromInfo(AnyLicenseInfo spdxLicenseInfo) {
         log.trace("Seen the spdxLicenseInfo=" + spdxLicenseInfo.toString() + "]");
         if (spdxLicenseInfo instanceof LicenseSet) {
 
@@ -88,10 +92,10 @@ public class SPDXParserTools {
         return Stream.empty();
     }
 
-    protected static Stream<LicenseNameWithText> getAllLicenseTexts(SpdxItem spdxItem, boolean useLicenseInfoFromFiles) {
+    private static Stream<LicenseNameWithText> getAllLicenseTexts(SpdxItem spdxItem, boolean useLicenseInfoFromFiles) {
         Stream<LicenseNameWithText> licenseTexts = getAllLicenseTextsFromInfo(spdxItem.getLicenseConcluded());
 
-        if (useLicenseInfoFromFiles){
+        if (useLicenseInfoFromFiles) {
             licenseTexts = Stream.concat(licenseTexts,
                     Arrays.stream(spdxItem.getLicenseInfoFromFiles())
                             .flatMap(SPDXParserTools::getAllLicenseTextsFromInfo));
@@ -103,7 +107,7 @@ public class SPDXParserTools {
                 licenseTexts = Stream.concat(licenseTexts,
                         getAllLicenseTextsFromInfo(spdxPackage.getLicenseDeclared()));
 
-                for (SpdxFile spdxFile: spdxPackage.getFiles()){
+                for (SpdxFile spdxFile : spdxPackage.getFiles()) {
                     licenseTexts = Stream.concat(licenseTexts,
                             getAllLicenseTexts(spdxFile, useLicenseInfoFromFiles));
                 }
@@ -116,9 +120,9 @@ public class SPDXParserTools {
         return licenseTexts;
     }
 
-    protected static Stream<String> getAllCopyrights(SpdxItem spdxItem) {
+    private static Stream<String> getAllCopyrights(SpdxItem spdxItem) {
         Stream<String> copyrights = Stream.of(spdxItem.getCopyrightText().trim());
-        if (spdxItem instanceof SpdxPackage){
+        if (spdxItem instanceof SpdxPackage) {
             SpdxPackage spdxPackage = (SpdxPackage) spdxItem;
             try {
                 copyrights = Stream.concat(copyrights,

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
@@ -139,7 +139,7 @@ public class SPDXParserTest {
 
         Attachment attachment = makeAttachment(exampleFile,
                 Arrays.stream(AttachmentType.values())
-                        .filter(at -> SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES.contains(at))
+                        .filter(SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES::contains)
                         .findAny()
                         .get());
 

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
@@ -69,15 +69,15 @@ public class SPDXParserTest {
         // @formatter:off
         return new Object[][] {
                 { spdxExampleFile,
-                        Arrays.asList("Apache-2.0", "LGPL-2.0", "LicenseRef-1", "GPL-2.0", "CyberNeko License", "LicenseRef-2"),
+                        Arrays.asList("Apache-2.0", "LGPL-2.0", "1", "GPL-2.0", "CyberNeko License", "2"),
                         4,
                         "Copyright 2008-2010 John Smith" },
                 { spdx11ExampleFile,
-                        Arrays.asList("LicenseRef-4", "LicenseRef-1", "Apache-2.0", "LicenseRef-2", "Apache-1.0", "MPL-1.1", "CyberNeko License"),
+                        Arrays.asList("4", "1", "Apache-2.0", "2", "Apache-1.0", "MPL-1.1", "CyberNeko License"),
                         2,
                         "Hewlett-Packard Development Company, LP" },
                 { spdx12ExampleFile,
-                        Arrays.asList("LicenseRef-4", "LicenseRef-1", "Apache-2.0", "LicenseRef-2", "Apache-1.0", "MPL-1.1", "CyberNeko License"),
+                        Arrays.asList("4", "1", "Apache-2.0", "2", "Apache-1.0", "MPL-1.1", "CyberNeko License"),
                         3,
                         "Hewlett-Packard Development Company, LP" },
         };


### PR DESCRIPTION
https://github.com/sw360/sw360portal/issues/575


* License names have LicenseRef prefix in License Info Documents when using SPDX
* License Texts miss formatting in lLicense Info document when using SPDX RDF
* License Texts are present multiple times in License Info Doc if generated from spdx report
