### PR TITLE
feat(bdpImport): Use of proper error message when importing projects

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
@@ -307,9 +307,9 @@ public class PortletUtils {
         JSONArray jsonNewIds = JSONFactoryUtil.createJSONArray();
         JSONArray jsonUpdatedIds = JSONFactoryUtil.createJSONArray();
 
-        updateStatus.getStatusToVulnerabilityIds().get(UpdateType.FAILED).forEach(id -> jsonFailedIds.put(id));
-        updateStatus.getStatusToVulnerabilityIds().get(UpdateType.NEW).forEach(id -> jsonNewIds.put(id));
-        updateStatus.getStatusToVulnerabilityIds().get(UpdateType.UPDATED).forEach(id -> jsonUpdatedIds.put(id));
+        updateStatus.getStatusToVulnerabilityIds().get(UpdateType.FAILED).forEach(jsonFailedIds::put);
+        updateStatus.getStatusToVulnerabilityIds().get(UpdateType.NEW).forEach(jsonNewIds::put);
+        updateStatus.getStatusToVulnerabilityIds().get(UpdateType.UPDATED).forEach(jsonUpdatedIds::put);
 
         responseData.put(PortalConstants.UPDATE_VULNERABILITIES__FAILED_IDS, jsonFailedIds);
         responseData.put(PortalConstants.UPDATE_VULNERABILITIES__NEW_IDS, jsonNewIds);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projectimport/ProjectImportPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projectimport/ProjectImportPortlet.java
@@ -224,8 +224,9 @@ public class ProjectImportPortlet extends Sw360Portlet {
 
     private void importBdpProjects(User user, List<String> selectedIds, JSONObject responseData, RemoteCredentials remoteCredentials) throws PortletException, IOException {
         ImportStatus importStatus = importDatasources(selectedIds, user, remoteCredentials);
-        JSONArray jsonFailedIds = JSONFactoryUtil.createJSONArray();
+        JSONObject jsonFailedIds = JSONFactoryUtil.createJSONObject();
         JSONArray jsonSuccessfulIds = JSONFactoryUtil.createJSONArray();
+
         if (importStatus.isSetRequestStatus() && importStatus.getRequestStatus().equals(RequestStatus.SUCCESS)) {
             importStatus.getFailedIds().forEach(jsonFailedIds::put);
             importStatus.getSuccessfulIds().forEach(jsonSuccessfulIds::put);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projectimport/ProjectImportPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projectimport/ProjectImportPortlet.java
@@ -19,9 +19,9 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.projectimport.ProjectImportService;
+import org.eclipse.sw360.datahandler.thrift.projectimport.RemoteCredentials;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
-import org.eclipse.sw360.datahandler.thrift.bdpimport.BdpImportService;
-import org.eclipse.sw360.datahandler.thrift.bdpimport.RemoteCredentials;
 import org.eclipse.sw360.datahandler.thrift.importstatus.ImportStatus;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.portal.portlets.Sw360Portlet;
@@ -43,7 +43,7 @@ import static com.google.common.base.Strings.nullToEmpty;
  */
 public class ProjectImportPortlet extends Sw360Portlet {
     private static final Logger log = Logger.getLogger(ProjectImportPortlet.class);
-    private static BdpImportService.Iface bdpImportClient = new ThriftClients().makeBdpImportClient();
+    private static ProjectImportService.Iface projectImportClient = new ThriftClients().makeProjectImportClient();
 
     static class LoginState {
         private Boolean loggedIn;
@@ -132,7 +132,7 @@ public class ProjectImportPortlet extends Sw360Portlet {
     private ImportStatus importDatasources(List<String> toImport, User user, RemoteCredentials remoteCredentials) {
         ImportStatus importStatus = new ImportStatus();
         try {
-            importStatus = bdpImportClient.importDatasources(toImport, user, remoteCredentials);
+            importStatus = projectImportClient.importDatasources(toImport, user, remoteCredentials);
             if (!isImportSuccessful(importStatus)) {
                 if (importStatus.getRequestStatus().equals(RequestStatus.FAILURE)) {
                     log.error("Importing of data sources failed.");
@@ -149,7 +149,7 @@ public class ProjectImportPortlet extends Sw360Portlet {
     private List<Project> loadImportables(RemoteCredentials remoteCredentials, String projectName) {
         try {
             log.info("Looking for importables with prefix " + projectName);
-            return bdpImportClient.suggestImportables(remoteCredentials, Strings.nullToEmpty(projectName));
+            return projectImportClient.suggestImportables(remoteCredentials, Strings.nullToEmpty(projectName));
         } catch (TException e) {
             log.error("Thrift failed, (uncaught TException)", e);
             return ImmutableList.of();
@@ -158,7 +158,7 @@ public class ProjectImportPortlet extends Sw360Portlet {
 
     private String getIdName() {
         try {
-            return bdpImportClient.getIdName();
+            return projectImportClient.getIdName();
         } catch (TException e) {
             log.error("Thrift failed, (uncaught TException)", e);
             return "";
@@ -215,7 +215,7 @@ public class ProjectImportPortlet extends Sw360Portlet {
 
     private boolean validateCredentials(RemoteCredentials credentials) {
         try {
-            return bdpImportClient.validateCredentials(credentials);
+            return projectImportClient.validateCredentials(credentials);
         } catch (TException e) {
             log.error("Thrift failed, (uncaught TException)", e);
             return false;

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/import.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/import.jsp
@@ -18,7 +18,7 @@
 <%@ page import="com.liferay.portlet.PortletURLFactoryUtil" %>
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%@ page import="javax.portlet.PortletRequest" %>
-<%@ page import="org.eclipse.sw360.datahandler.thrift.bdpimport.RemoteCredentials" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.projectimport.RemoteCredentials" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.projects.Project" %>
 <%@ page import="org.eclipse.sw360.portal.portlets.projectimport.ProjectImportConstants" %>
 

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/import.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/import.jsp
@@ -221,8 +221,15 @@
                             self.setContent('Projects imported successfully.');
                             break;
                         case '<%=ProjectImportConstants.RESPONSE__FAILURE%>':
-                            var failedIdsList = "<div>" + response.<%=ProjectImportConstants.RESPONSE__FAILED_IDS%> + "</div>";
-                            self.setContent('Some projects failed to import:' + failedIdsList);
+                            var bodyContent = "<ol>";
+                            var failedIdsList = response.<%=ProjectImportConstants.RESPONSE__FAILED_IDS%>;
+
+                            $.each(failedIdsList, function (key, value) {
+                                bodyContent += "<li><b>" + key + "</b>: " + value + "</li>";
+                            });
+                            bodyContent += "</ol>";
+
+                            self.setContent('Some projects failed to import:' + bodyContent);
                             break;
                         case '<%=ProjectImportConstants.RESPONSE__GENERAL_FAILURE%>':
                             flashErrorMessage('Could not import the projects.');

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projectimport/ProjectImportPortletTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projectimport/ProjectImportPortletTest.java
@@ -13,7 +13,7 @@ package org.eclipse.sw360.portal.portlets.projectimport;
 
 import com.liferay.portal.kernel.json.JSONObject;
 import junit.framework.TestCase;
-import org.eclipse.sw360.datahandler.thrift.bdpimport.RemoteCredentials;
+import org.eclipse.sw360.datahandler.thrift.projectimport.RemoteCredentials;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftClients.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftClients.java
@@ -20,7 +20,7 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoService;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
-import org.eclipse.sw360.datahandler.thrift.bdpimport.BdpImportService;
+import org.eclipse.sw360.datahandler.thrift.projectimport.ProjectImportService;
 import org.eclipse.sw360.datahandler.thrift.schedule.ScheduleService;
 import org.eclipse.sw360.datahandler.thrift.search.SearchService;
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
@@ -51,20 +51,20 @@ public class ThriftClients {
     public static final String BACKEND_URL;
 
     //! Service addresses
-    public static final String ATTACHMENT_SERVICE_URL = "/attachments/thrift";
-    public static final String COMPONENT_SERVICE_URL = "/components/thrift";
-    public static final String CVESEARCH_SERVICE_URL = "/cvesearch/thrift";
-    public static final String FOSSOLOGY_SERVICE_URL = "/fossology/thrift";
-    public static final String LICENSE_SERVICE_URL = "/licenses/thrift";
-    public static final String MODERATION_SERVICE_URL = "/moderation/thrift";
-    public static final String PROJECT_SERVICE_URL = "/projects/thrift";
-    public static final String LICENSEINFO_SERVICE_URL = "/licenseinfo/thrift";
-    public static final String SEARCH_SERVICE_URL = "/search/thrift";
-    public static final String USER_SERVICE_URL = "/users/thrift";
-    public static final String VENDOR_SERVICE_URL = "/vendors/thrift";
-    public static final String BDPIMPORT_SERVICE_URL = "/bdpimport/thrift";
-    public static final String VULNERABILITY_SERVICE_URL = "/vulnerabilities/thrift";
-    public static final String SCHEDULE_SERVICE_URL = "/schedule/thrift";
+    private static final String ATTACHMENT_SERVICE_URL = "/attachments/thrift";
+    private static final String COMPONENT_SERVICE_URL = "/components/thrift";
+    private static final String CVESEARCH_SERVICE_URL = "/cvesearch/thrift";
+    private static final String FOSSOLOGY_SERVICE_URL = "/fossology/thrift";
+    private static final String LICENSE_SERVICE_URL = "/licenses/thrift";
+    private static final String MODERATION_SERVICE_URL = "/moderation/thrift";
+    private static final String PROJECT_SERVICE_URL = "/projects/thrift";
+    private static final String LICENSEINFO_SERVICE_URL = "/licenseinfo/thrift";
+    private static final String SEARCH_SERVICE_URL = "/search/thrift";
+    private static final String USER_SERVICE_URL = "/users/thrift";
+    private static final String VENDOR_SERVICE_URL = "/vendors/thrift";
+    private static final String PROJECTIMPORT_SERVICE_URL = "/bdpimport/thrift";
+    private static final String VULNERABILITY_SERVICE_URL = "/vulnerabilities/thrift";
+    private static final String SCHEDULE_SERVICE_URL = "/schedule/thrift";
 
     // A service which has to be scheduled by the scheduler should be registered here!
     // names of services that can be scheduled by the schedule service, i.e. that have an "update" method
@@ -133,8 +133,8 @@ public class ThriftClients {
         return new VendorService.Client(makeProtocol(BACKEND_URL, VENDOR_SERVICE_URL));
     }
 
-    public BdpImportService.Iface makeBdpImportClient() {
-        return new BdpImportService.Client(makeProtocol(BACKEND_URL, BDPIMPORT_SERVICE_URL));
+    public ProjectImportService.Iface makeProjectImportClient() {
+        return new ProjectImportService.Client(makeProtocol(BACKEND_URL, PROJECTIMPORT_SERVICE_URL));
     }
 
     public VulnerabilityService.Iface makeVulnerabilityClient() {

--- a/libraries/lib-datahandler/src/main/thrift/importstatus.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/importstatus.thrift
@@ -23,7 +23,9 @@ typedef sw360.RequestStatus RequestStatus
 
 
 struct ImportStatus {
+    // List of all Ids that where sucessfully imported.
     1: list<string> successfulIds;
-    2: list<string> failedIds;
+    // Map of failed Ids (key) with a message why it failed (value)
+    2: map<string, string> failedIds;
     3: RequestStatus requestStatus;
 }

--- a/libraries/lib-datahandler/src/main/thrift/projectimport.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projectimport.thrift
@@ -20,8 +20,8 @@ include "sw360.thrift"
 include "users.thrift"
 include "importstatus.thrift"
 
-namespace java org.eclipse.sw360.datahandler.thrift.bdpimport
-namespace php sw360.thrift.bdpimport
+namespace java org.eclipse.sw360.datahandler.thrift.projectimport
+namespace php sw360.thrift.projectimport
 
 typedef projects.Project Project
 typedef users.User User
@@ -33,28 +33,28 @@ struct RemoteCredentials {
 3:  string serverUrl,
 }
 
-service BdpImportService {
+service ProjectImportService {
    /**
-    * check credentials with bdp API
+    * check credentials with API
     **/
    bool validateCredentials(1: RemoteCredentials credentials)
 
    /**
-    * returns a list of projects that can be imported from bdp with `reCred` credentials
+    * returns a list of projects that can be imported with `reCred` credentials
     **/
    list<Project> loadImportables(1: RemoteCredentials reCred)
 
    /**
-    * returns a list of projects that can be imported from bdp with `reCred` credentials,
+    * returns a list of projects that can be imported with `reCred` credentials,
     * where any word in the project name starts with the given string
     **/
    list<Project> suggestImportables(1: RemoteCredentials reCred, 2: string projectName)
 
    /**
-    *  imports projects from bdp specified by `bdpProjectIds` with credentials `reCred` and set user as creating
+    *  imports projects from external source specified by `projectIds` with credentials `reCred` and set user as creating
     *  user in SW360
     **/
-   ImportStatus importDatasources(1: list<string> bdpProjectIds, 2: User user, 3: RemoteCredentials reCred);
+   ImportStatus importDatasources(1: list<string> projectIds, 2: User user, 3: RemoteCredentials reCred);
 
    string getIdName();
 }


### PR DESCRIPTION
Instead of a list of IDs, now a error message is shown for each failed ID with a reason for the failure.

Backend PR:  https://github.com/sw360/sw360bdpImportService/pull/5
Depends on PR: https://github.com/sw360/sw360portal/pull/661

(note that before the message was like 'there was some problem', now it shall display which projects etc)