### PR TITLE
fix(pom): remove some unused dependencies

### DIFF
--- a/backend/src/src-cvesearch/pom.xml
+++ b/backend/src/src-cvesearch/pom.xml
@@ -21,12 +21,6 @@
             <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.liferay.portal</groupId>
-            <artifactId>portal-service</artifactId>
-            <version>${liferay.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.0</version>

--- a/backend/src/src-schedule/pom.xml
+++ b/backend/src/src-schedule/pom.xml
@@ -20,12 +20,6 @@
             <artifactId>datahandler</artifactId>
             <version>3.1.0-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>com.liferay.portal</groupId>
-            <artifactId>portal-service</artifactId>
-            <version>${liferay.version}</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <parent>


### PR DESCRIPTION
There were unused liferay dependencies in the backend.

Can be merged after travis is green.