### PR TITLE
fix(ui): hide scrollbar in tab menu and resize moderation table while zooming

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -11,8 +11,10 @@
  *
  * Description: Styles for sw360 portlet Pages
  *
- * Authors: nunifar.ms@siemens.com, puspa.panda@siemens.com,
- * johannes.najjar.ext@siemens.com
+ * Authors: nunifar.ms@siemens.com
+ *          puspa.panda@siemens.com,
+ *          johannes.najjar.ext@siemens.com
+ *          thomas.maier@evosoft.com
  */
 
 div.content1 {
@@ -523,6 +525,10 @@ input[readonly].clickable {
 
 .dataTable input, .dataTable select {
     max-width: 100%;
+}
+
+.aui .tab-content {
+    overflow: hidden;
 }
 
 .aui .table.dataTable th {

--- a/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/moderation/view.jsp
@@ -55,7 +55,7 @@
             </ul>
             <div class="tab-content span10">
                 <div id="tab-Open" class="tab-pane">
-                    <table id="moderationsTable" cellpadding="0" cellspacing="0" border="0" class="display">
+                    <table id="moderationsTable" cellpadding="0" cellspacing="0" border="0" class="display" style="width:100%">
                         <colgroup>
                             <col style="width: 5%;" />
                             <col style="width: 10%;" />
@@ -73,7 +73,7 @@
                     </table>
                 </div>
                 <div id="tab-Closed">
-                    <table id="closedModerationsTable" cellpadding="0" cellspacing="0" border="0" class="display">
+                    <table id="closedModerationsTable" cellpadding="0" cellspacing="0" border="0" class="display" style="width:100%">
                         <colgroup>
                             <col style="width: 5%;" />
                             <col style="width: 10%;" />


### PR DESCRIPTION
- hide horizontal and vertical scrollbar in the navigation tabs (on different zoom levels)
- resize the moderation datatable while zooming

closes sw360/sw360portal#678