### PR TITLE
feat(couchdb): support for linked documents in couchdb

### DIFF
--- a/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/LinkedDocumentLoadingTest.java
+++ b/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/LinkedDocumentLoadingTest.java
@@ -1,0 +1,127 @@
+package org.eclipse.sw360.datahandler.db;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.sw360.datahandler.TestUtils;
+import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
+import org.eclipse.sw360.datahandler.couchdb.DatabaseMixIn;
+import org.eclipse.sw360.datahandler.couchdb.MapperFactory;
+import org.eclipse.sw360.datahandler.couchdb.annotation.LinkedDocuments;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.eclipse.sw360.datahandler.TestUtils.assertTestString;
+
+public class LinkedDocumentLoadingTest {
+
+    private static final String dbName = DatabaseSettings.COUCH_DB_DATABASE;
+
+    private ComponentRepository componentRepository;
+    private ReleaseRepository releaseRepository;
+    private VendorRepository vendorRepository;
+
+    @Before
+    public void setUp() throws Exception {
+        assertTestString(dbName);
+        // assertTestString(attachmentsDbName);
+
+        TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+
+        // Prepare the database
+        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), dbName,
+                new TestMapperFactory());
+
+        vendorRepository = new VendorRepository(databaseConnector);
+        releaseRepository = new ReleaseRepository(databaseConnector, vendorRepository);
+        componentRepository = new ComponentRepository(databaseConnector, releaseRepository, vendorRepository);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Delete the database
+        TestUtils.deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+    }
+
+    @Test
+    public void testReleaseResolvingForOneComponent() {
+        Release release1 = new Release("r1", "1.0", "c1").setId("r1");
+        releaseRepository.add(release1);
+
+        Release release2 = new Release("r2", "2.0", "c1").setId("r2");
+        releaseRepository.add(release2);
+
+        Component component = new Component("Component 1").setId("c1");
+        component.addToReleaseIds("r1");
+        component.addToReleaseIds("r2");
+        componentRepository.add(component);
+
+        // check that releases are not resolved by default
+        component = componentRepository.get("c1");
+        Assert.assertNotNull(component);
+        Assert.assertThat(component.getReleaseIds(), Matchers.containsInAnyOrder("r1", "r2"));
+        Assert.assertNull(component.getReleases());
+
+        // check that releases are resolved with special method
+        component = componentRepository.getWithReleases("c1");
+        Assert.assertNotNull(component);
+        Assert.assertThat(component.getReleaseIds(), Matchers.containsInAnyOrder("r1", "r2"));
+        Assert.assertThat(component.getReleases(), Matchers.containsInAnyOrder(release1, release2));
+    }
+
+    @Test
+    public void testReleaseResolvingForMoreComponents() {
+        Release release1 = new Release("r1", "1.0", "c1").setId("r1");
+        releaseRepository.add(release1);
+
+        Release release2 = new Release("r2", "2.0", "c1").setId("r2");
+        releaseRepository.add(release2);
+
+        Release release3 = new Release("r3", "2.0", "c3").setId("r3");
+        releaseRepository.add(release3);
+
+        Component component1 = new Component("Component 1").setId("c1");
+        component1.addToReleaseIds("r1");
+        component1.addToReleaseIds("r2");
+        componentRepository.add(component1);
+
+        Component component2 = new Component("Component 2").setId("c2");
+        component2.addToReleaseIds("r2");
+        component2.addToReleaseIds("r3");
+        componentRepository.add(component2);
+
+        // check that releases are resolved with special method
+        List<Component> components = componentRepository.getWithReleases();
+        for (Component component : components) {
+            if (component.getId().equals("c1")) {
+                Assert.assertThat(component.getReleaseIds(), Matchers.containsInAnyOrder("r1", "r2"));
+                Assert.assertThat(component.getReleases(), Matchers.containsInAnyOrder(release1, release2));
+            }
+            if (component.getId().equals("c2")) {
+                Assert.assertThat(component.getReleaseIds(), Matchers.containsInAnyOrder("r2", "r3"));
+                Assert.assertThat(component.getReleases(), Matchers.containsInAnyOrder(release2, release3));
+            }
+        }
+    }
+
+    private static class TestMapperFactory extends MapperFactory {
+        @Override
+        public ObjectMapper createObjectMapper() {
+            ObjectMapper objectMapper = super.createObjectMapper();
+            objectMapper.addMixInAnnotations(Component.class, ComponentMixin.class);
+            return objectMapper;
+        }
+    }
+
+    private abstract static class ComponentMixin extends DatabaseMixIn {
+        @LinkedDocuments(targetField = "releases")
+        private Set<String> releaseIds;
+    }
+}

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/WrappedException.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/WrappedException.java
@@ -11,7 +11,7 @@ import org.eclipse.sw360.datahandler.thrift.SW360Exception;
  *
  * <pre>
  * try {
- *     x.stream.filter(element -> wrap(() -> element.test())).collect(Collectors.toList());
+ *     x.stream.filter(element -> wrapException(() -> element.test())).collect(Collectors.toList());
  * } catch (WrappedException e) {
  *     // e.getCause() contains original exception
  * }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseMixIn.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseMixIn.java
