### PR TITLE
feat(vulnerability): Limit the size of the related vulnerability tables

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -57,7 +57,6 @@ import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
 import static org.eclipse.sw360.datahandler.common.SW360Assert.fail;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import static org.eclipse.sw360.datahandler.thrift.ThriftUtils.copyFields;
-import static org.eclipse.sw360.datahandler.thrift.ThriftUtils.immutableOfComponent;
 import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.ensureEccInformationIsSet;
 import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.prepareComponents;
 import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.prepareReleases;
@@ -402,7 +401,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 component.setReleaseIds(actual.getReleaseIds());
             component.unsetReleases();
 
-            copyFields(actual, component, immutableOfComponent());
+            copyFields(actual, component, ThriftUtils.IMMUTABLE_OF_COMPONENT);
             component.setAttachments( getAllAttachmentsToKeep(actual.getAttachments(), component.getAttachments()) );
             // Update the database with the component
             componentRepository.update(component);
@@ -557,7 +556,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         try {
             Release release = getRelease(releaseAdditions.getId(), user);
             release = releaseModerator.updateReleaseFromModerationRequest(release, releaseAdditions, releaseDeletions);
-            return updateRelease(release, user, ThriftUtils.immutableOfRelease());
+            return updateRelease(release, user, ThriftUtils.IMMUTABLE_OF_RELEASE);
         } catch (SW360Exception e) {
             log.error("Could not get original release when updating from moderation request.");
             return RequestStatus.FAILURE;

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -263,7 +263,7 @@ public class ComponentHandler implements ComponentService.Iface {
         assertId(release.getId());
         assertUser(user);
 
-        return handler.updateRelease(release, user, ThriftUtils.immutableOfRelease());
+        return handler.updateRelease(release, user, ThriftUtils.IMMUTABLE_OF_RELEASE);
     }
 
     @Override
@@ -272,7 +272,7 @@ public class ComponentHandler implements ComponentService.Iface {
         assertId(release.getId());
         assertUser(user);
 
-        return handler.updateRelease(release, user, ThriftUtils.immutableOfReleaseForFossology());
+        return handler.updateRelease(release, user, ThriftUtils.IMMUTABLE_OF_RELEASE_FOR_FOSSOLOGY);
     }
 
     @Override

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -247,16 +247,16 @@ public class ComponentDatabaseHandlerTest {
     @Test
     public void testGetRecentComponents() throws Exception {
         List<Component> recentComponents = handler.getRecentComponentsSummary(5, user1);
-        Iterable<String> componentIds = getComponentIds(recentComponents);
-        assertThat(componentIds, contains("C3", "C2", "C1"));
+        Set<String> componentIds = getComponentIds(recentComponents);
+        assertThat(componentIds, containsInAnyOrder("C3", "C2", "C1"));
     }
 
     @Test
     public void testGetRecentComponents2() throws Exception {
         List<Component> recentComponents = handler.getRecentComponentsSummary(2, user1);
-        Iterable<String> componentIds = getComponentIds(recentComponents);
+        Set<String> componentIds = getComponentIds(recentComponents);
         assertEquals(2, recentComponents.size());
-        assertThat(componentIds, contains("C3", "C2"));
+        assertThat(componentIds, containsInAnyOrder("C3", "C2"));
     }
 
     @Test
@@ -343,21 +343,21 @@ public class ComponentDatabaseHandlerTest {
                                                        "R2A", ReleaseRelationship.REFERRED
             ));
 
-        handler.updateRelease(r1A, user1, ThriftUtils.immutableOfRelease());
+        handler.updateRelease(r1A, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
 
         final Release r1B = handler.getRelease("R1B", user2);
         r1B.setReleaseIdToRelationship(ImmutableMap.of("R2A", ReleaseRelationship.REFERRED));
-        handler.updateRelease(r1B,user2, ThriftUtils.immutableOfRelease());
+        handler.updateRelease(r1B,user2, ThriftUtils.IMMUTABLE_OF_RELEASE);
 
         final Release r2A = handler.getRelease("R2A", user1);
         r2A.setReleaseIdToRelationship(ImmutableMap.of("R2B", ReleaseRelationship.CONTAINED));
-        handler.updateRelease(r2A, user1, ThriftUtils.immutableOfRelease());
+        handler.updateRelease(r2A, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
 
         final Release r2B = handler.getRelease("R2B", user2);
         r2B.setReleaseIdToRelationship(ImmutableMap.of("R1B", ReleaseRelationship.CONTAINED,
                 "R1A", ReleaseRelationship.REFERRED));
 
-        handler.updateRelease(r2B, user2, ThriftUtils.immutableOfRelease());
+        handler.updateRelease(r2B, user2, ThriftUtils.IMMUTABLE_OF_RELEASE);
 
         // we wrap the potentially infinite loop in an executor
         final ExecutorService service = Executors.newSingleThreadExecutor();
@@ -403,14 +403,14 @@ public class ComponentDatabaseHandlerTest {
                 "R2A", ReleaseRelationship.REFERRED
         ));
 
-        handler.updateRelease(r1A, user1, ThriftUtils.immutableOfRelease());
+        handler.updateRelease(r1A, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
 
         final Release r1B = handler.getRelease("R1B", user2);
         r1B.setReleaseIdToRelationship(ImmutableMap.of("R2A", ReleaseRelationship.CONTAINED));
-        handler.updateRelease(r1B,user2, ThriftUtils.immutableOfRelease());
+        handler.updateRelease(r1B,user2, ThriftUtils.IMMUTABLE_OF_RELEASE);
 
         final Release r2A = handler.getRelease("R2A", user1);
-        handler.updateRelease(r2A, user1, ThriftUtils.immutableOfRelease());
+        handler.updateRelease(r2A, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
 
         // we wrap the potentially infinite loop in an executor
         final ExecutorService service = Executors.newSingleThreadExecutor();
@@ -813,7 +813,7 @@ public class ComponentDatabaseHandlerTest {
         Release expected = releases.get(1);
         expected.setName("UPDATED");
 
-        RequestStatus status = handler.updateRelease(expected, user2, ThriftUtils.immutableOfRelease());
+        RequestStatus status = handler.updateRelease(expected, user2, ThriftUtils.IMMUTABLE_OF_RELEASE);
         Release actual = handler.getRelease("R1B", user1);
 
         assertEquals(RequestStatus.SUCCESS, status);
@@ -836,7 +836,7 @@ public class ComponentDatabaseHandlerTest {
         release.setName("UPDATED");
 
         when(releaseModerator.updateRelease(release, user1)).thenReturn(RequestStatus.SENT_TO_MODERATOR);
-        RequestStatus status = handler.updateRelease(release, user1, ThriftUtils.immutableOfRelease());
+        RequestStatus status = handler.updateRelease(release, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
         Release actual = handler.getRelease("R1B", user1);
 
         assertEquals(RequestStatus.SENT_TO_MODERATOR, status);
@@ -851,7 +851,7 @@ public class ComponentDatabaseHandlerTest {
         release.getEccInformation().setAL("UPDATED");
 
         when(releaseModerator.updateReleaseEccInfo(release, user1)).thenReturn(RequestStatus.SENT_TO_MODERATOR);
-        RequestStatus status = handler.updateRelease(release, user1, ThriftUtils.immutableOfRelease());
+        RequestStatus status = handler.updateRelease(release, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
         Release actual = handler.getRelease("R1B", user1);
 
         assertEquals(RequestStatus.SENT_TO_MODERATOR, status);
@@ -882,7 +882,7 @@ public class ComponentDatabaseHandlerTest {
     public void testDontDeleteUsedComponent() throws Exception {
         final Release r1A = handler.getRelease("R1A", user1);
         r1A.setReleaseIdToRelationship(ImmutableMap.of("R2A", ReleaseRelationship.CONTAINED));
-        handler.updateRelease(r1A, user1, ThriftUtils.immutableOfRelease());
+        handler.updateRelease(r1A, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
 
         RequestStatus status = handler.deleteComponent("C2", user1);
         assertEquals(RequestStatus.IN_USE, status);
@@ -912,7 +912,7 @@ public class ComponentDatabaseHandlerTest {
 
         final Release r1A = handler.getRelease("R1A", user1);
         r1A.setReleaseIdToRelationship(ImmutableMap.of("R2A", ReleaseRelationship.CONTAINED));
-        handler.updateRelease(r1A, user1, ThriftUtils.immutableOfRelease());
+        handler.updateRelease(r1A, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
 
         RequestStatus status = handler.deleteRelease("R2A", user1);
         assertEquals(RequestStatus.IN_USE, status);

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
@@ -12,6 +12,13 @@
  */
 package org.eclipse.sw360.vulnerabilities;
 
+import com.google.common.base.MoreObjects;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
 import org.eclipse.sw360.datahandler.db.ProjectDatabaseHandler;
@@ -29,16 +36,13 @@ import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.*;
 import org.eclipse.sw360.vulnerabilities.common.VulnerabilityMapper;
 import org.eclipse.sw360.vulnerabilities.db.VulnerabilityDatabaseHandler;
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
-import org.apache.thrift.TException;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyList;
-import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static org.apache.log4j.Logger.getLogger;
 
 /**
@@ -67,7 +71,7 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
             return Collections.emptyList();
         }
 
-        return getVulsByReleaseId(releaseId, user);
+        return getVulsByReleaseId(Collections.singletonList(releaseId), user);
     }
 
     @Override
@@ -80,12 +84,8 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
             return Collections.emptyList();
         }
 
-        List<VulnerabilityDTO> dtos = new ArrayList<>();
-        releases.stream()
-                .map(rel -> getVulsByReleaseId(rel.getId(), user))
-                .forEach(dtos::addAll);
-
-        return dtos;
+        List<String> ids = releases.stream().map(Release::getId).collect(Collectors.toList());
+        return getVulsByReleaseId(ids, user);
     }
 
     @Override
@@ -94,11 +94,7 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
             return Collections.emptyList();
         }
         Set<String> releaseIds = projectDatabaseHandler.getProjectById(projectId, user).getReleaseIdToUsage().keySet();
-
-        return nullToEmptySet(releaseIds).stream()
-                .map(id -> getVulsByReleaseId(id, user))
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+        return getVulsByReleaseId(releaseIds, user);
     }
 
     @Override
@@ -107,7 +103,7 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
             return Collections.emptyList();
         }
 
-        return getVulsByReleaseIdWithoutIncorrect(releaseId, user);
+        return getVulsByReleaseIdWithoutIncorrect(Collections.singletonList(releaseId), user);
     }
 
     @Override
@@ -117,10 +113,8 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
         }
         List<Release> releases = compHandler.getReleasesFromComponentId(componentId, user);
 
-        return nullToEmptyList(releases).stream()
-                .map(rel -> getVulsByReleaseIdWithoutIncorrect(rel.getId(), user))
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+        List<String> ids = releases.stream().map(Release::getId).collect(Collectors.toList());
+        return getVulsByReleaseIdWithoutIncorrect(ids, user);
     }
 
     @Override
@@ -129,54 +123,57 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
             return Collections.emptyList();
         }
         Set<String> releaseIds = projectDatabaseHandler.getProjectById(projectId, user).getReleaseIdToUsage().keySet();
-        if (releaseIds == null || releaseIds.size() == 0) {
-            return Collections.emptyList();
-        }
+        return getVulsByReleaseIdWithoutIncorrect(releaseIds, user);
+    }
 
-        return releaseIds.stream()
-                .flatMap(id -> getVulsByReleaseIdWithoutIncorrect(id, user).stream())
+    private List<VulnerabilityDTO> getVulsByReleaseId(Collection<String> releaseIds, User user) {
+        List<ReleaseVulnerabilityRelation> relations = getReleaseVulnerabilityRelationByReleaseId(releaseIds);
+        return getDtosFromRelations(relations, user);
+    }
+
+    private List<VulnerabilityDTO> getVulsByReleaseIdWithoutIncorrect(Collection<String> releaseIds, User user) {
+        List<ReleaseVulnerabilityRelation> relations = getReleaseVulnerabilityRelationByReleaseId(releaseIds);
+        List<ReleaseVulnerabilityRelation> filteredRelations = relations.stream()
+                .filter(VulnerabilityHandler::releaseVulnerabilityRelationIsNotIncorrect)
                 .collect(Collectors.toList());
+        return getDtosFromRelations(filteredRelations, user);
     }
 
-    private List<VulnerabilityDTO> getVulsByReleaseId(String releaseId, User user) {
-        List<ReleaseVulnerabilityRelation> relations = dbHandler.getRelationsByReleaseIds(Arrays.asList(releaseId));
-        if (relations == null || relations.size() == 0) {
-            return Collections.emptyList();
-        }
-        List<VulnerabilityDTO> resultDtos = new ArrayList<>();
-        for (ReleaseVulnerabilityRelation relation : relations) {
-            resultDtos.add(getDtoFromRelation(relation, releaseId, user));
-        }
-        return resultDtos;
+    private List<ReleaseVulnerabilityRelation> getReleaseVulnerabilityRelationByReleaseId(Collection<String> releaseIds) {
+        List<ReleaseVulnerabilityRelation> relations = dbHandler.getRelationsByReleaseIds(releaseIds);
+        return MoreObjects.firstNonNull(relations, Collections.emptyList());
     }
 
-    private boolean releaseVulnerabilityRelationIsIncorrect(ReleaseVulnerabilityRelation relation) {
+    private static boolean releaseVulnerabilityRelationIsNotIncorrect(ReleaseVulnerabilityRelation relation) {
         if (!relation.isSetVerificationStateInfo()) {
-            return false;
+            return true;
         }
         List<VerificationStateInfo> stateHistory = relation.getVerificationStateInfo();
         VerificationStateInfo currentState = stateHistory.get(stateHistory.size() - 1);
-        return VerificationState.INCORRECT.equals(currentState.getVerificationState());
+        return !VerificationState.INCORRECT.equals(currentState.getVerificationState());
     }
 
-    private List<VulnerabilityDTO> getVulsByReleaseIdWithoutIncorrect(String releaseId, User user) {
-        List<ReleaseVulnerabilityRelation> relations = dbHandler.getRelationsByReleaseIds(Arrays.asList(releaseId));
-        if (relations == null || relations.size() == 0) {
-            return Collections.emptyList();
-        }
-        List<VulnerabilityDTO> resultDtos = new ArrayList<>();
-        for (ReleaseVulnerabilityRelation relation : relations) {
-            if (!releaseVulnerabilityRelationIsIncorrect(relation)) {
-                resultDtos.add(getDtoFromRelation(relation, releaseId, user));
-            }
-        }
-        return resultDtos;
+    private List<VulnerabilityDTO> getDtosFromRelations(List<ReleaseVulnerabilityRelation> relations, User user) {
+        Set<String> vulnerabilityIds = relations.stream()
+                .map(ReleaseVulnerabilityRelation::getVulnerabilityId)
+                .collect(Collectors.toSet());
+
+        List<Vulnerability> vulnerabilities = dbHandler.getByIds(Vulnerability.class, vulnerabilityIds);
+        Map<String, Vulnerability> vulnerabilityMap = vulnerabilities.stream()
+                .collect(Collectors.toMap(Vulnerability::getId, Function.identity()));
+
+        LoadingCache<String, Release> releaseCache = makeReleaseCache(user);
+        LoadingCache<String, Component> componentCache = makeComponentCache(user);
+
+        return relations.stream()
+                .map(relation -> getDtoFromRelation(relation, vulnerabilityMap.get(relation.getVulnerabilityId())))
+                .map(dto -> enrichVulnerabilityDTO(dto, componentCache, releaseCache))
+                .collect(Collectors.toList());
     }
 
-    private VulnerabilityDTO getDtoFromRelation(ReleaseVulnerabilityRelation relation, String releaseId, User user) {
-        Vulnerability vulnerability = dbHandler.getById(Vulnerability.class, relation.getVulnerabilityId());
+    private VulnerabilityDTO getDtoFromRelation(ReleaseVulnerabilityRelation relation, Vulnerability vulnerability) {
         VulnerabilityDTO dto = VulnerabilityMapper.createVulnerabilityDTO(vulnerability);
-        enrichVulnerabilityDTO(dto, releaseId, user);
+        dto.setIntReleaseId(relation.getReleaseId());
         dto.setReleaseVulnerabilityRelation(relation);
         if (relation.isSetMatchedBy()) {
             dto.setMatchedBy(relation.getMatchedBy());
@@ -187,13 +184,10 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
         return dto;
     }
 
-    private void enrichVulnerabilityDTO(VulnerabilityDTO dto, String releaseId, User user) {
-        if (dto == null) {
-            return;
-        }
-        dto.setIntReleaseId(releaseId);
+    private VulnerabilityDTO enrichVulnerabilityDTO(VulnerabilityDTO dto, LoadingCache<String, Component> componentCache, LoadingCache<String, Release> releaseCache) {
+        String releaseId = dto.getIntReleaseId();
         try {
-            Release release = compHandler.getRelease(releaseId, user);
+            Release release = releaseCache.get(releaseId);
             if (release != null) {
                 dto.setIntComponentId(release.getComponentId());
 
@@ -202,7 +196,7 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
                     releaseName = release.getName() + " ";
                     dto.setIntComponentName(release.getName());
                 } else {
-                    Component component = compHandler.getComponent(release.getComponentId(), user);
+                    Component component = componentCache.get(release.getComponentId());
                     if (component != null) {
                         releaseName = component.getName() + " ";
                         dto.setIntComponentName(component.getName());
@@ -210,9 +204,30 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
                 }
                 dto.setIntReleaseName(releaseName + release.getVersion());
             }
-        } catch (SW360Exception e) {
+        } catch (ExecutionException e) {
             log.error(e);
         }
+        return dto;
+    }
+
+    private LoadingCache<String, Release> makeReleaseCache(User user) {
+        return CacheBuilder.newBuilder()
+                .build(new CacheLoader<String, Release>() {
+                    public Release load(String key) throws SW360Exception {
+                        log.error("loading " + key + " release from db.");
+                        return compHandler.getRelease(key, user);
+                    }
+                });
+    }
+
+    private LoadingCache<String, Component> makeComponentCache(User user) {
+        return CacheBuilder.newBuilder()
+                .build(new CacheLoader<String, Component>() {
+                    public Component load(String key) throws SW360Exception {
+                        log.error("loading " + key + " component from db.");
+                        return compHandler.getComponent(key, user);
+                    }
+                });
     }
 
     @Override

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Siemens AG, 2016.
- * Copyright (c) Bosch Software Innovations GmbH 2016.
+ * Copyright (c) Bosch Software Innovations GmbH 2016-2017.
  * Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
@@ -23,10 +23,7 @@ import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
 import org.eclipse.sw360.datahandler.db.ProjectDatabaseHandler;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
-import org.eclipse.sw360.datahandler.thrift.RequestStatus;
-import org.eclipse.sw360.datahandler.thrift.SW360Exception;
-import org.eclipse.sw360.datahandler.thrift.VerificationState;
-import org.eclipse.sw360.datahandler.thrift.VerificationStateInfo;
+import org.eclipse.sw360.datahandler.thrift.*;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
@@ -71,7 +68,7 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
             return Collections.emptyList();
         }
 
-        return getVulsByReleaseId(Collections.singletonList(releaseId), user);
+        return getVulsByReleaseIds(Collections.singletonList(releaseId), user);
     }
 
     @Override
@@ -85,7 +82,7 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
         }
 
         List<String> ids = releases.stream().map(Release::getId).collect(Collectors.toList());
-        return getVulsByReleaseId(ids, user);
+        return getVulsByReleaseIds(ids, user);
     }
 
     @Override
@@ -94,7 +91,7 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
             return Collections.emptyList();
         }
         Set<String> releaseIds = projectDatabaseHandler.getProjectById(projectId, user).getReleaseIdToUsage().keySet();
-        return getVulsByReleaseId(releaseIds, user);
+        return getVulsByReleaseIds(releaseIds, user);
     }
 
     @Override
@@ -103,7 +100,7 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
             return Collections.emptyList();
         }
 
-        return getVulsByReleaseIdWithoutIncorrect(Collections.singletonList(releaseId), user);
+        return getVulsByReleaseIdsWithoutIncorrect(Collections.singletonList(releaseId), user);
     }
 
     @Override
@@ -114,7 +111,7 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
         List<Release> releases = compHandler.getReleasesFromComponentId(componentId, user);
 
         List<String> ids = releases.stream().map(Release::getId).collect(Collectors.toList());
-        return getVulsByReleaseIdWithoutIncorrect(ids, user);
+        return getVulsByReleaseIdsWithoutIncorrect(ids, user);
     }
 
     @Override
@@ -123,23 +120,23 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
             return Collections.emptyList();
         }
         Set<String> releaseIds = projectDatabaseHandler.getProjectById(projectId, user).getReleaseIdToUsage().keySet();
-        return getVulsByReleaseIdWithoutIncorrect(releaseIds, user);
+        return getVulsByReleaseIdsWithoutIncorrect(releaseIds, user);
     }
 
-    private List<VulnerabilityDTO> getVulsByReleaseId(Collection<String> releaseIds, User user) {
-        List<ReleaseVulnerabilityRelation> relations = getReleaseVulnerabilityRelationByReleaseId(releaseIds);
+    private List<VulnerabilityDTO> getVulsByReleaseIds(Collection<String> releaseIds, User user) {
+        List<ReleaseVulnerabilityRelation> relations = getReleaseVulnerabilityRelationByReleaseIds(releaseIds);
         return getDtosFromRelations(relations, user);
     }
 
-    private List<VulnerabilityDTO> getVulsByReleaseIdWithoutIncorrect(Collection<String> releaseIds, User user) {
-        List<ReleaseVulnerabilityRelation> relations = getReleaseVulnerabilityRelationByReleaseId(releaseIds);
+    private List<VulnerabilityDTO> getVulsByReleaseIdsWithoutIncorrect(Collection<String> releaseIds, User user) {
+        List<ReleaseVulnerabilityRelation> relations = getReleaseVulnerabilityRelationByReleaseIds(releaseIds);
         List<ReleaseVulnerabilityRelation> filteredRelations = relations.stream()
                 .filter(VulnerabilityHandler::releaseVulnerabilityRelationIsNotIncorrect)
                 .collect(Collectors.toList());
         return getDtosFromRelations(filteredRelations, user);
     }
 
-    private List<ReleaseVulnerabilityRelation> getReleaseVulnerabilityRelationByReleaseId(Collection<String> releaseIds) {
+    private List<ReleaseVulnerabilityRelation> getReleaseVulnerabilityRelationByReleaseIds(Collection<String> releaseIds) {
         List<ReleaseVulnerabilityRelation> relations = dbHandler.getRelationsByReleaseIds(releaseIds);
         return MoreObjects.firstNonNull(relations, Collections.emptyList());
     }
@@ -159,8 +156,7 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
                 .collect(Collectors.toSet());
 
         List<Vulnerability> vulnerabilities = dbHandler.getByIds(Vulnerability.class, vulnerabilityIds);
-        Map<String, Vulnerability> vulnerabilityMap = vulnerabilities.stream()
-                .collect(Collectors.toMap(Vulnerability::getId, Function.identity()));
+        Map<String, Vulnerability> vulnerabilityMap= ThriftUtils.getIdMap(vulnerabilities);
 
         LoadingCache<String, Release> releaseCache = makeReleaseCache(user);
         LoadingCache<String, Component> componentCache = makeComponentCache(user);

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityDatabaseHandler.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityDatabaseHandler.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.sw360.vulnerabilities.db;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TBase;
@@ -204,6 +205,20 @@ public class VulnerabilityDatabaseHandler {
             return (T) vulRepo.get(id);
         } else if (ReleaseVulnerabilityRelation.class.isAssignableFrom(type)) {
             return (T) relationRepo.get(id);
+        } else {
+            throw new IllegalArgumentException("unknown type " + type.getSimpleName());
+        }
+    }
+
+    public <T extends TBase> List<T> getByIds(Class<T> type, Collection<String> ids) {
+        if (type == null || ids == null) {
+            log.error("type/ids cannot be null " + type + " " + ids);
+            return ImmutableList.of();
+        }
+        if (Vulnerability.class.isAssignableFrom(type)) {
+            return (List<T>) vulRepo.get(ids);
+        } else if (ReleaseVulnerabilityRelation.class.isAssignableFrom(type)) {
+            return (List<T>) relationRepo.get(ids);
         } else {
             throw new IllegalArgumentException("unknown type " + type.getSimpleName());
         }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CommonVulnerabilityPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CommonVulnerabilityPortletUtils.java
@@ -11,13 +11,26 @@
  */
 package org.eclipse.sw360.portal.common;
 
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Ordering;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
 import org.jetbrains.annotations.NotNull;
 
+import javax.portlet.RenderRequest;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.eclipse.sw360.portal.common.PortalConstants.CUSTOM_FIELD_VULNERABILITIES_VIEW_SIZE;
+
 public class CommonVulnerabilityPortletUtils {
+
+    private static final Ordering<VulnerabilityDTO> VULNERABILITY_DTO_ORDERING = Ordering.from(Comparator.comparing(VulnerabilityDTO::getLastExternalUpdate, Comparator.nullsFirst(Comparator.naturalOrder())));
+
     @NotNull
     public static <T> String formatedMessageForVul(List<T> history,
                                                    Function<T,String> valueGetter,
@@ -39,5 +52,23 @@ public class CommonVulnerabilityPortletUtils {
                         "</span></li>"));
         sb.append("</ol>");
         return sb.toString();
+    }
+
+    public static void putLatestVulnerabilitiesInRequest(RenderRequest request, List<VulnerabilityDTO> vuls, User user) {
+        int limit = CustomFieldHelper.loadAndStoreStickyViewSize(request, user, CUSTOM_FIELD_VULNERABILITIES_VIEW_SIZE);
+        List<VulnerabilityDTO> lastestVuls = limit > 0
+                ? VULNERABILITY_DTO_ORDERING.greatestOf(vuls, limit)
+                : VULNERABILITY_DTO_ORDERING.immutableSortedCopy(vuls);
+
+        request.setAttribute(PortalConstants.NUMBER_OF_VULNERABILITIES, vuls.size());
+        request.setAttribute(PortalConstants.VULNERABILITY_LIST, lastestVuls);
+    }
+
+    public static void putMatchedByHistogramInRequest(RenderRequest request, List<VulnerabilityDTO> vuls) {
+        Map<String, Long> matchedByHistogram = vuls.stream()
+                .map(vul -> MoreObjects.firstNonNull(vul.getMatchedBy(), "UNKNOWN"))
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+        request.setAttribute(PortalConstants.VULNERABILITY_MATCHED_BY_HISTOGRAM, matchedByHistogram);
     }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CustomFieldHelper.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CustomFieldHelper.java
@@ -46,7 +46,7 @@ public class CustomFieldHelper {
 
     public static int loadAndStoreStickyViewSize(PortletRequest request, User user, String fieldName) {
         String view_size = request.getParameter(PortalConstants.VIEW_SIZE);
-        final int limit;
+        int limit;
         if (isNullEmptyOrWhitespace(view_size)) {
             limit = CustomFieldHelper
                     .loadField(Integer.class, request, user, fieldName)
@@ -54,6 +54,9 @@ public class CustomFieldHelper {
         } else {
             limit = Integer.parseInt(view_size);
             CustomFieldHelper.saveField(request, user, fieldName, limit);
+        }
+        if (limit == 0) {
+            limit = DEFAULT_VIEW_SIZE;
         }
         request.setAttribute(PortalConstants.VIEW_SIZE, limit);
         return limit;

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CustomFieldHelper.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CustomFieldHelper.java
@@ -35,11 +35,29 @@ import javax.portlet.PortletRequest;
 import java.io.Serializable;
 import java.util.Optional;
 
+import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
 import static org.eclipse.sw360.portal.common.PortalConstants.*;
 
 public class CustomFieldHelper {
 
     private static final Logger log = Logger.getLogger(CustomFieldHelper.class);
+
+    private static final int DEFAULT_VIEW_SIZE = 200;
+
+    public static int loadAndStoreStickyViewSize(PortletRequest request, User user, String fieldName) {
+        String view_size = request.getParameter(PortalConstants.VIEW_SIZE);
+        final int limit;
+        if (isNullEmptyOrWhitespace(view_size)) {
+            limit = CustomFieldHelper
+                    .loadField(Integer.class, request, user, fieldName)
+                    .orElse(DEFAULT_VIEW_SIZE);
+        } else {
+            limit = Integer.parseInt(view_size);
+            CustomFieldHelper.saveField(request, user, fieldName, limit);
+        }
+        request.setAttribute(PortalConstants.VIEW_SIZE, limit);
+        return limit;
+    }
 
     public static <T extends Serializable> void saveField(PortletRequest request, User user, String field, T value) {
         try {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
@@ -317,25 +317,6 @@ public class PortletUtils {
         return responseData;
     }
 
-    private static Map<String, Integer> addToMatchedByHistogram(Map<String, Integer> matchedByHistogram, String matchedBy){
-        if (matchedByHistogram.containsKey(matchedBy)){
-            matchedByHistogram.put(matchedBy, matchedByHistogram.get(matchedBy) + 1);
-        }else{
-            matchedByHistogram.put(matchedBy, 1);
-        }
-        return matchedByHistogram;
-    }
-
-    public static Map<String, Integer> addToMatchedByHistogram(Map<String,Integer> matchedByHistogram, VulnerabilityDTO vul){
-        final String isMatchedByUnknown = "UNKNOWN";
-
-        if (vul.isSetMatchedBy()) {
-            return addToMatchedByHistogram(matchedByHistogram, vul.getMatchedBy());
-        } else {
-            return addToMatchedByHistogram(matchedByHistogram, isMatchedByUnknown);
-        }
-    }
-
     public static VerificationState getVerificationState(VulnerabilityDTO vul){
         if(vul.isSetReleaseVulnerabilityRelation()){
             if(vul.getReleaseVulnerabilityRelation().isSetVerificationStateInfo()){

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortletUtils.java
@@ -41,8 +41,6 @@ import static org.eclipse.sw360.portal.common.PortalConstants.CUSTOM_FIELD_COMPO
  */
 public abstract class ComponentPortletUtils {
 
-    private static final int DEFAULT_VIEW_SIZE = 200;
-
     private ComponentPortletUtils() {
         // Utility class with only static functions
     }
@@ -347,13 +345,5 @@ public abstract class ComponentPortletUtils {
         verificationStateHistory.add(resultInfo);
 
         return dbRelation;
-    }
-
-    static void saveStickyViewSize(PortletRequest request, User user, int viewSize) {
-        CustomFieldHelper.saveField(request, user, CUSTOM_FIELD_COMPONENTS_VIEW_SIZE, viewSize);
-    }
-
-    static int loadStickyViewSize(PortletRequest request, User user) {
-        return CustomFieldHelper.loadField(Integer.class, request, user, CUSTOM_FIELD_COMPONENTS_VIEW_SIZE).orElse(DEFAULT_VIEW_SIZE);
     }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/vulnerabilities/VulnerabilitiesPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/vulnerabilities/VulnerabilitiesPortlet.java
@@ -23,7 +23,6 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityService;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityWithReleaseRelations;
 import org.eclipse.sw360.portal.common.CustomFieldHelper;
-import org.eclipse.sw360.portal.common.PortalConstants;
 import org.eclipse.sw360.portal.common.UsedAsLiferayAction;
 import org.eclipse.sw360.portal.portlets.Sw360Portlet;
 import org.eclipse.sw360.portal.users.UserCacheHolder;
@@ -37,7 +36,6 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
-import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
 import static org.eclipse.sw360.datahandler.common.SW360Utils.printName;
 import static org.eclipse.sw360.portal.common.PortalConstants.*;
 
@@ -102,7 +100,7 @@ public class VulnerabilitiesPortlet extends Sw360Portlet {
 
         try {
             final User user = UserCacheHolder.getUserFromRequest(request);
-            int limit = loadAndStoreStickyViewSize(request, user);
+            int limit = CustomFieldHelper.loadAndStoreStickyViewSize(request, user, CUSTOM_FIELD_VULNERABILITIES_VIEW_SIZE);
 
             VulnerabilityService.Iface vulnerabilityClient = thriftClients.makeVulnerabilityClient();
             if (!isNullOrEmpty(externalId) || !isNullOrEmpty(vulnerableConfig)) {
@@ -194,20 +192,4 @@ public class VulnerabilitiesPortlet extends Sw360Portlet {
         }
         return ImmutableList.of();
     }
-
-    private int loadAndStoreStickyViewSize(PortletRequest request, User user) {
-        String view_size = request.getParameter(PortalConstants.VIEW_SIZE);
-        final int limit;
-        if (isNullEmptyOrWhitespace(view_size)) {
-            limit = CustomFieldHelper
-                    .loadField(Integer.class, request, user, CUSTOM_FIELD_VULNERABILITIES_VIEW_SIZE)
-                    .orElse(DEFAULT_VIEW_SIZE);
-        } else {
-            limit = Integer.parseInt(view_size);
-            CustomFieldHelper.saveField(request, user, CUSTOM_FIELD_VULNERABILITIES_VIEW_SIZE, limit);
-        }
-        request.setAttribute(PortalConstants.VIEW_SIZE, limit);
-        return limit;
-    }
-
 }

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/vulnerabilities.jspf
@@ -1,8 +1,3 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="portlet" uri="http://java.sun.com/portlet_2_0" %>
-<%@ page import="org.eclipse.sw360.datahandler.thrift.RequestStatus" %>
-<%@ page import="org.eclipse.sw360.datahandler.thrift.VerificationState" %>
-<%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%--
   ~ Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
   ~ With modifications from Bosch Software Innovations GmbH, 2016.
@@ -14,6 +9,14 @@
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v10.html
 --%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="portlet" uri="http://java.sun.com/portlet_2_0" %>
+<%@ page import="com.liferay.portlet.PortletURLFactoryUtil" %>
+<%@ page import="javax.portlet.PortletRequest" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.RequestStatus" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.VerificationState" %>
+<%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
+
 <portlet:resourceURL var="updateVulnerabilitiesURL">
     <portlet:param name="<%=PortalConstants.ACTION%>" value="<%=PortalConstants.UPDATE_VULNERABILITIES_COMPONENT%>"/>
 </portlet:resourceURL>
@@ -22,8 +25,21 @@
 </portlet:resourceURL>
 <jsp:useBean id="vulnerabilityVerificationTooltips" type="java.util.Map<java.lang.String, java.util.Map<java.lang.String, java.lang.String>>"
              scope="request"/>
-<jsp:useBean id="vulnerabilityMatchedByHistogram" type="java.util.Map<java.lang.String, java.lang.Integer>" scope="request"/>
+<jsp:useBean id="vulnerabilityMatchedByHistogram" type="java.util.Map<java.lang.String, java.lang.Long>" scope="request"/>
+<jsp:useBean id="vulnerabilityList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO>" scope="request"/>
+<jsp:useBean id="numberOfVulnerabilities" type="java.lang.Integer" scope="request"/>
+<jsp:useBean id="viewSize" type="java.lang.Integer" scope="request"/>
 
+<p>
+    Showing
+    <select class="searchbar" id="view_size" name="<portlet:namespace/><%=PortalConstants.VIEW_SIZE%>" onchange="reloadViewSize()">
+        <option value="200" <core_rt:if test="${viewSize == 200}">selected</core_rt:if>>200 latest</option>
+        <option value="500" <core_rt:if test="${viewSize == 500}">selected</core_rt:if>>500 latest</option>
+        <option value="1000" <core_rt:if test="${viewSize == 1000}">selected</core_rt:if>>1000 latest</option>
+        <option value="-1" <core_rt:if test="${viewSize == -1}">selected</core_rt:if>>All</option>
+    </select>
+    vulnerabilities out of ${numberOfVulnerabilities} in total.
+</p>
 <div id="vulnerabilityTableDiv">
     <table id="vulnerabilityTable" cellpadding="0" cellspacing="0" border="0" class="display">
         <tfoot>
@@ -49,6 +65,15 @@
 </div>
 
 <script type="text/javascript">
+    function reloadViewSize(){
+        var PortletURL = Liferay.PortletURL;
+        var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>');
+        portletURL.setParameter('<%=PortalConstants.PAGENAME%>', '<%=PortalConstants.PAGENAME_DETAIL%>');
+        portletURL.setParameter('<%=PortalConstants.COMPONENT_ID%>', '${component.id}');
+        portletURL.setParameter('<%=PortalConstants.VIEW_SIZE%>', $('#view_size').val());
+        window.location.href=portletURL.toString();
+    }
+
     require(['jquery', 'utils/includes/vulnerabilityModal', /* jquery-plugins */ 'jquery-ui', 'datatables', 'modules/datatables-utils'], function($, vulnerarbilityModal) {
         var vulnerabilityTable;
         var modal;

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/vulnerabilities.jspf
@@ -1,7 +1,3 @@
-<%@ page import="org.eclipse.sw360.portal.common.page.PortletReleasePage" %>
-<%@ page import="org.eclipse.sw360.datahandler.thrift.RequestStatus" %>
-<%@ page import="org.eclipse.sw360.datahandler.thrift.VerificationState" %>
-<%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%--
   ~ Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
   ~ With modifications from Bosch Software Innovations GmbH, 2016.
@@ -13,6 +9,12 @@
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v10.html
 --%>
+<%@ page import="com.liferay.portlet.PortletURLFactoryUtil" %>
+<%@ page import="javax.portlet.PortletRequest" %>
+<%@ page import="org.eclipse.sw360.portal.common.page.PortletReleasePage" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.RequestStatus" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.VerificationState" %>
+<%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 
 <portlet:resourceURL var="updateVulnerabilitiesURL">
     <portlet:param name="<%=PortalConstants.ACTION%>" value="<%=PortalConstants.UPDATE_VULNERABILITIES_RELEASE%>"/>
@@ -25,8 +27,21 @@
              scope="request"/>
 <jsp:useBean id="vulnerabilityVerificationTooltips" type="java.util.Map<java.lang.String, java.lang.String>"
              scope="request"/>
-<jsp:useBean id="vulnerabilityMatchedByHistogram" type="java.util.Map<java.lang.String, java.lang.Integer>" scope="request"/>
+<jsp:useBean id="vulnerabilityMatchedByHistogram" type="java.util.Map<java.lang.String, java.lang.Long>" scope="request"/>
+<jsp:useBean id="vulnerabilityList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO>" scope="request"/>
+<jsp:useBean id="numberOfVulnerabilities" type="java.lang.Integer" scope="request"/>
+<jsp:useBean id="viewSize" type="java.lang.Integer" scope="request"/>
 
+<p>
+    Showing
+    <select class="searchbar" id="view_size" name="<portlet:namespace/><%=PortalConstants.VIEW_SIZE%>" onchange="reloadViewSize()">
+        <option value="200" <core_rt:if test="${viewSize == 200}">selected</core_rt:if>>200 latest</option>
+        <option value="500" <core_rt:if test="${viewSize == 500}">selected</core_rt:if>>500 latest</option>
+        <option value="1000" <core_rt:if test="${viewSize == 1000}">selected</core_rt:if>>1000 latest</option>
+        <option value="-1" <core_rt:if test="${viewSize == -1}">selected</core_rt:if>>All</option>
+    </select>
+    vulnerabilities out of ${numberOfVulnerabilities} in total.
+</p>
 <div id="vulnerabilityTableDiv">
     <table id="vulnerabilityTable" cellpadding="0" cellspacing="0" border="0" class="display">
         <tfoot>
@@ -52,6 +67,16 @@
 </div>
 
 <script type="text/javascript">
+    function reloadViewSize(){
+        var PortletURL = Liferay.PortletURL;
+        var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>');
+        portletURL.setParameter('<%=PortalConstants.PAGENAME%>', '<%=PortalConstants.PAGENAME_RELEASE_DETAIL%>');
+        portletURL.setParameter('<%=PortalConstants.COMPONENT_ID%>', '${component.id}');
+        portletURL.setParameter('<%=PortalConstants.RELEASE_ID%>', '${release.id}');
+        portletURL.setParameter('<%=PortalConstants.VIEW_SIZE%>', $('#view_size').val());
+        window.location.href=portletURL.toString();
+    }
+
     require(['jquery', 'utils/includes/vulnerabilityModal', /* jquery-plugins */ 'jquery-ui', 'datatables', 'modules/datatables-utils'], function($, vulnerarbilityModal) {
         var vulnerabilityTable;
         var modal;

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/vulnerabilities.jspf
@@ -1,8 +1,3 @@
-<%@ page import="org.eclipse.sw360.portal.common.page.PortletReleasePage" %>
-<%@ page import="org.eclipse.sw360.datahandler.thrift.RequestStatus" %>
-<%@ page import="org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability" %>
-<%@ page import="org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityRatingForProject" %>
-<%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%--
   ~ Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
   ~ With modifications from Bosch Software Innovations GmbH, 2016.
@@ -14,22 +9,42 @@
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v10.html
 --%>
+<%@ page import="com.liferay.portlet.PortletURLFactoryUtil" %>
+<%@ page import="javax.portlet.PortletRequest" %>
+<%@ page import="org.eclipse.sw360.portal.common.page.PortletReleasePage" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.RequestStatus" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityRatingForProject" %>
+<%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
+
 <portlet:resourceURL var="updateProjectVulnerabilitiesURL">
     <portlet:param name="<%=PortalConstants.ACTION%>" value="<%=PortalConstants.UPDATE_VULNERABILITIES_PROJECT%>"/>
 </portlet:resourceURL>
 <portlet:resourceURL var="updateVulnerabilityRatings">
     <portlet:param name="<%=PortalConstants.ACTION%>" value="<%=PortalConstants.UPDATE_VULNERABILITY_RATINGS%>"/>
 </portlet:resourceURL>
+<jsp:useBean id="vulnerabilityList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO>" scope="request"/>
 <jsp:useBean id="vulnerabilityRatings" type="java.util.Map<java.lang.String, org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityRatingForProject>" scope="request"/>
 <jsp:useBean id="vulnerabilityRatingsEditable" type="java.lang.Boolean" scope="request"/>
 <jsp:useBean id="vulnerabilityCheckstatusTooltips" type="java.util.Map<java.lang.String, java.lang.String>" scope="request"/>
-<jsp:useBean id="vulnerabilityMatchedByHistogram" type="java.util.Map<java.lang.String, java.lang.Integer>" scope="request"/>
+<jsp:useBean id="vulnerabilityMatchedByHistogram" type="java.util.Map<java.lang.String, java.lang.Long>" scope="request"/>
+<jsp:useBean id="viewSize" type="java.lang.Integer" scope="request"/>
 
 <p>Security Vulnerability Monitoring:
         <span
             <core_rt:if test="${project.enableSvm}">class="notificationBulletInline backgroundOK">enabled</core_rt:if>
             <core_rt:if test="${not project.enableSvm}">class="notificationBulletInline backgroundGrey">disabled</core_rt:if>
         </span>
+</p>
+<p>
+    Showing
+    <select class="searchbar" id="view_size" name="<portlet:namespace/><%=PortalConstants.VIEW_SIZE%>" onchange="reloadViewSize()">
+        <option value="200" <core_rt:if test="${viewSize == 200}">selected</core_rt:if>>200 latest</option>
+        <option value="500" <core_rt:if test="${viewSize == 500}">selected</core_rt:if>>500 latest</option>
+        <option value="1000" <core_rt:if test="${viewSize == 1000}">selected</core_rt:if>>1000 latest</option>
+        <option value="-1" <core_rt:if test="${viewSize == -1}">selected</core_rt:if>>All</option>
+    </select>
+    vulnerabilities out of ${numberOfVulnerabilities} in total.
 </p>
 <div id="vulnerabilityTableDiv">
     <table id="vulnerabilityTable" cellpadding="0" cellspacing="0" border="0" class="display">
@@ -56,6 +71,15 @@
 </div>
 
 <script type="text/javascript">
+    function reloadViewSize(){
+        var PortletURL = Liferay.PortletURL;
+        var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>');
+        portletURL.setParameter('<%=PortalConstants.PAGENAME%>', '<%=PortalConstants.PAGENAME_DETAIL%>');
+        portletURL.setParameter('<%=PortalConstants.PROJECT_ID%>', '${project.id}');
+        portletURL.setParameter('<%=PortalConstants.VIEW_SIZE%>', $('#view_size').val());
+        window.location.href=portletURL.toString();
+    }
+
     require(['jquery', 'utils/includes/vulnerabilityModal', /* jquery-plugins */ 'jquery-ui', 'datatables', 'modules/datatables-utils'], function($, vulnerarbilityModal) {
         var projectVulnerabilityTable;
         var modal;
@@ -106,7 +130,7 @@
             });
             </core_rt:forEach>
 
-            projectVulnerabilityTable = $('#vulnerabilityTable').DataTable({
+            projectVulnerabilityTable = $('#vulnerabilityTable').dataTable({
                 pagingType: "simple_numbers",
                 "data": result,
                 "columns": [

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/usingReleasesTable.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/usingReleasesTable.jspf
@@ -12,11 +12,10 @@
     <table class="table info_table" title="Usage overview">
         <thead>
         <tr>
-            <th colspan="4">${documentName} is present in the following releases</th>
+            <th colspan="3">${documentName} is present in the following releases</th>
         </tr>
         <tr>
-            <th>Release name</th>
-            <th>Version</th>
+            <th>Release</th>
             <th>CPE-ID</th>
             <th>Release date</th>
         </tr>
@@ -24,14 +23,7 @@
         <core_rt:forEach var="release" items="${usingReleases}" varStatus="loop">
             <tr>
                 <td>
-                    <sw360:DisplayComponentLink componentId="${release.componentId}" showName="false">
-                        <sw360:out value="${release.name}"/>
-                    </sw360:DisplayComponentLink>
-                </td>
-                <td>
-                    <a href="<sw360:DisplayReleaseLink releaseId="${release.id}" bare="true" />">
-                        <sw360:out value="${release.version}"/>
-                    </a>
+                    <sw360:DisplayReleaseLink release="${release}" showName="true"/>
                 </td>
                 <td><sw360:out value="${release.cpeid}"/></td>
                 <td><sw360:out value="${release.releaseDate}"/></td>

--- a/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/view.jsp
@@ -22,6 +22,7 @@
 <jsp:useBean id="vulnerabilityList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability>"
              scope="request"/>
 <jsp:useBean id="totalRows" type="java.lang.Integer" scope="request"/>
+<jsp:useBean id="viewSize" type="java.lang.Integer" scope="request"/>
 
 <jsp:useBean id="externalId" class="java.lang.String" scope="request"/>
 <jsp:useBean id="vulnerableConfiguration" class="java.lang.String" scope="request"/>

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.log4j.Logger;
@@ -45,10 +44,8 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
-import static com.google.common.collect.Iterables.transform;
 import static org.apache.log4j.Logger.getLogger;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyMap;
-import static org.eclipse.sw360.datahandler.thrift.ThriftUtils.extractId;
 
 /**
  * @author Cedric.Bodet@tngtech.com
@@ -157,19 +154,15 @@ public class SW360Utils {
     }
 
     public static Set<String> getReleaseIds(Collection<Release> in) {
-        return ImmutableSet.copyOf(getIdsIterable(in));
+        return in.stream().map(Release::getId).collect(Collectors.toSet());
     }
 
     public static Set<String> getComponentIds(Collection<Component> in) {
-        return ImmutableSet.copyOf(getIdsIterable(in));
+        return in.stream().map(Component::getId).collect(Collectors.toSet());
     }
 
     public static Set<String> getProjectIds(Collection<Project> in) {
-        return ImmutableSet.copyOf(getIdsIterable(in));
-    }
-
-    public static <T> Iterable<String> getIdsIterable(Iterable<T> projects) {
-        return transform(projects, extractId());
+        return in.stream().map(Project::getId).collect(Collectors.toSet());
     }
 
     public static String getVersionedName(String name, String version) {

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
@@ -12,7 +12,6 @@
 package org.eclipse.sw360.datahandler.thrift;
 
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -39,6 +38,7 @@ import org.ektorp.util.Documents;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Utility class to supplement the Thrift generated code
@@ -81,6 +81,23 @@ public class ThriftUtils {
             AttachmentContent.class, AttachmentContentWrapper.class
     );
 
+    public static final ImmutableList<Component._Fields> IMMUTABLE_OF_COMPONENT = ImmutableList.of(
+            Component._Fields.CREATED_BY,
+            Component._Fields.CREATED_ON);
+
+    public static final ImmutableList<Release._Fields> IMMUTABLE_OF_RELEASE = ImmutableList.of(
+            Release._Fields.CREATED_BY,
+            Release._Fields.CREATED_ON,
+            Release._Fields.FOSSOLOGY_ID,
+            Release._Fields.ATTACHMENT_IN_FOSSOLOGY,
+            Release._Fields.CLEARING_TEAM_TO_FOSSOLOGY_STATUS);
+
+
+    public static final ImmutableList<Release._Fields> IMMUTABLE_OF_RELEASE_FOR_FOSSOLOGY = ImmutableList.of(
+            Release._Fields.CREATED_BY,
+            Release._Fields.CREATED_ON);
+
+
     private ThriftUtils() {
         // Utility class with only static functions
     }
@@ -116,17 +133,8 @@ public class ThriftUtils {
         }
     }
 
-    public static Function<Object, String> extractId() {
-        return new Function<Object, String>() {
-            @Override
-            public String apply(Object input) {
-                return Documents.getId(input);
-            }
-        };
-    }
-
     public static <T> Map<String, T> getIdMap(Collection<T> in) {
-        return Maps.uniqueIndex(in, extractId());
+        return Maps.uniqueIndex(in, Documents::getId);
     }
 
     public static <T extends TBase<T, F>, F extends TFieldIdEnum> Function<T, Object> extractField(final F field) {
@@ -134,47 +142,18 @@ public class ThriftUtils {
     }
 
     public static <T extends TBase<T, F>, F extends TFieldIdEnum, R> Function<T, R> extractField(final F field, final Class<R> clazz) {
-        return new Function<T, R>() {
-            @Override
-            public R apply(T input) {
-                if (input.isSet(field)) {
-                    Object fieldValue = input.getFieldValue(field);
-                    if (clazz.isInstance(fieldValue)) {
-                        @SuppressWarnings("unchecked")
-                        R value = (R) fieldValue;
-                        return value;
-                    } else {
-                        log.error("field " + field + " of " + input + " cannot be cast to" + clazz.getSimpleName());
-                        return null;
-                    }
+        return input -> {
+            if (input.isSet(field)) {
+                Object fieldValue = input.getFieldValue(field);
+                if (clazz.isInstance(fieldValue)) {
+                    return clazz.cast(fieldValue);
                 } else {
+                    log.error("field " + field + " of " + input + " cannot be cast to" + clazz.getSimpleName());
                     return null;
                 }
+            } else {
+                return null;
             }
         };
-    }
-
-    public static Iterable<Component._Fields> immutableOfComponent() {
-        return ImmutableList.of(
-                Component._Fields.CREATED_BY,
-                Component._Fields.CREATED_ON
-        );
-    }
-
-    public static Iterable<Release._Fields> immutableOfRelease() {
-        return ImmutableList.of(
-                Release._Fields.CREATED_BY,
-                Release._Fields.CREATED_ON,
-                Release._Fields.FOSSOLOGY_ID,
-                Release._Fields.ATTACHMENT_IN_FOSSOLOGY,
-                Release._Fields.CLEARING_TEAM_TO_FOSSOLOGY_STATUS
-        );
-    }
-
-    public static Iterable<Release._Fields> immutableOfReleaseForFossology() {
-        return ImmutableList.of(
-                Release._Fields.CREATED_BY,
-                Release._Fields.CREATED_ON
-        );
     }
 }

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/thrift/ThriftUtilsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/thrift/ThriftUtilsTest.java
@@ -10,14 +10,14 @@
  */
 package org.eclipse.sw360.datahandler.thrift;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -53,7 +53,7 @@ public class ThriftUtilsTest {
         List<Attachment> input = ImmutableList.of(getAttachment(contentId), getAttachment(contentId1));
         List<String> expected = ImmutableList.of(contentId, contentId1);
 
-        assertThat(Lists.transform(input, stringIdExtractor), is(expected));
+        assertThat(input.stream().map(stringIdExtractor).collect(Collectors.toList()), is(expected));
     }
 
     private static Attachment getAttachment(String contentId) {


### PR DESCRIPTION
Limit the size of the related vulnerability tables (in the UI) for project/component/release
* Allow for choose the size of tables of related vulnerabilities
* limit db requests to vulnerabilities
* limit db requests to component and releases
* Also fixes https://github.com/sw360/sw360portal/issues/657