### PR TITLE
feat(licenseinfo): Generate different variants of DOCX files

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
@@ -10,18 +10,19 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.eclipse.sw360.licenseinfo.outputGenerators;
 
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFRun;
+import org.apache.thrift.TException;
 import org.apache.xmlbeans.XmlException;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
-import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
-import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
-import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
-import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.*;
+import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
+import org.eclipse.sw360.datahandler.thrift.licenses.Todo;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -34,35 +35,50 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
 
     private static final String UNKNOWN_LICENSE_NAME = "Unknown license name";
     private static final String UNKNOWN_FILE_NAME = "Unknown file name";
+    private static final String TODO_DEFAULT_TEXT = "todo not determined so far.";
 
-    public DocxGenerator() {
-        super("docx", "License information as DOCX", true, "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+    private static final String DOCX_TEMPLATE_FILE = "/templateFrontpageContent.docx";
+    private static final String DOCX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    private static final String DOCX_OUTPUT_TYPE = "docx";
+
+    public DocxGenerator(OutputFormatVariant outputFormatVariant, String description) {
+        super(DOCX_OUTPUT_TYPE, description, true, DOCX_MIME_TYPE, outputFormatVariant);
     }
 
     @Override
     public byte[] generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, String projectName, String projectVersion, String licenseInfoHeaderText) throws SW360Exception {
+        ByteArrayOutputStream docxOutputStream = new ByteArrayOutputStream();
         try {
-            XWPFDocument document = new XWPFDocument(this.getClass().getResourceAsStream("/templateFrontpageContent.docx"));
-            fillDocument(document, projectLicenseInfoResults, projectName, projectVersion, licenseInfoHeaderText);
-            ByteArrayOutputStream docxOutputStream = new ByteArrayOutputStream();
-            document.write(docxOutputStream);
+            XWPFDocument xwpfDocument = new XWPFDocument(this.getClass().getResourceAsStream(DOCX_TEMPLATE_FILE));
+            switch (getOutputVariant()) {
+                case DISCLOSURE:
+                    fillDocument(xwpfDocument, projectLicenseInfoResults, projectName, projectVersion, licenseInfoHeaderText, false);
+                    break;
+                case REPORT:
+                    fillDocument(xwpfDocument, projectLicenseInfoResults, projectName, projectVersion, licenseInfoHeaderText, true);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown generator variant type: " + getOutputVariant());
+            }
+            xwpfDocument.write(docxOutputStream);
             docxOutputStream.close();
-            return docxOutputStream.toByteArray();
         } catch (XmlException e) {
             throw new SW360Exception("Got XmlException while generating docx document: " + e.getMessage());
-        } catch (IOException ioe) {
-            throw new SW360Exception("Got IOException when generating docx document: " + ioe.getMessage());
+        } catch (IOException e) {
+            throw new SW360Exception("Got IOException when generating docx document: " + e.getMessage());
+        } catch (TException e) {
+            throw new SW360Exception("Error reading sw360 licenses: " + e.getMessage());
         }
+        return docxOutputStream.toByteArray();
     }
 
     private void fillDocument(XWPFDocument document, Collection<LicenseInfoParsingResult> projectLicenseInfoResults,
-                              String projectName, String projectVersion, String licenseInfoHeaderText) throws XmlException {
+                              String projectName, String projectVersion, String licenseInfoHeaderText, boolean includeObligations) throws XmlException, TException {
         replaceText(document, "$license-info-header", licenseInfoHeaderText);
         replaceText(document, "$project-name", projectName);
         replaceText(document, "$project-version", projectVersion);
-
         fillReleaseBulletList(document, projectLicenseInfoResults);
-        fillReleaseDetailList(document, projectLicenseInfoResults);
+        fillReleaseDetailList(document, projectLicenseInfoResults, includeObligations);
         fillLicenseList(document, projectLicenseInfoResults);
     }
 
@@ -75,32 +91,17 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
         addPageBreak(document);
     }
 
