### PR TITLE
feat(licenseinfo): clean license texts in license info generation

### DIFF
--- a/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
+++ b/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
@@ -90,7 +90,7 @@ Open Source Software Licenses
 #foreach($license in $allLicenseNamesWithTexts)
 #set($licenseName = "<no license name available>")
 #if($license.licenseName)
-#set($licenseName = $esc.xml($license.licenseName))
+#set($licenseName = $license.licenseName)
 #end## if($license.licenseName)
 ##
 #set($licenseText = "<no license text available>")


### PR DESCRIPTION
tiny modification to the velocity template for plain text generation.
Removed xml-escaping.