### PR TITLE
feat(travis): test that all files contain license headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # -----------------------------------------------------------------------------
-# Copyright Siemens AG, 2016.
+# Copyright Siemens AG, 2016-2017.
 # Copyright Bosch Software Innovations GmbH, 2017.
 # Part of the SW360 Portal Project.
 #
@@ -39,5 +39,9 @@ matrix:
       before_install:
     - env: MVN_ARGS="dependency:analyze -DfailOnWarning"
       install: mvn package -DskipTests
+    - before_install: true
+      install: true
+      script: .travis/testForLicenseHeaders.sh
+      env: DESC="test for license headers"
   allow_failures:
     - env: MVN_ARGS="dependency:analyze -DfailOnWarning"

--- a/.travis/testForLicenseHeaders.sh
+++ b/.travis/testForLicenseHeaders.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Copyright Siemens AG, 2017.
+# Part of the SW360 Portal Project.
+#
+# All rights reserved. This configuration file is provided to you under the
+# terms and conditions of the Eclipse Distribution License v1.0 which
+# accompanies this distribution, and is available at
+# http://www.eclipse.org/org/documents/edl-v10.php
+#
+# initial author: maximilian.huber@tngtech.com
+# -----------------------------------------------------------------------------
+
+cd "$(dirname $0)/.."
+
+failure=false
+
+while read file ; do
+    if ! head -15 $file | grep -q 'SPDX-License-Identifier:' $file; then
+        echo "WARN: no 'SPDX-License-Identifier' in  $file"
+    fi
+    if head -15 $file | grep -q 'http://www.eclipse.org/legal/epl-v10.html'; then
+        continue # epl found
+    fi
+    if head -15 $file | grep -q 'http://www.eclipse.org/org/documents/edl-v10.php'; then
+        continue # edl found
+    fi
+    if head -15 $file | grep -q 'Modifications applied by Siemens AG'; then
+        continue
+    fi
+
+    echo "$(tput bold)ERROR: neither epl-1.0 nor edl-1.0 are specified in $file$(tput sgr0)"
+    failure=true
+done <<< "$(git ls-files \
+    | grep -Ev '\.(csv|rdf|ent|dtd|lar|png|gif|psd|ico|jpg|docx|gitignore)' \
+    | grep -Ev '(LICENSE|NOTICE|README)' \
+    | grep -v 'id_rsa')"
+
+if [ "$failure" = true ]; then
+    echo "test failed"
+    exit 1
+fi

--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/matcher/Match.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/matcher/Match.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2016.
+ * Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.sw360.cvesearch.datasource.matcher;
 
 import java.util.Comparator;

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/heuristics/SearchLevelsTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/heuristics/SearchLevelsTest.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2016.
+ * Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.sw360.cvesearch.datasource.heuristics;
 
 import org.eclipse.sw360.datahandler.thrift.components.Release;

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/helper/VulnerabilityUtilsTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/helper/VulnerabilityUtilsTest.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) Bosch Software Innovations GmbH 2016.
+ * Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.sw360.cvesearch.helper;
 
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/util/LicenseNameWithTextUtils.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/util/LicenseNameWithTextUtils.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.sw360.licenseinfo.util;
 
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;

--- a/backend/src/src-licenseinfo/src/main/resources/velocity-tools.xml
+++ b/backend/src/src-licenseinfo/src/main/resources/velocity-tools.xml
@@ -1,3 +1,13 @@
+<!--
+  ~ Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  -->
 <tools>
     <toolbox scope="application">
         <tool class="org.apache.velocity.tools.generic.EscapeTool"/>

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/util/LicenseNameWithTextUtilsTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/util/LicenseNameWithTextUtilsTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.sw360.licenseinfo.util;
 
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;

--- a/backend/src/src-licenseinfo/src/test/resources/CombinedCLITest.xml
+++ b/backend/src/src-licenseinfo/src/test/resources/CombinedCLITest.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  -->
 <CombinedCLI component="InternalComponent 1.0" creator="Creative Employee" date="15.03.2017" baseDoc="-" componentID="1111">
     <License type="global" name="License1" subtype="global" srcFile="some_cli_file.xml" srcComponent="1234">
         <Content><![CDATA[License1Text

--- a/backend/src/src-search/src/main/java/org/eclipse/sw360/search/Sw360usersDatabaseSearchHandler.java
+++ b/backend/src/src-search/src/main/java/org/eclipse/sw360/search/Sw360usersDatabaseSearchHandler.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.sw360.search;
 
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;

--- a/backend/src/src-search/src/main/java/org/eclipse/sw360/search/db/Sw360dbDatabaseSearchHandler.java
+++ b/backend/src/src-search/src/main/java/org/eclipse/sw360/search/db/Sw360dbDatabaseSearchHandler.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.sw360.search.db;
 
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;

--- a/backend/src/src-users/src/test/java/org/eclipse/sw360/users/UserHandlerTest.java
+++ b/backend/src/src-users/src/test/java/org/eclipse/sw360/users/UserHandlerTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.sw360.users;
 
 import org.eclipse.sw360.datahandler.TestUtils;

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/liferay-display.xml
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/liferay-display.xml
@@ -3,10 +3,10 @@
   ~ Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
   ~ With modifications by Bosch Software Innovations GmbH, 2016.
   ~
-  ~ Copying and distribution of this file, with or without modification,
-  ~ are permitted in any medium without royalty provided the copyright
-  ~ notice and this notice are preserved.  This file is offered as-is,
-  ~ without any warranty.
+  ~ All rights reserved. This configuration file is provided to you under the
+  ~ terms and conditions of the Eclipse Distribution License v1.0 which
+  ~ accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/org/documents/edl-v10.php
   -->
 <!DOCTYPE display PUBLIC "-//Liferay//DTD Display 6.2.0//EN" "http://www.liferay.com/dtd/liferay-display_6_2_0.dtd">
 

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editExternalIds.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editExternalIds.jsp
@@ -1,3 +1,13 @@
+<%--
+  ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+--%>
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.components.Release" %>
 

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/logError.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/logError.jspf
@@ -1,3 +1,13 @@
+<%--
+  ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+--%>
 <%@ page import="org.apache.log4j.Logger" %>
 <%Logger log = Logger.getLogger(getClass());%>
 

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/TestUserCacheHolder.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/TestUserCacheHolder.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.sw360.portal;
 
 import org.eclipse.sw360.datahandler.thrift.users.User;

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtilsTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtilsTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.sw360.portal.portlets.projects;
 
 import com.google.common.collect.ImmutableMap;

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/WrappedException.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/WrappedException.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.sw360.datahandler.common;
 
 import org.apache.thrift.TException;


### PR DESCRIPTION
This adds a simple script `.travis/testForLicenseHeaders.sh` which checks with a very simple heuristic whether all files contain a license header.