### PR TITLE
feat(attachments): Adding ReadMe OSS document type to attachments

### DIFF
--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
@@ -82,6 +82,7 @@ public class ThriftEnumUtils {
             .put(AttachmentType.LEGAL_EVALUATION, "Legal evaluation report")
             .put(AttachmentType.LICENSE_AGREEMENT, "License agreement")
             .put(AttachmentType.SCREENSHOT, "Screenshot of website")
+            .put(AttachmentType.README_OSS, "ReadMe OSS")
             .put(AttachmentType.OTHER, "Other")
             .build();
 
@@ -104,6 +105,7 @@ public class ThriftEnumUtils {
             .put(AttachmentType.LEGAL_EVALUATION, "LRT")
             .put(AttachmentType.LICENSE_AGREEMENT, "LAT")
             .put(AttachmentType.SCREENSHOT, "SCR")
+            .put(AttachmentType.README_OSS, "RDM")
             .put(AttachmentType.OTHER, "OTH")
             .build();
     // @formatter:on

--- a/libraries/lib-datahandler/src/main/thrift/attachments.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/attachments.thrift
@@ -36,7 +36,8 @@ enum AttachmentType {
     LEGAL_EVALUATION = 13,
     LICENSE_AGREEMENT = 14,
     SCREENSHOT = 15,
-    OTHER = 16
+    OTHER = 16,
+    README_OSS = 17
 }
 
 enum CheckStatus {


### PR DESCRIPTION
Adds ReadMe OSS as an option when adding a new attachment or editing attachments

![screenshot from 2017-09-08 10-50-28](https://user-images.githubusercontent.com/30042647/30205963-e43b9da8-948a-11e7-89aa-65595eea996f.png)

fixes #523