### PR TITLE
fix(rest): show all linked releases with project relationship information

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
@@ -92,7 +92,7 @@ public class AttachmentController implements ResourceProcessor<RepositoryLinksRe
         Link releaseLink = linkTo(AttachmentController.class).slash("api/releases/" + sw360Release.getId()).withRel("release");
         halAttachment.add(releaseLink);
 
-        restControllerHelper.addEmbeddedRelease(halAttachment, sw360Release, "release");
+        restControllerHelper.addEmbeddedRelease(halAttachment, sw360Release);
         restControllerHelper.addEmbeddedUser(halAttachment, sw360User, "createdBy");
 
         return halAttachment;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -142,7 +142,7 @@ public class ComponentController implements ResourceProcessor<RepositoryLinksRes
 
         if (sw360Component.getReleaseIds() != null) {
             Set<String> releases = sw360Component.getReleaseIds();
-            restControllerHelper.addEmbeddedReleases(halComponent, releases, releaseService, user, "releases");
+            restControllerHelper.addEmbeddedReleases(halComponent, releases, releaseService, user);
         }
 
         if (sw360Component.getReleases() != null) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017.
+ * Copyright Siemens AG, 2017-2018.
  * Copyright Bosch Software Innovations GmbH, 2017.
  * Part of the SW360 Portal Project.
  *
@@ -10,10 +10,14 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
+
 package org.eclipse.sw360.rest.resourceserver.core;
 
+import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ECCStatus;
@@ -21,11 +25,14 @@ import org.eclipse.sw360.datahandler.thrift.components.EccInformation;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectType;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
+import org.eclipse.sw360.rest.resourceserver.core.serializer.JsonProjectRelationSerializer;
+import org.eclipse.sw360.rest.resourceserver.core.serializer.JsonReleaseRelationSerializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -37,7 +44,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @Configuration
 class JacksonCustomizations {
-
     @Bean
     public Module sw360Module() {
         return new Sw360Module();
@@ -45,7 +51,6 @@ class JacksonCustomizations {
 
     @SuppressWarnings("serial")
     static class Sw360Module extends SimpleModule {
-
         public Sw360Module() {
             setMixInAnnotation(Project.class, Sw360Module.ProjectMixin.class);
             setMixInAnnotation(User.class, Sw360Module.UserMixin.class);
@@ -72,7 +77,6 @@ class JacksonCustomizations {
                 "moderators",
                 "contributors",
                 "visbility",
-                "linkedProjects",
                 "clearingTeam",
                 "preevaluationDeadline",
                 "systemTestStart",
@@ -142,12 +146,23 @@ class JacksonCustomizations {
                 "setProjectOwner",
                 "enableSvm",
                 "setEnableSvm"
-                })
+        })
         static abstract class ProjectMixin extends Project {
+
             @Override
             @JsonProperty("projectType")
             abstract public ProjectType getProjectType();
-            
+
+            @Override
+            @JsonSerialize(using = JsonProjectRelationSerializer.class)
+            @JsonProperty("linkedProjects")
+            abstract public Map<String, ProjectRelationship> getLinkedProjects();
+
+            @Override
+            @JsonSerialize(using = JsonReleaseRelationSerializer.class)
+            @JsonProperty("linkedReleases")
+            abstract public Map<String, ProjectReleaseRelationship> getReleaseIdToUsage();
+
             @Override
             @JsonProperty("id")
             abstract public String getId();
@@ -268,7 +283,7 @@ class JacksonCustomizations {
                 "setOwnerCountry",
                 "rolesSize",
                 "setRoles",
-                })
+        })
         static abstract class ComponentMixin extends Component {
             @Override
             @JsonProperty("vendors")
@@ -346,7 +361,7 @@ class JacksonCustomizations {
             @Override
             @JsonProperty("cpeId")
             abstract public String getCpeid();
-            
+
             @Override
             @JsonProperty("eccInformation")
             abstract public EccInformation getEccInformation();
@@ -448,7 +463,7 @@ class JacksonCustomizations {
                 "setRisks",
                 "setText",
                 "mainLicenseIdsIterator"
-                })
+        })
         static abstract class LicenseMixin extends License {
             @Override
             @JsonProperty("fullName")
@@ -507,21 +522,21 @@ class JacksonCustomizations {
                 "setTitle",
                 "referencesIterator",
                 "cveReferencesIterator"
-                })
+        })
         static abstract class VulnerabilityDTOMixin extends VulnerabilityDTO {
             @Override
             @JsonProperty("id")
             abstract public String getId();
-            
+
             @Override
             @JsonProperty("intReleaseId")
             abstract public String getIntReleaseId();
-            
+
             @Override
             @JsonProperty("intReleaseName")
             abstract public String getIntReleaseName();
         }