@@ -27,7 +27,7 @@ import static org.eclipse.sw360.datahandler.common.SW360Constants.KEY_REV;
 // Always put _id and _rev upfront. Not required, but serialized objects then look nicer.
 @JsonIgnoreProperties({"optionals", "_attachments"})
 @SuppressWarnings("unused")
-public class DatabaseMixIn {
+public abstract class DatabaseMixIn {
 
     @JsonProperty("issetBitfield")
     private byte __isset_bitfield = 0;
@@ -37,23 +37,14 @@ public class DatabaseMixIn {
      */
 
     @JsonProperty(KEY_ID)
-    public String getId() {
-        return null;
-    }
+    public abstract String getId();
 
     @JsonProperty(KEY_ID)
-    public void setId(String id) {
-        // No implementation necessary
-    }
+    public abstract void setId(String id);
 
     @JsonProperty(KEY_REV)
-    public String getRevision() {
-        return null;
-    }
+    public abstract String getRevision();
 
     @JsonProperty(KEY_REV)
-    public void setRevision(String revision) {
-        // No implementation necessary
-    }
-
+    public abstract void setRevision(String revision);
 }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseRepository.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseRepository.java
@@ -35,6 +35,10 @@ public class DatabaseRepository<T> extends CouchDbRepositorySupport<T> {
         return connector;
     }
 
+    protected Class<T> getType() {
+        return type;
+    }
+
     public static Set<String> getIds(ViewResult rows) {
         HashSet<String> ids = new HashSet<>();
 

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/LinkedDocumentViewResponseHandler.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/LinkedDocumentViewResponseHandler.java
@@ -1,0 +1,197 @@
+package org.eclipse.sw360.datahandler.couchdb;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.AnnotatedField;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.type.SimpleType;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.eclipse.sw360.datahandler.couchdb.annotation.LinkedDocument;
+import org.eclipse.sw360.datahandler.couchdb.annotation.LinkedDocuments;
+import org.ektorp.DbAccessException;
+import org.ektorp.ViewResultException;
+import org.ektorp.http.HttpResponse;
+import org.ektorp.http.StdResponseHandler;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This response handler is able to parse views that were created to load linked
+ * documents. Such views contains as key always the main document id. However
+ * the document itself can be of the main type or of type of a linked document.
+ *
+ * This handler will parse all rows and remember each document and its id.
+ * Afterwards all main documents are traversed and ids are resolved to the
+ * Remembered documents.
+ *
+ * The resulting json is then parsed by the object mapper which will generate
+ * the correct types for each node.
+ *
+ * Fields that contain ids to linked documents must be annotated with
+ * {@link LinkedDocuments} or {@link LinkedDocument}.
+ */
+public class LinkedDocumentViewResponseHandler<T> extends StdResponseHandler<List<T>> {
+    private static final String ROWS_FIELD_NAME = "rows";
+
+    private final Class<T> mainType;
+    private final String mainTypeName;
+    private final ObjectMapper objectMapper;
+
+    @JsonAutoDetect(fieldVisibility = Visibility.ANY)
+    private static class Row {
+        @SuppressWarnings("unused")
+        private String id;
+        private JsonNode key;
+        @SuppressWarnings("unused")
+        private JsonNode value;
+        private JsonNode doc;
+        private String error;
+    }
+
+    public LinkedDocumentViewResponseHandler(Class<T> mainType, String mainTypeName, ObjectMapper objectMapper) {
+        this.mainType = mainType;
+        this.mainTypeName = mainTypeName;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<T> success(HttpResponse response) throws Exception {
+        JsonParser parser = objectMapper.getFactory().createParser(response.getContent());
+
+        try {
+            return parseResult(parser);
+        } finally {
+            parser.close();
+        }
+    }
+
+    private List<T> parseResult(JsonParser parser) throws IOException {
+        if (parser.nextToken() != JsonToken.START_OBJECT) {
+            throw new DbAccessException("Expected data to start with an Object");
+        }
+
+        while (parser.nextValue() != JsonToken.END_OBJECT) {
+            String currentName = parser.getCurrentName();
+            if (ROWS_FIELD_NAME.equals(currentName)) {
+                return parseRows(parser);
+            }
+        }
+
+        throw new DbAccessException("No rows found!");
+    }
+
+    private List<T> parseRows(JsonParser parser) throws IOException {
+        Set<Row> mainRows = Sets.newHashSet();
+        Map<String, JsonNode> objects = Maps.newHashMap();
+
+        if (parser.getCurrentToken() != JsonToken.START_ARRAY) {
+            throw new DbAccessException("Expected rows to start with an Array");
+        }
+
+        // parse rows and remember objects and there id. Also remember main objects
+        while (parser.nextToken() == JsonToken.START_OBJECT) {
+            Row row = parser.readValueAs(Row.class);
+            if (row.doc == null) {
+                throw new ViewResultException(row.key, "Document not set in row.");
+            }
+            if (row.error != null) {
+                throw new ViewResultException(row.key, row.error);
+            }
+
+            String objectId = row.doc.path("_id").asText();
+            if (objectId == null) {
+                throw new ViewResultException(row.doc, "Document does not specify an id (_id)");
+            }
+            objects.put(objectId, row.doc);
+
+            String type = row.doc.path("type").asText();
+            if (mainTypeName.equals(type)) {
+                mainRows.add(row);
+            }
+        }
+
+        // now resolve linked document fields in the main objects
+        List<T> results = Lists.newArrayList();
+        for (Row row : mainRows) {
+            try {
+                replaceIdsWithObjects(row.doc, objects);
+                results.add(objectMapper.readValue(row.doc.traverse(parser.getCodec()), mainType));
+            } catch (Exception exception) {
+                throw new ViewResultException(row.doc, exception.getMessage());
+            }
+        }
+        return results;
+    }
+
+    private void replaceIdsWithObjects(JsonNode document, Map<String, JsonNode> objects) {
+        // we only have to respect annotated fields
+        for (AnnotatedField field : objectMapper.getDeserializationConfig().introspect(SimpleType.construct(mainType)).getClassInfo().fields()) {
+            if (field.hasAnnotation(LinkedDocuments.class)) {
+                /*
+                 *  support of arrays in the form of
+                 *      - [ { _id: "<id>", ... } ]
+                 *      - [ "<id>", ... ]
+                 */
+
+                JsonNode nodeToFill = document.path(field.getName());
+                if (nodeToFill.isMissingNode()) {
+                    throw new ViewResultException(document, "Field not found: " + field.getName());
+                }
+
+                if (!nodeToFill.isArray()) {
+                    throw new ViewResultException(nodeToFill, "Field is not an array!");
+                }
+
+                ArrayNode nodeWithIds;
+                String targetField = field.getAnnotation(LinkedDocuments.class).targetField();
+                if (targetField != null) {
+                    // we want to write the resolved objects into another field
+                    // the original field will remain untouched
+                    nodeWithIds = (ArrayNode) nodeToFill;
+                    nodeToFill = JsonNodeFactory.instance.arrayNode();
+                    ((ObjectNode) document).put(targetField, nodeToFill);
+                } else {
+                    nodeWithIds = (ArrayNode) nodeToFill.deepCopy();
+                    ((ArrayNode) nodeToFill).removeAll();
+                }
+
+                for (JsonNode node : nodeWithIds) {
+                    ((ArrayNode) nodeToFill).add(mapToObject(node, objects));
+                }
+            } else if (field.hasAnnotation(LinkedDocument.class)) {
+                /*
+                 *  support of fields in the form of
+                 *      - { linkedId: { _id: "<id>" } }
+                 *      - { linkedId: "<id>" }
+                 */
+                JsonNode node = document.path(field.getName());
+                if (node.isMissingNode()) {
+                    throw new ViewResultException(document, "Field not found: " + field.getName());
+                }
+
+                ((ObjectNode) document).put(field.getName(), mapToObject(node, objects));
+            }
+        }
+    }
+
+    private JsonNode mapToObject(JsonNode node, Map<String, JsonNode> objects) {
+        if (node.isTextual()) {
+            return objects.get(node.asText());
+        } else if (node.isObject()) {
+            return objects.get(node.path("_id").asText());
+        } else {
+            throw new ViewResultException(node, "Neither object nor string node.");
+        }
+    }
+}

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/annotation/LinkedDocument.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/annotation/LinkedDocument.java
@@ -1,0 +1,16 @@
+package org.eclipse.sw360.datahandler.couchdb.annotation;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Used to mark fields that only contain an id but should be expanded to a full
+ * object.
+ */
+@JacksonAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LinkedDocument {
+
+}

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/annotation/LinkedDocuments.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/annotation/LinkedDocuments.java
@@ -1,0 +1,38 @@
+package org.eclipse.sw360.datahandler.couchdb.annotation;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to mark fields that only contain ids but should be expanded to full
+ * objects.
+ */
+@JacksonAnnotation
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LinkedDocuments {
+
+    /**
+     * Can be used to control where to write the resolved objects to. By default the
+     * annotated filed is replaced with the resolved object.
+     *
+     * <h4>Example</h4>
+     *
+     * <pre>
+     *    {
+     *       ids: [ ...],
+     *       objects: []
+     *    }
+     * </pre>
+     *
+     * If such a json is parsed and the field "id" is annotated with
+     * <code>&#64;LinkedDocuments(targetField = "objects")</code>, the "ids"-field
+     * will remain untouched and the "objects"-field will be filled with the
+     * resolved objects.
+     */
+    public String targetField();
+}


### PR DESCRIPTION
This commit adds a method to the database connector which allows the retrieval of linked documents
from couchdb as described in http://docs.couchdb.org/en/2.1.0/ddocs/views/joins.html.

Read the documentation for the annotations LinkedDocument and LinkedDocuments as well as the
test cases in LinkedDocumentLoadingTest for more information about how it works.

Another source might be https://github.com/sw360/sw360portal/wiki/External-documents-with-CouchDB