### PR TITLE
fix(projects): duplicating project does not copy linked projects

### DIFF
--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -246,7 +246,7 @@ public class SW360Utils {
     }
 
     public static Collection<ProjectLink> getLinkedProjects(Project project, boolean deep, ThriftClients thriftClients, Logger log, User user) {
-        if (project != null && project.isSetId()) {
+        if (project != null) {
             try {
                 ProjectService.Iface client = thriftClients.makeProjectClient();
                 List<ProjectLink> linkedProjects = client.getLinkedProjectsOfProject(project, deep, user);


### PR DESCRIPTION
Duplicating a project makes a deep copy of the original, including linked projects and releases, but then for displaying project edit page, linked projects are searched in backend. SW360Utils, however, refused to search for linked projects of a project that has no id and the backend wasn't capable of returning them.

- relaxed the check of project in SW360Utils
- made ProjectDatabaseHandler capable of returning linked projects of a new project (without id yet)
- added some tests to prevent regressions

closes sw360/sw360portal#673