-        
+
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonIgnoreProperties({
                 "revision",
@@ -590,33 +605,33 @@ class JacksonCustomizations {
                 "setCvssTime",
                 "setAccess",
                 "accessSize",
-                })
+        })
         static abstract class VulnerabilityMixin extends Vulnerability {
             @Override
             @JsonProperty("id")
             abstract public String getId();
         }
-        
+
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
         @JsonIgnoreProperties({
-            "AL",
-            "ECCN",
-            "assessorContactPerson",
-            "assessorDepartment",
-            "eccComment",
-            "materialIndexNumber",
-            "assessmentDate",
-            "al",
-            "eccn",
-            "setEccComment",
-            "setECCN",
-            "setEccStatus",
-            "setAL",
-            "setAssessorContactPerson",
-            "setAssessmentDate",
-            "setAssessorDepartment",
-            "setMaterialIndexNumber"
-                })
+                "AL",
+                "ECCN",
+                "assessorContactPerson",
+                "assessorDepartment",
+                "eccComment",
+                "materialIndexNumber",
+                "assessmentDate",
+                "al",
+                "eccn",
+                "setEccComment",
+                "setECCN",
+                "setEccStatus",
+                "setAL",
+                "setAssessorContactPerson",
+                "setAssessmentDate",
+                "setAssessorDepartment",
+                "setMaterialIndexNumber"
+        })
         static abstract class EccInformationMixin extends EccInformation {
             @Override
             @JsonProperty("eccStatus")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
@@ -14,6 +14,7 @@ package org.eclipse.sw360.rest.resourceserver.core;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import org.eclipse.sw360.rest.resourceserver.core.serializer.JsonInstantSerializer;
 import org.apache.thrift.TException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.OptimisticLockingFailureException;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/serializer/JsonInstantSerializer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/serializer/JsonInstantSerializer.java
@@ -9,7 +9,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  */
 
-package org.eclipse.sw360.rest.resourceserver.core;
+package org.eclipse.sw360.rest.resourceserver.core.serializer;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/serializer/JsonProjectRelationSerializer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/serializer/JsonProjectRelationSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Siemens AG, 2018.
+ * Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.sw360.rest.resourceserver.core.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
+import org.eclipse.sw360.rest.resourceserver.project.ProjectController;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+
+@Component
+public class JsonProjectRelationSerializer extends JsonSerializer<Map<String, ProjectRelationship>> {
+
+    @Override
+    public void serialize(Map<String, ProjectRelationship> projectRelationMap, JsonGenerator gen, SerializerProvider provider)
+            throws IOException, JsonProcessingException {
+
+        List<Map<String, String>> linkedProjects = new ArrayList<>();
+        for (Map.Entry<String, ProjectRelationship> projectRelation : projectRelationMap.entrySet()) {
+            String projectLink = linkTo(ProjectController.class).slash("api" +
+                    ProjectController.PROJECTS_URL + "/" + projectRelation.getKey()).withSelfRel().getHref();
+
+            Map<String, String> linkedProject = new HashMap<>();
+            linkedProject.put("relation", projectRelation.getValue().name());
+            linkedProject.put("project", projectLink);
+            linkedProjects.add(linkedProject);
+
+        }
+        gen.writeObject(linkedProjects);
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/serializer/JsonReleaseRelationSerializer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/serializer/JsonReleaseRelationSerializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Siemens AG, 2018.
+ * Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.sw360.rest.resourceserver.core.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
+import org.eclipse.sw360.rest.resourceserver.project.ProjectController;
+import org.eclipse.sw360.rest.resourceserver.release.ReleaseController;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+
+@Component
+public class JsonReleaseRelationSerializer extends JsonSerializer<Map<String, ProjectReleaseRelationship>> {
+
+    @Override
+    public void serialize(Map<String, ProjectReleaseRelationship> releaseRelationMap, JsonGenerator gen, SerializerProvider provider)
+            throws IOException, JsonProcessingException {
+
+        List<Map<String, String>> linkedReleases = new ArrayList<>();
+        for (Map.Entry<String, ProjectReleaseRelationship> releaseRelation : releaseRelationMap.entrySet()) {
+            String releaseLink = linkTo(ProjectController.class).slash("api" +
+                    ReleaseController.RELEASES_URL + "/" + releaseRelation.getKey()).withSelfRel().getHref();
+
+            Map<String, String> linkedRelease = new HashMap<>();
+            ProjectReleaseRelationship projectReleaseRelationship = releaseRelation.getValue();
+            linkedRelease.put("relation", projectReleaseRelationship.getReleaseRelation().name());
+            linkedRelease.put("mainlineState", projectReleaseRelationship.getMainlineState().name());
+            linkedRelease.put("release", releaseLink);
+            linkedReleases.add(linkedRelease);
+        }
+        gen.writeObject(linkedReleases);
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
@@ -131,7 +131,7 @@ public class AttachmentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("checkedOn").description("The date the attachment was checked"),
                                 fieldWithPath("checkStatus").description("The checking status. possible values are " + Arrays.asList(CheckStatus.values())),
                                 fieldWithPath("_embedded.createdBy").description("The user who created this attachment"),
-                                fieldWithPath("_embedded.release").description("The release this attachment belongs to"),
+                                fieldWithPath("_embedded.sw360:releases").description("The release this attachment belongs to"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -177,9 +177,9 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("ownerCountry").description("The owner country of the component"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
                                 fieldWithPath("_embedded.createdBy").description("The user who created this component"),
-                                fieldWithPath("_embedded.releases").description("An array of all component releases with version and link to their <<resources-releases,Releases resource>>"),
-                                fieldWithPath("_embedded.moderators").description("An array of all component moderators with email and link to their <<resources-user-get,User resource>>"),
-                                fieldWithPath("_embedded.vendors").description("An array of all component vendors with ful name and link to their <<resources-vendor-get,Vendor resource>>")
+                                fieldWithPath("_embedded.sw360:releases").description("An array of all component releases with version and link to their <<resources-releases,Releases resource>>"),
+                                fieldWithPath("_embedded.sw360:moderators").description("An array of all component moderators with email and link to their <<resources-user-get,User resource>>"),
+                                fieldWithPath("_embedded.sw360:vendors").description("An array of all component vendors with ful name and link to their <<resources-vendor-get,Vendor resource>>")
                         )));
     }
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -143,7 +143,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("ownerCountry").description("The owner country of the project"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
                                 fieldWithPath("_embedded.createdBy").description("The user who created this project"),
-                                fieldWithPath("_embedded.moderators").description("An array of all project moderators with email and link to their <<resources-user-get,User resource>>")
+                                fieldWithPath("_embedded.sw360:moderators").description("An array of all project moderators with email and link to their <<resources-user-get,User resource>>")
                         )));
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -150,7 +150,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("createdOn").description("The creation date of the internal sw360 release"),
                                 fieldWithPath("type").description("is always 'release'"),
                                 fieldWithPath("externalIds").description("When releases are imported from other tools, the external ids can be stored here"),
-                                fieldWithPath("_embedded.moderators").description("An array of all release moderators with email and link to their <<resources-user-get,User resource>>"),
+                                fieldWithPath("_embedded.sw360:moderators").description("An array of all release moderators with email and link to their <<resources-user-get,User resource>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }


### PR DESCRIPTION
- All releases for a project are now displayed
- Added `linkRelation` to the self link of linked releases

```
 "containedReleases": [
      {
        "name": "Release ABC",
        "version": "1.2.3",
        "clearingState": "APPROVED",
        "_links": {
          "self": {
            "href": "https://localhost:8443/resource/api/releases/1234567.....",
            "linkRelation": {
              "releaseRelation": "CONTAINED",
              "mainlineState": "OPEN"
            }
          }
        }
      }
    ]
```

closes sw360/sw360portal#718
closes sw360/sw360portal#722