### PR TITLE
feat(licenseinfo): make licenseinfo generation more robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-backend/*/target/
-frontend/*/target/
-libraries/*/target/
 target/
 
 # Ignore private and public keys
@@ -37,18 +34,4 @@ target/
 #ignore any log files
 *.log
 
-/libraries/target/
-/libraries/lib-datahandler/target/
-/libraries/commonIO/target/
-/libraries/importers/component-importer/target/
-/libraries/exporters/target/
-/backend/src-common/target/
-/backend/src/src-vendors/target/
-/backend/src/src-components/target/
-/backend/src/src-attachments/target/
-/frontend/sw360-portlets/target/
-/frontend/target/
-/libraries/importers/license-importer/target/
-/backend/src/src-projects/target/
-/backend/svc/svc-licenses/target/
 /backend/src-common/src/main/resources/sw360.properties

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -54,6 +54,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
     private static final int CACHE_MAX_ITEMS = 100;
     private static final String DEFAULT_LICENSE_INFO_HEADER_FILE="/DefaultLicenseInfoHeader.txt";
     private static final String DEFAULT_LICENSE_INFO_TEXT = loadDefaultLicenseInfoHeaderText();
+    public static final String MSG_NO_RELEASE_GIVEN = "No release given";
 
     protected List<LicenseInfoParser> parsers;
     protected List<OutputGenerator<?>> outputGenerators;
@@ -135,7 +136,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
     public List<LicenseInfoParsingResult> getLicenseInfoForAttachment(Release release, String attachmentContentId, User user)
             throws TException {
         if (release == null) {
-            return Collections.singletonList(noSourceParsingResult("No release given"));
+            return Collections.singletonList(noSourceParsingResult(MSG_NO_RELEASE_GIVEN));
         }
 
         List<LicenseInfoParsingResult> cachedResults = licenseInfoCache.getIfPresent(attachmentContentId);

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
@@ -28,6 +28,7 @@ public class DocxUtils {
 
     private static final int FONT_SIZE = 12;
     public static final String ALERT_COLOR = "e95850";
+    public static final String FONT_FAMILY = "Calibri";
 
     private DocxUtils() {
         //only static members
@@ -99,7 +100,7 @@ public class DocxUtils {
             } else {
                 String filename = Optional.ofNullable(result.getLicenseInfo())
                         .map(LicenseInfo::getFilenames)
-                        .map(l -> l.stream().findFirst().orElse(null))
+                        .flatMap(l -> l.stream().findFirst())
                         .orElse("");
                 addReleaseTableErrorRow(table, releaseName, version, nullToEmptyString(result.getMessage()), filename);
             }
@@ -241,11 +242,11 @@ public class DocxUtils {
     }
 
     private static void addFormattedText(XWPFRun run, String text, int fontSize, boolean bold, String rrggbbColor) {
-        addFormattedText(run, text, "Calibri", fontSize, bold, rrggbbColor);
+        addFormattedText(run, text, FONT_FAMILY, fontSize, bold, rrggbbColor);
     }
 
     private static void addFormattedText(XWPFRun run, String text, int fontSize, boolean bold) {
-        addFormattedText(run, text, "Calibri", fontSize, bold, null);
+        addFormattedText(run, text, FONT_FAMILY, fontSize, bold, null);
     }
 
     private static void addFormattedText(XWPFRun run, String text, int fontSize) {

--- a/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
+++ b/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
@@ -8,8 +8,9 @@ $licenseInfoHeader
 
 Open Source Software Contained in this Product/Device:
 ======================================================
-#foreach($releaseName in $licenseInfoResults.keySet())
-* $releaseName
+#foreach($releaseName in $licenseInfoResults.keySet()) #set($errorResults=[])
+* $releaseName #foreach($errorResult in $licenseInfoErrorResults.get($releaseName))
+(ERROR when reading license information from file $errorResult.licenseInfo.filenames[0]: $errorResult.message) #end
 #end
 
 

--- a/backend/src/src-licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
+++ b/backend/src/src-licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
@@ -61,6 +61,10 @@
             visibility: hidden;
         }
 
+        .error {
+            background: #e95850;
+        }
+
     </style>
     <title>
         Open Source Software
@@ -84,6 +88,9 @@
         <ul id="releases" style="list-style-type:none">
             #foreach($releaseName in $licenseInfoResults.keySet())
                 <li id="$esc.xml($releaseName).replace(" ","_").replace(",","-")" class="release" title="$esc.xml($releaseName)">
+                    #foreach($errorResult in $licenseInfoErrorResults.get($releaseName))
+                        <div class="inset error">ERROR when reading license information from file $esc.xml($errorResult.licenseInfo.filenames[0]): $esc.xml($errorResult.message)</div>
+                    #end
                     <div class="inset">
                         <h3 id="h3$esc.xml($releaseName).replace(" ","_").replace(",","-")">$esc.xml($releaseName)
                             <a class="top" href="#releaseHeader">&#8679;</a>

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
@@ -13,6 +13,7 @@ package org.eclipse.sw360.licenseinfo.outputGenerators;
 
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
 import org.dom4j.Document;
 import org.dom4j.Element;
@@ -175,6 +176,7 @@ public class XhtmlGeneratorTest {
 
     private static LicenseInfoParsingResult generateLIPResult(LicenseInfo info, String releaseName, String version, String vendor){
         return new LicenseInfoParsingResult()
+                .setStatus(LicenseInfoRequestStatus.SUCCESS)
                 .setLicenseInfo(info)
                 .setName(releaseName)
                 .setVendor(vendor)

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -59,6 +59,7 @@ import java.io.PrintWriter;
 import java.net.URLConnection;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -178,14 +179,11 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             Project project = projectClient.getProjectById(projectId, user);
             LicenseInfoFile licenseInfoFile = licenseInfoClient.getLicenseInfoFile(project, user, generatorClassName,
                     selectedReleaseAndAttachmentIds, excludedLicensesPerAttachmentId);
-
-            if (PermissionUtils.makePermission(project, user).isActionAllowed(RequestedAction.WRITE)) {
-                List<AttachmentUsage> attachmentUsages = ProjectPortletUtils.makeAttachmentUsages(project, selectedReleaseAndAttachmentIds,
-                        excludedLicensesPerAttachmentId);
-                AttachmentService.Iface attachmentClient = thriftClients.makeAttachmentClient();
-                attachmentClient.replaceAttachmentUsages(Source.projectId(project.getId()), attachmentUsages);
-            } else {
-                log.info("LicenseInfo usage is not stored since the user has no write permissions for this project.");
+            try {
+                replaceAttachmentUsages(user, selectedReleaseAndAttachmentIds, excludedLicensesPerAttachmentId, project);
+            } catch (TException e) {
+                // there's no need to abort the user's desired action just because the ancillary action of storing selection failed
+                log.warn("LicenseInfo usage is not stored due to exception: ", e);
             }
 
             OutputFormatInfo outputFormatInfo = licenseInfoFile.getOutputFormatInfo();
@@ -200,6 +198,22 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         } catch (TException e) {
             log.error("Error getting LicenseInfo file for project with id " + projectId + " and generator " + generatorClassName, e);
             response.setProperty(ResourceResponse.HTTP_STATUS_CODE, Integer.toString(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private void replaceAttachmentUsages(User user, Map<String, Set<String>> selectedReleaseAndAttachmentIds, Map<String, Set<LicenseNameWithText>> excludedLicensesPerAttachmentId, Project project) throws TException {
+        List<AttachmentUsage> attachmentUsages = ProjectPortletUtils.makeAttachmentUsages(project, selectedReleaseAndAttachmentIds,
+                excludedLicensesPerAttachmentId);
+        if (PermissionUtils.makePermission(project, user).isActionAllowed(RequestedAction.WRITE)) {
+            AttachmentService.Iface attachmentClient = thriftClients.makeAttachmentClient();
+            if (attachmentUsages.isEmpty()) {
+                attachmentClient.deleteAttachmentUsagesByUsageDataType(Source.projectId(project.getId()),
+                        UsageData.licenseInfo(new LicenseInfoUsage(Collections.emptySet())));
+            } else {
+                attachmentClient.replaceAttachmentUsages(Source.projectId(project.getId()), attachmentUsages);
+            }
+        } else {
+            log.info("LicenseInfo usage is not stored since the user has no write permissions for this project.");
         }
     }
 
@@ -539,58 +553,61 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             // In addition we remember the license information for exclusion later on
             Map<String, LicenseNameWithText> licenseStore = Maps.newHashMap();
             List<Map<String, String>> licenses = Lists.newArrayList();
-            licenseInfos.forEach(licenseInfoResult -> {
-                        switch (licenseInfoResult.getStatus()){
-                            case SUCCESS:
-                                Set<LicenseNameWithText> licenseNamesWithTexts = nullToEmptySet(licenseInfoResult.getLicenseInfo().getLicenseNamesWithTexts());
-                                List<Map<String, String>> licensesAsObject = licenseNamesWithTexts.stream()
-                                        .filter(licenseNameWithText -> {
-                                            return !Strings.isNullOrEmpty(licenseNameWithText.getLicenseName())
-                                                    || !Strings.isNullOrEmpty(licenseNameWithText.getLicenseText());
-                                        }).map(licenseNameWithText -> {
-                                            // Since the license has no good identifier, we create one and store the license
-                                            // in the session. If the final report is generated, we use the identifier to
-                                            // identify the licenses to be excluded
-                                            // FIXME: this could be changed if we scan the attachments once after uploading
-                                            // and store them as own entity
-                                            String key = UUID.randomUUID().toString();
-                                            licenseStore.put(key, licenseNameWithText);
-
-                                            Map<String, String> data = Maps.newHashMap();
-                                            data.put(LICENSE_NAME_WITH_TEXT_KEY, key);
-                                            data.put(LICENSE_NAME_WITH_TEXT_NAME, Strings.isNullOrEmpty(licenseNameWithText.getLicenseName()) ? EMPTY
-                                                    : licenseNameWithText.getLicenseName());
-                                            data.put(LICENSE_NAME_WITH_TEXT_TEXT, licenseNameWithText.getLicenseText());
-                                            return data;
-                                        }).collect(Collectors.toList());
-
-                                licenses.addAll(licensesAsObject);
-                                break;
-                            case FAILURE:
-                            case NO_APPLICABLE_SOURCE:
-                                LicenseInfo licenseInfo = licenseInfoResult.getLicenseInfo();
-                                String filename = Optional.ofNullable(licenseInfo)
-                                        .map(LicenseInfo::getFilenames)
-                                        .map(CommonUtils.COMMA_JOINER::join)
-                                        .orElse("<filename unknown>");
-                                String message = Optional.ofNullable(licenseInfoResult.getMessage())
-                                        .orElse("<no message>");
-                                licenses.add(ImmutableMap.of(LICENSE_NAME_WITH_TEXT_ERROR, message,
-                                        LICENSE_NAME_WITH_TEXT_FILE, filename));
-                                break;
-                            default:
-                                throw new IllegalArgumentException("Unknown LicenseInfoRequestStatus: " + licenseInfoResult.getStatus());
-                        }
-                    });
-            licenses.stream().sorted((l1, l2) -> {
-                return Strings.nullToEmpty(l1.get(LICENSE_NAME_WITH_TEXT_NAME)).compareTo(l2.get(LICENSE_NAME_WITH_TEXT_NAME));
-            }).collect(Collectors.toList());
+            licenseInfos.forEach(licenseInfoResult ->
+                    addLicenseInfoResultToJsonSerializableLicensesList(licenseInfoResult, licenses, licenseStore::put));
+            licenses.sort((l1, l2) ->
+                    Strings.nullToEmpty(l1.get(LICENSE_NAME_WITH_TEXT_NAME))
+                            .compareTo(l2.get(LICENSE_NAME_WITH_TEXT_NAME)));
 
             request.getPortletSession().setAttribute(LICENSE_STORE_KEY_PREFIX + attachmentContentId, licenseStore);
             writeJSON(request, response, OBJECT_MAPPER.writeValueAsString(licenses));
         } catch (TException exception) {
             log.error("Cannot retrieve license information for attachment id " + attachmentContentId + ".", exception);
             response.setProperty(ResourceResponse.HTTP_STATUS_CODE, "500");
+        }
+    }
+
+    private void addLicenseInfoResultToJsonSerializableLicensesList(LicenseInfoParsingResult licenseInfoResult,
+                                                                    List<Map<String, String>> licenses,
+                                                                    BiConsumer<String, LicenseNameWithText> storeLicense) {
+        switch (licenseInfoResult.getStatus()){
+            case SUCCESS:
+                Set<LicenseNameWithText> licenseNamesWithTexts = nullToEmptySet(licenseInfoResult.getLicenseInfo().getLicenseNamesWithTexts());
+                List<Map<String, String>> licensesAsObject = licenseNamesWithTexts.stream()
+                        .filter(licenseNameWithText -> !Strings.isNullOrEmpty(licenseNameWithText.getLicenseName())
+                                || !Strings.isNullOrEmpty(licenseNameWithText.getLicenseText())).map(licenseNameWithText -> {
+                            // Since the license has no good identifier, we create one and store the license
+                            // in the session. If the final report is generated, we use the identifier to
+                            // identify the licenses to be excluded
+                            // FIXME: this could be changed if we scan the attachments once after uploading
+                            // and store them as own entity
+                            String key = UUID.randomUUID().toString();
+                            storeLicense.accept(key, licenseNameWithText);
+
+                            Map<String, String> data = Maps.newHashMap();
+                            data.put(LICENSE_NAME_WITH_TEXT_KEY, key);
+                            data.put(LICENSE_NAME_WITH_TEXT_NAME, Strings.isNullOrEmpty(licenseNameWithText.getLicenseName()) ? EMPTY
+                                    : licenseNameWithText.getLicenseName());
+                            data.put(LICENSE_NAME_WITH_TEXT_TEXT, licenseNameWithText.getLicenseText());
+                            return data;
+                        }).collect(Collectors.toList());
+
+                licenses.addAll(licensesAsObject);
+                break;
+            case FAILURE:
+            case NO_APPLICABLE_SOURCE:
+                LicenseInfo licenseInfo = licenseInfoResult.getLicenseInfo();
+                String filename = Optional.ofNullable(licenseInfo)
+                        .map(LicenseInfo::getFilenames)
+                        .map(CommonUtils.COMMA_JOINER::join)
+                        .orElse("<filename unknown>");
+                String message = Optional.ofNullable(licenseInfoResult.getMessage())
+                        .orElse("<no message>");
+                licenses.add(ImmutableMap.of(LICENSE_NAME_WITH_TEXT_ERROR, message,
+                        LICENSE_NAME_WITH_TEXT_FILE, filename));
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown LicenseInfoRequestStatus: " + licenseInfoResult.getStatus());
         }
     }
 

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
@@ -257,10 +257,10 @@
                     }).done(function(licenses) {
                         var $rows;
 
-                        if(licenses.length == 0) {
+                        if(licenses.length == 0 || licenses[0].error) {
                             $linkedProjectsInfoTable.find('tr[data-tt-id=' + data.ttId + '_loader] td').append($('<div/>', {
                                 'class': 'error foregroundAlert',
-                                text: 'No license found.'
+                                text: 'No license found.' + licenses[0].error ? ' Error: ' + licenses[0].error + ' Parsed file: ' + licenses[0].file : ''
                             }));
                             $linkedProjectsInfoTable.find('tr[data-tt-id=' + data.ttId + '_loader] td .spinner').hide();
                             loadedCallback();

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
@@ -10,6 +10,7 @@
   ~ http://www.eclipse.org/legal/epl-v10.html
 --%>
 
+<%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <portlet:resourceURL var="downloadLicenseInfoURL">
     <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.GET_LICENCES_FROM_ATTACHMENT%>'/>
 </portlet:resourceURL>
@@ -18,7 +19,11 @@
     <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.LOAD_LICENSE_INFO_ATTACHMENT_USAGE%>'/>
 </portlet:resourceURL>
 
-<core_rt:if test="${projectLinkTableMode == PortalConstants.PROJECT_LINK_TABLE_MODE_LICENSE_INFO}">
+<%--These variables are used as a trick to allow referencing constant values in EL expressions below--%>
+<c:set var="tableModeLicenseInfo" value="<%=PortalConstants.PROJECT_LINK_TABLE_MODE_LICENSE_INFO%>"/>
+<c:set var="tableModeSourceBundle" value="<%=PortalConstants.PROJECT_LINK_TABLE_MODE_SOURCE_BUNDLE%>"/>
+
+<core_rt:if test="${projectLinkTableMode == tableModeLicenseInfo}">
     <div id="infobar" class="infobar backgroundGrey">
         <div class="spinner">Loading selected licenses and exclusions...</div>
     </div>
@@ -26,8 +31,8 @@
 
 <table class="table info_table" id="LinkedProjectsInfo"
     data-table-mode="${projectLinkTableMode}"
-    data-table-mode-license-info="<%=PortalConstants.PROJECT_LINK_TABLE_MODE_LICENSE_INFO%>"
-    data-table-mode-source-bundle="<%=PortalConstants.PROJECT_LINK_TABLE_MODE_SOURCE_BUNDLE%>"
+    data-table-mode-license-info="${tableModeLicenseInfo}"
+    data-table-mode-source-bundle="${tableModeSourceBundle}"
     data-portlet-namespace="<portlet:namespace/>"
     data-license-info-base-url="<%=downloadLicenseInfoURL%>"
     data-license-info-state-url="<%=downloadLicenseInfoStateURL%>"
@@ -137,7 +142,7 @@
                         <sw360:out value="${attachment.filename}"/>
                     </td>
                     <td colspan="2">
-                        <core_rt:if test="${projectLinkTableMode == PortalConstants.PROJECT_LINK_TABLE_MODE_LICENSE_INFO}">
+                        <core_rt:if test="${projectLinkTableMode == tableModeLicenseInfo}">
                             <c:set var="mapKey">${releaseLink.id.concat("_").concat(attachment.attachmentContentId)}</c:set>
                             <core_rt:choose>
                                 <core_rt:when test="${attachmenUsageCountMap[mapKey] != null}">
@@ -156,7 +161,7 @@
                         <sw360:out value="${attachment.createdTeam}"/>
                     </td>
                 </tr>
-                <core_rt:if test="${PortalConstants.PROJECT_LINK_TABLE_MODE_LICENSE_INFO == projectLinkTableMode}">
+                <core_rt:if test="${projectLinkTableMode == tableModeLicenseInfo}">
                     <tr data-tt-id="${releaseLink.nodeId}_${attachment.attachmentContentId}_loader" data-tt-parent-id="${releaseLink.nodeId}_${attachment.attachmentContentId}">
                         <td colspan="7">
                             <div class="spinner">Loading license information. Please wait...</div>
@@ -258,9 +263,10 @@
                         var $rows;
 
                         if(licenses.length == 0 || licenses[0].error) {
+                            var errorText = licenses.length > 0 ? ' Error: ' + licenses[0].error + ' Parsed file: ' + licenses[0].file : '';
                             $linkedProjectsInfoTable.find('tr[data-tt-id=' + data.ttId + '_loader] td').append($('<div/>', {
                                 'class': 'error foregroundAlert',
-                                text: 'No license found.' + licenses[0].error ? ' Error: ' + licenses[0].error + ' Parsed file: ' + licenses[0].file : ''
+                                text: 'No license found.' + errorText
                             }));
                             $linkedProjectsInfoTable.find('tr[data-tt-id=' + data.ttId + '_loader] td .spinner').hide();
                             loadedCallback();

--- a/libraries/lib-datahandler/src/main/thrift/attachments.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/attachments.thrift
@@ -200,8 +200,13 @@ service AttachmentService {
 
     /**
      * Replaces all attachment usages for a source with the given list of attachment usages. Only usages of the same type are
-     * replaces. The type is determined by the type of usage data. Replacement means that all exisitng usages with the same type
-     * are deleted and all given usages are added.
+     * replaced. The type is determined by the type of usage data. Replacement means that all existing usages with the same type
+     * are deleted and all given usages are added. Note that this does not allow replacing attachment usages of any given type
+     * with an empty list, because the given list of usages must contain at least one element to determine what type of
+     * usages is to be replaced. Passing an empty list of usages to this method has no effect.
+     *
+     * @see deleteAttachmentUsagesByUsageDataType()
+     *
      */
     void replaceAttachmentUsages(1: Source usedBy, 2: list<AttachmentUsage> attachmentUsages);
 
@@ -214,6 +219,12 @@ service AttachmentService {
      * Deletes the given list of attachment usage objects. The given usage objects must exist in the database.
      */
     void deleteAttachmentUsages(1: list<AttachmentUsage> attachmentUsages);
+    /**
+     * Deletes the all attachment usage objects with the usedBy source `usedBy` and of the same type as `usageData`.
+     * The content of `usageData` is unimportant. Only its type is consedered.
+     * If `usageData` is null, the attachment usages with no `usageData` are deleted.
+     */
+    void deleteAttachmentUsagesByUsageDataType(1: Source usedBy, 2: UsageData usageData);
 
     /**
      * Returns the list of usage objects describing the usage of the attachment that can be identified


### PR DESCRIPTION
display error messages at license selection screen and in the generated
license info files when one of the attachments cannot be parsed, as opposed
to failing outright.

merge license info data when multiple CLI attachments were selected by
the user (only for text and xhtml generators)

closes sw360/sw360portal#606
