### PR TITLE
feat(attachments): Prevent deletion of approved attachments

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentAwareDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentAwareDatabaseHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyCollection;
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
+
+public abstract class AttachmentAwareDatabaseHandler {
+
+    public Set<Attachment> getAllAttachmentsToKeep(Set<Attachment> originalAttachments, Set<Attachment> changedAttachments) {
+        Set <Attachment> attachmentsToKeep = new HashSet<>();
+        attachmentsToKeep.addAll(nullToEmptySet(changedAttachments));
+        Set<String> alreadyPresentIdsInAttachmentsToKeep = nullToEmptyCollection(attachmentsToKeep).stream().map(Attachment::getAttachmentContentId).collect(Collectors.toSet());
+
+        // prevent deletion of already accepted attachments
+        Set<Attachment> acceptedAttachmentsNotYetToKeep = nullToEmptySet(originalAttachments).stream().filter(a -> (a.getCheckStatus() == CheckStatus.ACCEPTED && !alreadyPresentIdsInAttachmentsToKeep.contains(a.getAttachmentContentId()))).collect(Collectors.toSet());
+        attachmentsToKeep.addAll(acceptedAttachmentsNotYetToKeep);
+
+        return attachmentsToKeep;
+    }
+
+
+    public AttachmentAwareDatabaseHandler() {
+
+    }
+}

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -69,7 +69,7 @@ import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.prepareRelease
  * @author Johannes.Najjar@tngtech.com
  * @author alex.borodin@evosoft.com
  */