-    private void fillReleaseDetailList(XWPFDocument document, Collection<LicenseInfoParsingResult> projectLicenseInfoResults) {
-        XWPFRun releaseTitleTextRun = document.createParagraph().createRun();
-        addFormattedText(releaseTitleTextRun, "Detailed Releases Information", FONT_SIZE + 2, true);
-        XWPFRun releaseInfoTextRun = document.createParagraph().createRun();
-        setText(releaseInfoTextRun, "Please note the following license conditions and copyright " +
+    private void fillReleaseDetailList(XWPFDocument document, Collection<LicenseInfoParsingResult> projectLicenseInfoResults, boolean includeObligations) throws TException {
+        addFormattedText(document.createParagraph().createRun(), "Detailed Releases Information", FONT_SIZE + 2, true);
+        setText(document.createParagraph().createRun(), "Please note the following license conditions and copyright " +
                 "notices applicable to Open Source Software and/or other components (or parts thereof):");
         addNewLines(document, 0);
 
         for (LicenseInfoParsingResult parsingResult : projectLicenseInfoResults) {
             addReleaseTitle(document, parsingResult);
             if (parsingResult.getStatus() == LicenseInfoRequestStatus.SUCCESS) {
-                XWPFRun copyrightTitleRun = document.createParagraph().createRun();
-                addFormattedText(copyrightTitleRun, "Copyrights", FONT_SIZE, true);
-                for (String copyright : getReleaseCopyrights(parsingResult)) {
-                    XWPFParagraph copyPara = document.createParagraph();
-                    copyPara.setSpacingAfter(0);
-                    setText(copyPara.createRun(), copyright);
-                }
-                XWPFRun licensesTitleRun = document.createParagraph().createRun();
-                addNewLines(licensesTitleRun, 1);
-                addFormattedText(licensesTitleRun, "Licenses", FONT_SIZE, true);
-                for (String licenseName : getReleasesLicenses(parsingResult)) {
-                    XWPFParagraph licensePara = document.createParagraph();
-                    licensePara.setSpacingAfter(0);
-                    addBookmarkHyperLink(licensePara, licenseName, licenseName);
-                }
+                addCopyrights(document, parsingResult);
+                addLicenses(document, parsingResult, includeObligations);
             } else {
                 XWPFRun errorRun = document.createParagraph().createRun();
                 String errorText = nullToEmptyString(parsingResult.getMessage());
@@ -119,6 +120,45 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
         releaseTitleParagraph.setStyle(STYLE_HEADING);
         addBookmark(releaseTitleParagraph, releaseTitle, releaseTitle);
         addNewLines(document, 0);
+    }
+
+    private void addCopyrights(XWPFDocument document, LicenseInfoParsingResult parsingResult) {
+        XWPFRun copyrightTitleRun = document.createParagraph().createRun();
+        addFormattedText(copyrightTitleRun, "Copyrights", FONT_SIZE, true);
+        for (String copyright : getReleaseCopyrights(parsingResult)) {
+            XWPFParagraph copyPara = document.createParagraph();
+            copyPara.setSpacingAfter(0);
+            setText(copyPara.createRun(), copyright);
+        }
+    }
+
+    private void addLicenses(XWPFDocument document, LicenseInfoParsingResult parsingResult, boolean includeObligations) throws TException {
+        XWPFRun licensesTitleRun = document.createParagraph().createRun();
+        addNewLines(licensesTitleRun, 1);
+        addFormattedText(licensesTitleRun, "Licenses", FONT_SIZE, true);
+        for (String licenseName : getReleasesLicenses(parsingResult)) {
+            XWPFParagraph licensePara = document.createParagraph();
+            licensePara.setSpacingAfter(0);
+            addBookmarkHyperLink(licensePara, licenseName, licenseName);
+            if (includeObligations) {
+                addLicenseObligations(document, licenseName);
+            }
+        }
+    }
+
+    private void addLicenseObligations(XWPFDocument document, String spdxLicense) throws TException {
+        List<License> sw360Licenses = getLicenses();
+        XWPFRun todoTitleRun = document.createParagraph().createRun();
+        addNewLines(todoTitleRun, 0);
+        Set<String> todos = getTodosFromLicenses(spdxLicense, sw360Licenses);
+        addFormattedText(todoTitleRun, "Obligations for license " + spdxLicense + ":", FONT_SIZE, true);
+        for (String todo : todos) {
+            XWPFParagraph copyPara = document.createParagraph();
+            copyPara.setSpacingAfter(0);
+            XWPFRun todoRun = copyPara.createRun();
+            setText(todoRun, todo);
+            addNewLines(todoRun, 1);
+        }
     }
 
     private Set<String> getReleaseCopyrights(LicenseInfoParsingResult licenseInfoParsingResult) {
@@ -154,6 +194,28 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
                 .orElse(UNKNOWN_FILE_NAME);
     }
 
+    private static Set<String> getTodosFromLicenses(String spdxLicense, List<License> licenses) {
+        Set<String> todos = new HashSet<>();
+        if (spdxLicense != null && !spdxLicense.isEmpty() && licenses != null) {
+            for (License license : licenses) {
+                if (spdxLicense.equalsIgnoreCase(license.getId())) {
+                    for (Todo todo : license.getTodos()) {
+                        todos.add(todo.getText());
+                    }
+                }
+            }
+            if (todos.isEmpty()) {
+                todos.add(TODO_DEFAULT_TEXT);
+            }
+        }
+        return todos;
+    }
+
+    private static List<License> getLicenses() throws TException {
+        LicenseService.Iface licenseClient = new ThriftClients().makeLicenseClient();
+        return licenseClient.getLicenses();
+    }
+
     private void fillLicenseList(XWPFDocument document, Collection<LicenseInfoParsingResult> projectLicenseInfoResults) {
         List<LicenseNameWithText> licenseNameWithTexts = OutputGenerator.getSortedLicenseNameWithTexts(projectLicenseInfoResults);
         XWPFRun licenseHeaderRun = document.createParagraph().createRun();
@@ -165,6 +227,7 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
             licenseParagraph.setStyle(STYLE_HEADING);
             String licenseName = licenseNameWithText.isSetLicenseName() ? licenseNameWithText.getLicenseName() : UNKNOWN_LICENSE_NAME;
             addBookmark(licenseParagraph, licenseName, licenseName);
+            addNewLines(document, 0);
             setText(document.createParagraph().createRun(), nullToEmptyString(licenseNameWithText.getLicenseText()));
             addNewLines(document, 1);
         }

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 
 public class DocxUtils {
 
-    public static final int FONT_SIZE = 12;
+    public static final int FONT_SIZE = 10;
     public static final String ALERT_COLOR = "e95850";
     public static final String FONT_FAMILY = "Calibri";
     public static final String STYLE_HEADING = "Heading2";

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
@@ -36,21 +36,23 @@ public abstract class OutputGenerator<T> {
     protected static final String LICENSE_REFERENCE_ID_MAP_CONTEXT_PROPERTY = "licenseNameWithTextToReferenceId";
     protected static final String ACKNOWLEDGEMENTS_CONTEXT_PROPERTY = "acknowledgements";
     protected static final String ALL_LICENSE_NAMES_WITH_TEXTS = "allLicenseNamesWithTexts";
-    protected static final String LICENSES_CONTEXT_PROPERTY = "licenses";
     protected static final String LICENSE_INFO_RESULTS_CONTEXT_PROPERTY = "licenseInfoResults";
     protected static final String LICENSE_INFO_ERROR_RESULTS_CONTEXT_PROPERTY = "licenseInfoErrorResults";
     protected static final String LICENSE_INFO_HEADER_TEXT = "licenseInfoHeader";
+    protected static final String LICENSE_INFO_PROJECT_TITLE = "projectTitle";
 
     private final String outputType;
     private final String outputDescription;
     private final boolean isOutputBinary;
     private final String outputMimeType;
+    private final OutputFormatVariant outputVariant;
 
-    OutputGenerator(String outputType, String outputDescription, boolean isOutputBinary, String mimeType){
+    OutputGenerator(String outputType, String outputDescription, boolean isOutputBinary, String mimeType, OutputFormatVariant variant) {
         this.outputType = outputType;
         this.outputDescription = outputDescription;
         this.isOutputBinary = isOutputBinary;
         this.outputMimeType = mimeType;
+        this.outputVariant = variant;
     }
 
     public abstract T generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, String projectName, String projectVersion, String licenseInfoHeaderText) throws SW360Exception;
@@ -71,13 +73,18 @@ public abstract class OutputGenerator<T> {
         return outputMimeType;
     }
 
+    public OutputFormatVariant getOutputVariant() {
+        return outputVariant;
+    }
+
     public OutputFormatInfo getOutputFormatInfo() {
         return new OutputFormatInfo()
                 .setFileExtension(getOutputType())
                 .setDescription(getOutputDescription())
                 .setIsOutputBinary(isOutputBinary())
-                .setGeneratorClassName(this.getClass().getName())
-                .setMimeType(getOutputMimeType());
+                .setGeneratorClassName(this.getClass().getSimpleName())
+                .setMimeType(getOutputMimeType())
+                .setVariant(getOutputVariant());
     }
 
     public String getComponentLongName(LicenseInfoParsingResult li) {
@@ -182,9 +189,11 @@ public abstract class OutputGenerator<T> {
      *            name of template file
      * @return rendered template
      */
-    protected String renderTemplateWithDefaultValues(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, String file, String licenseInfoHeaderText) {
+    protected String renderTemplateWithDefaultValues(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, String file,
+                                                     String projectTitle, String licenseInfoHeaderText) {
         VelocityContext vc = getConfiguredVelocityContext();
         // set header
+        vc.put(LICENSE_INFO_PROJECT_TITLE, projectTitle);
         vc.put(LICENSE_INFO_HEADER_TEXT, licenseInfoHeaderText);
 
         // sorted lists of all license to be displayed at the end of the file at once

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/TextGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/TextGenerator.java
@@ -16,23 +16,36 @@ package org.eclipse.sw360.licenseinfo.outputGenerators;
 import org.apache.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant;
 
 import java.util.Collection;
 
 public class TextGenerator extends OutputGenerator<String> {
     private static final Logger LOGGER = Logger.getLogger(TextGenerator.class);
-    private static final String LICENSE_INFO_TEMPLATE_FILE = "textLicenseInfoFile.vm";
 
-    public TextGenerator() {
-        super("txt", "License information as TEXT", false, "text/plain");
+    private static final String TXT_TEMPLATE_FILE = "textLicenseInfoFile.vm";
+    private static final String TXT_MIME_TYPE = "text/plain";
+    private static final String TXT_OUTPUT_TYPE = "txt";
+
+    public TextGenerator(OutputFormatVariant outputFormatVariant, String outputDescription) {
+        super(TXT_OUTPUT_TYPE, outputDescription, false, TXT_MIME_TYPE, outputFormatVariant);
     }
 
     @Override
     public String generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, String projectName, String projectVersion, String licenseInfoHeaderText) throws SW360Exception {
+        switch (getOutputVariant()) {
+            case DISCLOSURE:
+                return generateDisclosure(projectLicenseInfoResults, projectName + " " + projectVersion, licenseInfoHeaderText);
+            default:
+                throw new IllegalArgumentException("Unknown generator variant type: " + getOutputVariant());
+        }
+    }
+
+    private String generateDisclosure(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, String projectTitle, String licenseInfoHeaderText) {
         try {
-            return renderTemplateWithDefaultValues(projectLicenseInfoResults, LICENSE_INFO_TEMPLATE_FILE, licenseInfoHeaderText);
+            return renderTemplateWithDefaultValues(projectLicenseInfoResults, TXT_TEMPLATE_FILE, projectTitle, licenseInfoHeaderText);
         } catch (Exception e) {
-            LOGGER.error("Could not generate text licenseinfo file for project " + projectName, e);
+            LOGGER.error("Could not generate text licenseinfo file for project " + projectTitle, e);
             return "License information could not be generated.\nAn exception occurred: " + e.toString();
         }
     }

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
@@ -17,23 +17,36 @@ import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant;
 
 import java.util.Collection;
 
 public class XhtmlGenerator extends OutputGenerator<String> {
     private static final Logger LOGGER = Logger.getLogger(XhtmlGenerator.class);
-    private static final String XHTML_TEMPLATE_FILE = "xhtmlLicenseInfoFile.vm";
 
-    public XhtmlGenerator() {
-        super("html", "License information as XHTML", false, "application/xhtml+xml");
+    private static final String XHTML_TEMPLATE_FILE = "xhtmlLicenseInfoFile.vm";
+    private static final String XHTML_MIME_TYPE = "application/xhtml+xml";
+    private static final String XHTML_OUTPUT_TYPE = "html";
+
+    public XhtmlGenerator(OutputFormatVariant outputFormatVariant, String description) {
+        super(XHTML_OUTPUT_TYPE, description, false, XHTML_MIME_TYPE, outputFormatVariant);
     }
 
     @Override
     public String generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, String projectName, String projectVersion, String licenseInfoHeaderText) throws SW360Exception {
+        switch (getOutputVariant()) {
+            case DISCLOSURE:
+                return generateDisclosure(projectLicenseInfoResults, projectName + " " + projectVersion, licenseInfoHeaderText);
+            default:
+                throw new IllegalArgumentException("Unknown generator variant type: " + getOutputVariant());
+        }
+    }
+
+    private String generateDisclosure(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, String projectTitle, String licenseInfoHeaderText) {
         try {
-            return renderTemplateWithDefaultValues(projectLicenseInfoResults, XHTML_TEMPLATE_FILE, convertHeaderTextToHTML(licenseInfoHeaderText));
+            return renderTemplateWithDefaultValues(projectLicenseInfoResults, XHTML_TEMPLATE_FILE, projectTitle, convertHeaderTextToHTML(licenseInfoHeaderText));
         } catch (Exception e) {
-            LOGGER.error("Could not generate xhtml license info file for project " + projectName, e);
+            LOGGER.error("Could not generate xhtml license info file for project " + projectTitle, e);
             return "License information could not be generated.\nAn exception occured: " + e.toString();
         }
     }

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -51,7 +51,9 @@ public abstract class AbstractCLIParser extends LicenseInfoParser {
     private static final String LICENSE_ACKNOWLEDGEMENTS_ELEMENT_NAME = "Acknowledgements";
     protected static final String XML_FILE_EXTENSION = ".xml";
     private static final String LICENSENAME_ATTRIBUTE_NAME = "name";
+    private static final String SPDX_IDENTIFIER_ATTRIBUTE_NAME = "spdxidentifier";
     private static final String LICENSE_NAME_UNKNOWN = "License name unknown";
+    private static final String SPDX_IDENTIFIER_UNKNOWN = "SPDX identifier unknown";
     private static final Logger log = Logger.getLogger(CLIParser.class);
 
     public AbstractCLIParser(AttachmentConnector attachmentConnector, AttachmentContentProvider attachmentContentProvider) {
@@ -139,7 +141,10 @@ public abstract class AbstractCLIParser extends LicenseInfoParser {
                         .orElse(null))
                 .setLicenseName(findNamedAttribute(node, LICENSENAME_ATTRIBUTE_NAME)
                         .map(Node::getNodeValue)
-                        .orElse(LICENSE_NAME_UNKNOWN));
+                        .orElse(LICENSE_NAME_UNKNOWN))
+                .setLicenseSpdxId(findNamedAttribute(node, SPDX_IDENTIFIER_ATTRIBUTE_NAME)
+                        .map(Node::getNodeValue)
+                        .orElse(SPDX_IDENTIFIER_UNKNOWN));
     }
 
     protected class NodeListIterator implements Iterator<Node> {

--- a/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
+++ b/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
@@ -2,6 +2,9 @@
 ## terms and conditions of the Eclipse Distribution License v1.0 which
 ## accompanies this distribution, and is available at
 ## http://www.eclipse.org/org/documents/edl-v10.php
+$projectTitle
+
+
 Open Source Software
 ====================
 $licenseInfoHeader

--- a/backend/src/src-licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
+++ b/backend/src/src-licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
@@ -71,7 +71,8 @@
     </title>
 </head>
 <body>
-    <h1>Open Source Software</h1>
+    <h1>$projectTitle</h1>
+    <h2>Open Source Software</h2>
     $licenseInfoHeader
 
     <h2 id="releaseHeader">Releases</h2>

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
@@ -12,10 +12,7 @@
  */
 package org.eclipse.sw360.licenseinfo.outputGenerators;
 
-import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
-import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
-import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
-import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.*;
 import org.dom4j.Document;
 import org.dom4j.Element;
 import org.dom4j.Text;
@@ -125,7 +122,7 @@ public class XhtmlGeneratorTest {
         LicenseInfoParsingResult lipresultEmpty = generateLIPResult(liEmpty, releaseName, version1, vendorName);
         lipresultsEmpty = Collections.singletonList(lipresultEmpty);
 
-        xhtmlGenerator = new XhtmlGenerator();
+        xhtmlGenerator = new XhtmlGenerator(OutputFormatVariant.DISCLOSURE, "License Disclosure as XHTML");
 
         xmlString = xhtmlGenerator.generateOutputFile(lipresults, "myproject", "1.0", "Lorem Ipsum");
         xmlString2 = xhtmlGenerator.generateOutputFile(lipresults2, "myproject", "1.0", "Lorem Ipsum");

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -164,7 +164,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
     private void downloadLicenseInfo(ResourceRequest request, ResourceResponse response) throws IOException {
         final User user = UserCacheHolder.getUserFromRequest(request);
         final String projectId = request.getParameter(PROJECT_ID);
-        final String generatorClassName = request.getParameter(PortalConstants.LICENSE_INFO_SELECTED_OUTPUT_FORMAT);
+        final String outputGenerator = request.getParameter(PortalConstants.LICENSE_INFO_SELECTED_OUTPUT_FORMAT);
         final Map<String, Set<String>> selectedReleaseAndAttachmentIds = ProjectPortletUtils
                 .getSelectedReleaseAndAttachmentIdsFromRequest(request);
         final Set<String> attachmentIds = selectedReleaseAndAttachmentIds.values().stream().flatMap(Collection::stream)
@@ -177,7 +177,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             final ProjectService.Iface projectClient = thriftClients.makeProjectClient();
 
             Project project = projectClient.getProjectById(projectId, user);
-            LicenseInfoFile licenseInfoFile = licenseInfoClient.getLicenseInfoFile(project, user, generatorClassName,
+            LicenseInfoFile licenseInfoFile = licenseInfoClient.getLicenseInfoFile(project, user, outputGenerator,
                     selectedReleaseAndAttachmentIds, excludedLicensesPerAttachmentId);
             try {
                 replaceAttachmentUsages(user, selectedReleaseAndAttachmentIds, excludedLicensesPerAttachmentId, project);
@@ -196,7 +196,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
 
             PortletResponseUtil.sendFile(request, response, filename, licenseInfoFile.getGeneratedOutput(), mimetype);
         } catch (TException e) {
-            log.error("Error getting LicenseInfo file for project with id " + projectId + " and generator " + generatorClassName, e);
+            log.error("Error getting LicenseInfo file for project with id " + projectId + " and generator " + outputGenerator, e);
             response.setProperty(ResourceResponse.HTTP_STATUS_CODE, Integer.toString(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
         }
     }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayOutputFormats.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayOutputFormats.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Bosch Software Innovations GmbH, 2016.
+ * With modifications by Siemens AG, 2018.
  * Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
@@ -36,18 +37,19 @@ public class DisplayOutputFormats extends SimpleTagSupport {
     }
 
     public void doTag() throws JspException, IOException {
-            writeOptions(options);
+        writeOptions(options);
     }
 
     private void writeOptions(Collection<OutputFormatInfo> options) throws IOException {
         JspWriter jspWriter = getJspContext().getOut();
-        for (OutputFormatInfo outputOption : options) {
-            String formattedOutputOption = outputOption.getDescription();
+        for (OutputFormatInfo option : options) {
+            String optionDescription = option.getDescription();
+            String optionValue = option.getGeneratorClassName() + "::" + option.getVariant();
             jspWriter.write(String.format(
                     "<option value=\"%s\" class=\"textlabel stackedLabel\" \" +\n" +
                             "                            (selected ? \"selected=\\\"selected\\\" \" : \"\") +\n" +
                             "                            \">%s</option>",
-                    outputOption.getGeneratorClassName(), formattedOutputOption));
+                    optionValue, optionDescription));
         }
     }
 }

--- a/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2016-2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2016-2018. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
  * SPDX-License-Identifier: EPL-1.0
@@ -27,12 +27,18 @@ enum LicenseInfoRequestStatus{
     FAILURE = 2,
 }
 
+enum OutputFormatVariant{
+    REPORT = 0,
+    DISCLOSURE = 1,
+}
+
 struct OutputFormatInfo {
     1: optional string fileExtension,
     2: optional string description,
     3: optional string generatorClassName,
     4: bool isOutputBinary,
     5: optional string mimeType,
+    6: optional OutputFormatVariant variant,
 }
 
 struct LicenseNameWithText {
@@ -40,6 +46,7 @@ struct LicenseNameWithText {
     2: optional string licenseText,
     /* 3: optional i32 id, removed since only used as counter in XhtmlGenerator */
     4: optional string acknowledgements,
+    5: optional string licenseSpdxId,
 }
 
 struct LicenseInfo {


### PR DESCRIPTION
this PR supports to generate different output variants for the DOCX generator
- disclosure license info file
- report license info file (contains sw360 license todos)
- add project title (project name and version) to text/xhtml generator

![licenseinfo-generators](https://user-images.githubusercontent.com/29916928/36683663-0c52d024-1b16-11e8-911f-338ff3809102.jpg)