-public class ComponentDatabaseHandler {
+public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     private static final Logger log = Logger.getLogger(ComponentDatabaseHandler.class);
 
@@ -403,8 +403,10 @@ public class ComponentDatabaseHandler {
             component.unsetReleases();
 
             copyFields(actual, component, immutableOfComponent());
+            component.setAttachments( getAllAttachmentsToKeep(actual.getAttachments(), component.getAttachments()) );
             // Update the database with the component
             componentRepository.update(component);
+
             //clean up attachments in database
             attachmentConnector.deleteAttachmentDifference(actual.getAttachments(),component.getAttachments());
             sendMailNotificationsForComponentUpdate(component, user.getEmail());
@@ -463,7 +465,7 @@ public class ComponentDatabaseHandler {
             if (hasChangesInEccFields) {
                 autosetEccUpdaterInfo(release, user);
             }
-
+            release.setAttachments( getAllAttachmentsToKeep(actual.getAttachments(), release.getAttachments()) );
             releaseRepository.update(release);
             updateReleaseDependentFieldsForComponentId(release.getComponentId());
             //clean up attachments in database
@@ -584,6 +586,7 @@ public class ComponentDatabaseHandler {
     ///////////////////////////////
     // DELETE INDIVIDUAL OBJECTS //
     ///////////////////////////////
+
 
     public RequestStatus deleteComponent(String id, User user) throws SW360Exception {
         Component component = componentRepository.get(id);

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -54,7 +54,7 @@ import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePerm
  * @author daniele.fognini@tngtech.com
  * @author alex.borodin@evosoft.com
  */
-public class ProjectDatabaseHandler {
+public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     private static final Logger log = Logger.getLogger(ProjectDatabaseHandler.class);
     private static final int DELETION_SANITY_CHECK_THRESHOLD = 5;
@@ -182,6 +182,7 @@ public class ProjectDatabaseHandler {
             return RequestStatus.FAILED_SANITY_CHECK;
         } else if (makePermission(actual, user).isActionAllowed(RequestedAction.WRITE)) {
             copyImmutableFields(project,actual);
+            project.setAttachments( getAllAttachmentsToKeep(actual.getAttachments(), project.getAttachments()) );
             repository.update(project);
 
             //clean up attachments in database

--- a/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/AttachmentAwareDatabaseHandlerTest.java
+++ b/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/AttachmentAwareDatabaseHandlerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AttachmentAwareDatabaseHandlerTest {
+
+    AttachmentAwareDatabaseHandler handler;
+
+    @Before
+    public void setUp() throws Exception {
+
+        handler = new AttachmentAwareDatabaseHandler() {
+            @Override
+            public Set<Attachment> getAllAttachmentsToKeep(Set<Attachment> originalAttachments, Set<Attachment> changedAttachments) {
+                return super.getAllAttachmentsToKeep(originalAttachments, changedAttachments);
+            }
+        };
+    }
+
+    @Test
+    public void testGetAllAttachmentsToKeep() throws Exception {
+
+        // Try to delete one approved and one rejected attachment.
+        //  -> the approved one should not be deleted.
+        Attachment attachmentAccepted = new Attachment().setAttachmentContentId("acceptedAtt").setFilename("att1.file").setCheckStatus(CheckStatus.ACCEPTED);
+        Attachment attachmentRejected = new Attachment().setAttachmentContentId("rejectedAtt").setFilename("att2.file").setCheckStatus(CheckStatus.REJECTED);
+        Set<Attachment> attachmentsBefore = new HashSet<>();
+        attachmentsBefore.add(attachmentAccepted);
+        attachmentsBefore.add(attachmentRejected);
+        Set<Attachment> attachmentsAfter = new HashSet<>();
+
+        Set<Attachment> attachmentsToKeep = handler.getAllAttachmentsToKeep(attachmentsBefore, attachmentsAfter);
+
+        assertEquals(1, attachmentsToKeep.size());
+        assertTrue(attachmentsToKeep.contains(attachmentAccepted));
+        assertFalse(attachmentsToKeep.contains(attachmentRejected));
+
+        // Change an attachment
+        //  -> it should not be stored twice
+        Attachment originalAttachment = new Attachment().setAttachmentContentId("att").setFilename("att.file").setCheckStatus(CheckStatus.ACCEPTED);
+        attachmentsBefore = new HashSet<>();
+        attachmentsBefore.add(originalAttachment);
+
+        Attachment changedAttachment = originalAttachment.deepCopy().setCheckStatus(CheckStatus.REJECTED);
+        attachmentsAfter = new HashSet<>();
+        attachmentsAfter.add(changedAttachment);
+
+        attachmentsToKeep = handler.getAllAttachmentsToKeep(attachmentsBefore, attachmentsAfter);
+
+        assertEquals(1, attachmentsToKeep.size());
+        assertTrue(attachmentsToKeep.contains(changedAttachment));
+    }
+
+    @Test
+    public void testGetAllAttachmentsToKeepCanHandleNull() throws Exception {
+
+        // Test what happens if `changedAttachments` are `null`
+        //  ->  only not-accepted attachments should be deleted
+        Attachment attachmentAccepted1 = new Attachment().setAttachmentContentId("acceptedAtt1").setFilename("att1.file").setCheckStatus(CheckStatus.ACCEPTED);
+        Attachment attachmentRejected1 = new Attachment().setAttachmentContentId("rejectedAtt1").setFilename("att2.file").setCheckStatus(CheckStatus.REJECTED);
+        Attachment attachmentRejected2 = new Attachment().setAttachmentContentId("rejectedAtt2").setFilename("att3.file").setCheckStatus(CheckStatus.NOTCHECKED);
+
+        Set<Attachment> attachments = new HashSet<>();
+        attachments.add(attachmentAccepted1);
+        attachments.add(attachmentRejected1);
+        attachments.add(attachmentRejected2);
+
+        Set<Attachment> attachmentsToKeep = handler.getAllAttachmentsToKeep(attachments, null);
+        assertEquals(1, attachmentsToKeep.size());
+        assertTrue(attachmentsToKeep.contains(attachmentAccepted1));
+        assertFalse(attachmentsToKeep.contains(attachmentRejected1));
+        assertFalse(attachmentsToKeep.contains(attachmentRejected2));
+
+        // Test what happens if `originalAttachments` are `null`  (this means adding of attachments)
+        //  ->  all should be added
+        attachmentsToKeep = handler.getAllAttachmentsToKeep(null, attachments);
+        assertEquals(3, attachmentsToKeep.size());
+        assertTrue(attachmentsToKeep.contains(attachmentAccepted1));
+        assertTrue(attachmentsToKeep.contains(attachmentRejected1));
+        assertTrue(attachmentsToKeep.contains(attachmentRejected2));
+    }
+}

--- a/frontend/sw360-portlet/src/main/webapp/html/components/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/edit.jsp
@@ -15,6 +15,7 @@
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%@ page import="org.eclipse.sw360.portal.portlets.projects.ProjectPortlet" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.users.RequestedAction" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus" %>
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
@@ -57,6 +58,7 @@
 <%--These variables are used as a trick to allow referencing enum values in EL expressions below--%>
 <c:set var="WRITE" value="<%=RequestedAction.WRITE%>"/>
 <c:set var="DELETE" value="<%=RequestedAction.DELETE%>"/>
+<c:set var="hasWritePermissions" value="${component.permissions[WRITE]}"/>
 
 <%@include file="/html/utils/includes/logError.jspf" %>
 <core_rt:if test="${empty attributeNotFoundException}">

--- a/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
@@ -15,6 +15,7 @@
 <%@ page import="org.eclipse.sw360.datahandler.thrift.components.Release" %>
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.users.RequestedAction" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus" %>
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
@@ -60,6 +61,7 @@
 <%--These variables are used as a trick to allow referencing enum values in EL expressions below--%>
 <c:set var="WRITE" value="<%=RequestedAction.WRITE%>"/>
 <c:set var="DELETE" value="<%=RequestedAction.DELETE%>"/>
+<c:set var="hasWritePermissions" value="${release.permissions[WRITE]}"/>
 
 <%@include file="/html/utils/includes/logError.jspf" %>
 
@@ -95,8 +97,8 @@
                         <core_rt:if test="${not addMode}">
                             <li><a href="#tab-ReleaseClearingInformation">Clearing Details</a></li>
                             <li><a href="#tab-ReleaseECCInformation">ECC Details</a></li>
+                            <li><a href="#tab-Attachments">Attachments</a></li>
                         </core_rt:if>
-                        <li><a href="#tab-Attachments">Attachments</a></li>
                         <core_rt:if test="${cotsMode}">
                             <li><a href="#tab-COTSDetails">Commercial Details</a></li>
                         </core_rt:if>
@@ -119,16 +121,16 @@
                             <%@include file="/html/utils/includes/editLinkedReleases.jspf" %>
                         </div>
                         <core_rt:if test="${not addMode}">
-                            <div id="tab-ReleaseClearingInformation">
-                               <%@include file="/html/components/includes/releases/editReleaseClearingInformation.jspf" %>
-                            </div>
-                            <div id="tab-ReleaseECCInformation">
-                                <%@include file="/html/components/includes/releases/editReleaseECCInformation.jspf" %>
-                            </div>
-                        </core_rt:if>
+                        <div id="tab-ReleaseClearingInformation">
+                                <%@include file="/html/components/includes/releases/editReleaseClearingInformation.jspf" %>
+                             </div>
+                             <div id="tab-ReleaseECCInformation">
+                                 <%@include file="/html/components/includes/releases/editReleaseECCInformation.jspf" %>
+                             </div>
                         <div id="tab-Attachments">
                             <%@include file="/html/utils/includes/editAttachments.jspf" %>
                         </div>
+                        </core_rt:if>
                         <core_rt:if test="${cotsMode}">
                             <div id="tab-COTSDetails">
                                 <%@include file="/html/components/includes/releases/editCommercialDetails.jspf" %>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
@@ -17,6 +17,7 @@
 <%@ page import="org.eclipse.sw360.datahandler.thrift.moderation.DocumentType" %>
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.users.RequestedAction" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus" %>
 
 <%@ include file="/html/init.jsp"%>
 <%-- the following is needed by liferay to display error messages--%>
@@ -44,13 +45,13 @@
     <jsp:useBean id="projectList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.projects.ProjectLink>"  scope="request"/>
     <jsp:useBean id="releaseList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.components.ReleaseLink>"  scope="request"/>
     <jsp:useBean id="attachments" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.attachments.Attachment>" scope="request"/>
-
     <core_rt:set  var="addMode"  value="${empty project.id}" />
 </c:catch>
 
 <%--These variables are used as a trick to allow referencing enum values in EL expressions below--%>
 <c:set var="WRITE" value="<%=RequestedAction.WRITE%>"/>
 <c:set var="DELETE" value="<%=RequestedAction.DELETE%>"/>
+<c:set var="hasWritePermissions" value="${project.permissions[WRITE]}"/>
 
 <%@include file="/html/utils/includes/logError.jspf" %>
 <core_rt:if test="${empty attributeNotFoundException}">

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/editAttachments.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/editAttachments.jspf
@@ -15,16 +15,18 @@
     Required Imports:       - org.eclipse.sw360.portal.common.PortalConstants
                             - org.eclipse.sw360.datahandler.thrift.attachments.Attachment
                             - org.eclipse.sw360.datahandler.thrift.components.Release
+                            - org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus
 
     Required Beans:         - documentID
                             - documentType
+
+    Required variables:     - hasWritePermissions
 
     Required Stylesheets:   - jquery-ui
                             - jquery-confirm
 
     Included JSPFs:         - utils/includes/attachmentsUpload
 --%>
-
 <portlet:resourceURL var="attachmentListAjaxURL">
     <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.ATTACHMENT_LIST%>'/>
     <portlet:param name="<%=PortalConstants.DOCUMENT_ID%>" value="${documentID}"/>
@@ -120,7 +122,7 @@
               /*  8 */ { data: "checkedTeam", defaultContent: "", render: $.fn.dataTable.render.ellipsis },
               /*  9 */ { data: "checkedBy", defaultContent: "", render: $.fn.dataTable.render.ellipsis },
               /* 10 */ { data: "checkedOn", defaultContent: "" },
-              /* 11 */ { data: "actions", orderable: false, render: $.fn.dataTable.render.actions( [{ key: 'attachmentContentId', 'class': 'delete-attachment', icon: 'Trash', title: 'Delete Attachment' }] ) }
+              /* 11 */ { data: "actions", orderable: false, render: $.fn.dataTable.render.actions( [{ key: 'attachmentContentId', 'class': 'delete-attachment', icon: 'Trash', title: 'Delete Attachment', approvalKey: 'checkStatus'}] ) }
             ],
             columnDefs: [{
                   targets: 1,
@@ -173,9 +175,12 @@
 
         $('#attachmentInfo').on('click', 'img.delete-attachment', function(event) {
             var data = $(event.currentTarget).data();
-            deleteAttachment(data.key);
+            if(data.approvalstate != <%=CheckStatus.ACCEPTED.getValue()%>) {
+                deleteAttachment(data.key);
+            } else {
+                displayDeleteNotAllowedWarning();
+            }
         });
-
 
         // helper methods
         function renderFilename(filename, type, row) {
@@ -197,6 +202,24 @@
             }
 
             confirm.confirmDeletion("Do you really want to delete attachment <b>" + attachmentName + "</b> (" + attachmentId + ")?", deleteAttachmentInternal);
+        }
+
+        function displayDeleteNotAllowedWarning() {
+            var warningMessage = "<p>An attachment cannot be deleted while it is approved. You have to reject the approval first.</p>";
+            <core_rt:if test="${hasWritePermissions == false}">
+                warningMessage += "<p>For this, you have to create a moderation request.</p>";
+            </core_rt:if>
+            $.confirm({
+                title: 'Warning',
+                content: warningMessage,
+                buttons: {
+                    cancel: function() {
+                        // close
+                    }
+                },
+                escapeKey: 'cancel',
+                animation: 'zoom',
+            });
         }
     });
 </script>

--- a/frontend/sw360-portlet/src/main/webapp/js/modules/datatables-renderer.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/modules/datatables-renderer.js
@@ -237,17 +237,18 @@ define('modules/datatables-renderer', ['jquery', /* jquery-plugins */ 'datatable
     /**
      * Renders the given actions. Actions are an array of action objects. Each action object must provide the following properties:
      * <ol>
-     *   <li>key:   Will be set as "data-key" attribute to be able to identify the row</li>
-     *   <li>class: class name or space space separated class names for the action element</li>
-     *   <li>icon:  name of the icon to be shown, e.g. "Trash"
-     *   <li>title: Title to be shown on mouse over or if the icon could not be found</li>
+     *   <li>key:         Will be set as "data-key" attribute to be able to identify the row</li>
+     *   <li>class:       class name or space space separated class names for the action element</li>
+     *   <li>icon:        name of the icon to be shown, e.g. "Trash"
+     *   <li>title:       Title to be shown on mouse over or if the icon could not be found</li>
+     *   <li>approvalKey: Will be set as "data-approval-state" attribute. This allows to decide whether an attachment is deletable.</li>
      * </ol>
      *
      * @param {Array} actions the actions as defined before
      *
      * @return {Function} render function for DataTable
      *
-     * Example usage in column definition: <code>..., renderer: $.fn.dataTable.render.actions( [{ key: 'attachmentContentId', 'class': 'delete-attachment', icon: 'Trash', title: 'Delete Attachment' }] ), ...</code>
+     * Example usage in column definition: <code>..., renderer: $.fn.dataTable.render.actions( [{ key: 'attachmentContentId', 'class': 'delete-attachment', icon: 'Trash', title: 'Delete Attachment', approvalKey: 'checkStatus' }] ), ...</code>
      */
     $.fn.dataTable.render.actions = function(actions) {
         return function(data, type, row) {
@@ -259,7 +260,8 @@ define('modules/datatables-renderer', ['jquery', /* jquery-plugins */ 'datatable
                         src: '/sw360-portlet/images/' + action.icon + '.png',
                         alt: action.title,
                         title: action.title,
-                        'data-key': row[action.key]
+                        'data-key': row[action.key],
+                        'data-approvalstate': row[action.approvalKey]
                     })[0].outerHTML;
                 });
                 return actionsHtml;

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentConnectorTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentConnectorTest.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.datahandler.couchdb;
 
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
+import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,6 +67,34 @@ public class AttachmentConnectorTest {
 
         attachmentConnector.deleteAttachmentDifference(before, after);
         verify(connector).deleteIds(deletedIds, AttachmentContent.class);
+    }
+
+    @Test
+    public void testDeleteAttachmentsDifferenceOnlyNonAcceptedIsDeleted() throws Exception {
+        Attachment a1 = mock(Attachment.class);
+        when(a1.getAttachmentContentId()).thenReturn("a1");
+
+        Attachment a2 = mock(Attachment.class);
+        when(a2.getAttachmentContentId()).thenReturn("a2");
+        when(a2.getCheckStatus()).thenReturn(CheckStatus.REJECTED);
+
+        Attachment a3 = mock(Attachment.class);
+        when(a3.getAttachmentContentId()).thenReturn("a3");
+        when(a3.getCheckStatus()).thenReturn(CheckStatus.ACCEPTED);
+
+        Set<Attachment> before = new HashSet<>();
+        before.add(a1);
+        before.add(a2);
+        before.add(a3);
+
+        Set<Attachment> after = new HashSet<>();
+        after.add(a1);
+
+        Set<String> expectedIdsToDelete = new HashSet<>();
+        expectedIdsToDelete.add("a2");
+
+        attachmentConnector.deleteAttachmentDifference(before, after);
+        verify(connector).deleteIds(expectedIdsToDelete, AttachmentContent.class);
     }
 
 


### PR DESCRIPTION
* Attachments can only be deleted if they are not approved (enforced this in the backend)
* In the GUI a warning is displayed if the user wants to delete an approved attachment, that does not allow him to do so.

Closes sw360/sw360portal#457