### PR TITLE
feat(rest): list all transitive releases for a specific project

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -14,6 +14,7 @@ package org.eclipse.sw360.rest.resourceserver.attachment;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -52,40 +53,32 @@ public class AttachmentController implements ResourceProcessor<RepositoryLinksRe
     @RequestMapping(value = ATTACHMENTS_URL, params = "sha1", method = RequestMethod.GET)
     public ResponseEntity<Resource<Attachment>> getAttachmentForSha1(
             OAuth2Authentication oAuth2Authentication,
-            @RequestParam String sha1) {
-        try {
-            User sw360User = restControllerHelper.getSw360UserFromAuthentication(oAuth2Authentication);
-            AttachmentInfo attachmentInfo = attachmentService.getAttachmentBySha1ForUser(sha1, sw360User);
-            HalResource<Attachment> attachmentResource =
-                    createHalAttachment(
-                            attachmentInfo.getAttachment(),
-                            attachmentInfo.getRelease(),
-                            sw360User);
-            return new ResponseEntity<>(attachmentResource, HttpStatus.OK);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-        }
-        return null;
+            @RequestParam String sha1) throws TException {
+
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication(oAuth2Authentication);
+        AttachmentInfo attachmentInfo = attachmentService.getAttachmentBySha1ForUser(sha1, sw360User);
+        HalResource<Attachment> attachmentResource =
+                createHalAttachment(
+                        attachmentInfo.getAttachment(),
+                        attachmentInfo.getRelease(),
+                        sw360User);
+        return new ResponseEntity<>(attachmentResource, HttpStatus.OK);
     }
 
     @RequestMapping(value = ATTACHMENTS_URL + "/{id}", method = RequestMethod.GET)
     public ResponseEntity<Resource<Attachment>> getAttachmentForId(
             @PathVariable("id") String id,
-            OAuth2Authentication oAuth2Authentication) {
-        try {
-            User sw360User = restControllerHelper.getSw360UserFromAuthentication(oAuth2Authentication);
-            AttachmentInfo attachmentInfo =
-                    attachmentService.getAttachmentByIdForUser(id, sw360User);
+            OAuth2Authentication oAuth2Authentication) throws TException {
 
-            HalResource<Attachment> attachmentResource =
-                    createHalAttachment(attachmentInfo.getAttachment(),
-                            attachmentInfo.getRelease(),
-                            sw360User);
-            return new ResponseEntity<>(attachmentResource, HttpStatus.OK);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-        }
-        return null;
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication(oAuth2Authentication);
+        AttachmentInfo attachmentInfo =
+                attachmentService.getAttachmentByIdForUser(id, sw360User);
+
+        HalResource<Attachment> attachmentResource =
+                createHalAttachment(attachmentInfo.getAttachment(),
+                        attachmentInfo.getRelease(),
+                        sw360User);
+        return new ResponseEntity<>(attachmentResource, HttpStatus.OK);
     }
 
     private HalResource<Attachment> createHalAttachment(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -36,42 +36,34 @@ public class Sw360AttachmentService {
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;
 
-    public AttachmentInfo getAttachmentBySha1ForUser(String sha1, User sw360User) {
-        try {
-            ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-            List<Release> releases = sw360ComponentClient.getReleaseSummary(sw360User);
-            for (Release release : releases) {
-                final Set<Attachment> attachments = release.getAttachments();
-                if (attachments != null && attachments.size() > 0) {
-                    for (Attachment attachment : attachments) {
-                        if (sha1.equals(attachment.getSha1())) {
-                            return new AttachmentInfo(attachment, release);
-                        }
+    public AttachmentInfo getAttachmentBySha1ForUser(String sha1, User sw360User) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        List<Release> releases = sw360ComponentClient.getReleaseSummary(sw360User);
+        for (Release release : releases) {
+            final Set<Attachment> attachments = release.getAttachments();
+            if (attachments != null && attachments.size() > 0) {
+                for (Attachment attachment : attachments) {
+                    if (sha1.equals(attachment.getSha1())) {
+                        return new AttachmentInfo(attachment, release);
                     }
                 }
             }
-        } catch (TException e) {
-            log.error("Cannot get attachment from sw360 with sha1: " + sha1);
         }
         return null;
     }
 
-    public AttachmentInfo getAttachmentByIdForUser(String id, User sw360User) {
-        try {
-            ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-            List<Release> releases = sw360ComponentClient.getReleaseSummary(sw360User);
-            for (Release release : releases) {
-                final Set<Attachment> attachments = release.getAttachments();
-                if (attachments != null && attachments.size() > 0) {
-                    for (Attachment attachment : attachments) {
-                        if (id.equals(attachment.getAttachmentContentId())) {
-                            return new AttachmentInfo(attachment, release);
-                        }
+    public AttachmentInfo getAttachmentByIdForUser(String id, User sw360User) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        List<Release> releases = sw360ComponentClient.getReleaseSummary(sw360User);
+        for (Release release : releases) {
+            final Set<Attachment> attachments = release.getAttachments();
+            if (attachments != null && attachments.size() > 0) {
+                for (Attachment attachment : attachments) {
+                    if (id.equals(attachment.getAttachmentContentId())) {
+                        return new AttachmentInfo(attachment, release);
                     }
                 }
             }
-        } catch (TException e) {
-            log.error("Cannot get attachment from sw360 with id: " + id);
         }
         return null;
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -16,6 +16,7 @@ package org.eclipse.sw360.rest.resourceserver.component;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -64,7 +65,7 @@ public class ComponentController implements ResourceProcessor<RepositoryLinksRes
     @RequestMapping(value = COMPONENTS_URL, method = RequestMethod.GET)
     public ResponseEntity<Resources<Resource<Component>>> getComponents(@RequestParam(value = "name", required = false) String name,
                                                                         @RequestParam(value = "type", required = false) String componentType,
-                                                                        OAuth2Authentication oAuth2Authentication) {
+                                                                        OAuth2Authentication oAuth2Authentication) throws TException {
 
         User sw360User = restControllerHelper.getSw360UserFromAuthentication(oAuth2Authentication);
         List<Component> sw360Components = new ArrayList<>();
@@ -92,7 +93,7 @@ public class ComponentController implements ResourceProcessor<RepositoryLinksRes
 
     @RequestMapping(value = COMPONENTS_URL + "/{id}", method = RequestMethod.GET)
     public ResponseEntity<Resource<Component>> getComponent(
-            @PathVariable("id") String id, OAuth2Authentication oAuth2Authentication) {
+            @PathVariable("id") String id, OAuth2Authentication oAuth2Authentication) throws TException {
         User user = restControllerHelper.getSw360UserFromAuthentication(oAuth2Authentication);
         Component sw360Component = componentService.getComponentForUserById(id, user);
         HalResource<Component> userHalResource = createHalComponent(sw360Component, user);
@@ -103,7 +104,7 @@ public class ComponentController implements ResourceProcessor<RepositoryLinksRes
     @RequestMapping(value = COMPONENTS_URL, method = RequestMethod.POST)
     public ResponseEntity<Resource<Component>> createComponent(
             OAuth2Authentication oAuth2Authentication,
-            @RequestBody Component component) throws URISyntaxException {
+            @RequestBody Component component) throws URISyntaxException, TException {
 
         User user = restControllerHelper.getSw360UserFromAuthentication(oAuth2Authentication);
 
@@ -136,7 +137,7 @@ public class ComponentController implements ResourceProcessor<RepositoryLinksRes
         return resource;
     }
 
-    private HalResource<Component> createHalComponent(Component sw360Component, User user) {
+    private HalResource<Component> createHalComponent(Component sw360Component, User user) throws TException {
         HalResource<Component> halComponent = new HalResource<>(sw360Component);
 
         if (sw360Component.getReleaseIds() != null) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017.
+ * Copyright Siemens AG, 2017-2018.
  * Copyright Bosch Software Innovations GmbH, 2017.
  * Part of the SW360 Portal Project.
  *
@@ -37,47 +37,31 @@ public class Sw360ComponentService {
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;
 
-    public List<Component> getComponentsForUser(User sw360User) {
-        try {
-            ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-            return sw360ComponentClient.getComponentSummary(sw360User);
-        } catch (TException e) {
-            throw new RuntimeException(e);
-        }
+    public List<Component> getComponentsForUser(User sw360User) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        return sw360ComponentClient.getComponentSummary(sw360User);
     }
 
-    public Component getComponentForUserById(String componentId, User sw360User) {
-        try {
-            ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-            return sw360ComponentClient.getComponentById(componentId, sw360User);
-        } catch (TException e) {
-            throw new RuntimeException(e);
-        }
+    public Component getComponentForUserById(String componentId, User sw360User) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        return sw360ComponentClient.getComponentById(componentId, sw360User);
     }
 
-    public Component createComponent(Component component, User sw360User) {
-        try {
-            ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-            AddDocumentRequestSummary documentRequestSummary = sw360ComponentClient.addComponent(component, sw360User);
-            if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.SUCCESS) {
-                component.setId(documentRequestSummary.getId());
-                return component;
-            } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE) {
-                throw new DataIntegrityViolationException("sw360 component with name '" + component.getName() + "' already exists.");
-            }
-        } catch (TException e) {
-            throw new RuntimeException(e);
+    public Component createComponent(Component component, User sw360User) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        AddDocumentRequestSummary documentRequestSummary = sw360ComponentClient.addComponent(component, sw360User);
+        if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.SUCCESS) {
+            component.setId(documentRequestSummary.getId());
+            return component;
+        } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE) {
+            throw new DataIntegrityViolationException("sw360 component with name '" + component.getName() + "' already exists.");
         }
         return null;
     }
 
-    public List<Component> searchComponentByName(String name) {
-        try {
-            ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-            return sw360ComponentClient.searchComponentForExport(name);
-        } catch (TException e) {
-            throw new RuntimeException(e);
-        }
+    public List<Component> searchComponentByName(String name) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        return sw360ComponentClient.searchComponentForExport(name);
     }
 
     private ComponentService.Iface getThriftComponentClient() throws TTransportException {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -14,6 +14,7 @@ package org.eclipse.sw360.rest.resourceserver.core;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
@@ -75,8 +76,12 @@ public class RestControllerHelper {
             User user,
             String linkRelation) {
         for (String releaseId : releases) {
-            final Release release = sw360ReleaseService.getReleaseForUserById(releaseId, user);
-            addEmbeddedRelease(halResource, release, linkRelation);
+            try {
+                final Release release = sw360ReleaseService.getReleaseForUserById(releaseId, user);
+                addEmbeddedRelease(halResource, release, linkRelation);
+            } catch (TException e) {
+                log.error("cannot create embedded releases");
+            }
         }
     }
 
@@ -110,7 +115,6 @@ public class RestControllerHelper {
             HalResource<Vendor> vendorHalResource = addEmbeddedVendor(vendorFullName);
             halComponent.addEmbeddedResource("vendors", vendorHalResource);
         }
-
     }
 
     private HalResource<Vendor> addEmbeddedVendor(String vendorFullName) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -14,6 +14,7 @@ package org.eclipse.sw360.rest.resourceserver.core;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import org.apache.thrift.TException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -31,33 +32,33 @@ import java.time.Instant;
 @ControllerAdvice
 public class RestExceptionHandler {
 
-    @ExceptionHandler(Exception.class)
+    @ExceptionHandler({Exception.class, TException.class})
     public ResponseEntity<ErrorMessage> handleException(Exception e) {
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.INTERNAL_SERVER_ERROR), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ErrorMessage> handleAccessDeniedException(Exception e) {
+    public ResponseEntity<ErrorMessage> handleAccessDeniedException(AccessDeniedException e) {
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.FORBIDDEN), HttpStatus.FORBIDDEN);
     }
 
     @ExceptionHandler(ResourceNotFoundException.class)
-    public ResponseEntity<ErrorMessage> handleResourceNotFound(Exception e) {
+    public ResponseEntity<ErrorMessage> handleResourceNotFound(ResourceNotFoundException e) {
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.NOT_FOUND), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ErrorMessage> handleMessageNotReadableException(Exception e) {
+    public ResponseEntity<ErrorMessage> handleMessageNotReadableException(HttpMessageNotReadableException e) {
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.BAD_REQUEST), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ResponseEntity<ErrorMessage> handleRequestMethodNotSupported(Exception e) {
+    public ResponseEntity<ErrorMessage> handleRequestMethodNotSupported(HttpRequestMethodNotSupportedException e) {
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.METHOD_NOT_ALLOWED), HttpStatus.METHOD_NOT_ALLOWED);
     }
 
     @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
-    public ResponseEntity<ErrorMessage> handleMediaTypeNotSupportedException(Exception e) {
+    public ResponseEntity<ErrorMessage> handleMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException e) {
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.UNSUPPORTED_MEDIA_TYPE), HttpStatus.UNSUPPORTED_MEDIA_TYPE);
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017.
+ * Copyright Siemens AG, 2017-2018.
  * Copyright Bosch Software Innovations GmbH, 2017.
  * Part of the SW360 Portal Project.
  *
@@ -10,11 +10,13 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
+
 package org.eclipse.sw360.rest.resourceserver.license;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
@@ -55,7 +57,7 @@ public class LicenseController implements ResourceProcessor<RepositoryLinksResou
     private final RestControllerHelper restControllerHelper;
 
     @RequestMapping(value = LICENSES_URL, method = RequestMethod.GET)
-    public ResponseEntity<Resources<Resource<License>>> getLicenses(OAuth2Authentication oAuth2Authentication) {
+    public ResponseEntity<Resources<Resource<License>>> getLicenses(OAuth2Authentication oAuth2Authentication) throws TException {
         List<License> licenses = licenseService.getLicenses();
 
         List<Resource<License>> licenseResources = new ArrayList<>();
@@ -76,7 +78,7 @@ public class LicenseController implements ResourceProcessor<RepositoryLinksResou
 
     @RequestMapping(value = LICENSES_URL + "/{id:.+}", method = RequestMethod.GET)
     public ResponseEntity<Resource<License>> getLicense(
-            @PathVariable("id") String id, OAuth2Authentication oAuth2Authentication) {
+            @PathVariable("id") String id, OAuth2Authentication oAuth2Authentication) throws TException {
         License sw360License = licenseService.getLicenseById(id);
         HalResource<License> licenseHalResource = createHalLicense(sw360License);
         return new ResponseEntity<>(licenseHalResource, HttpStatus.OK);
@@ -86,7 +88,7 @@ public class LicenseController implements ResourceProcessor<RepositoryLinksResou
     @RequestMapping(value = LICENSES_URL, method = RequestMethod.POST)
     public ResponseEntity<Resource<License>> createLicense(
             OAuth2Authentication oAuth2Authentication,
-            @RequestBody License license) throws URISyntaxException {
+            @RequestBody License license) throws URISyntaxException, TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication(oAuth2Authentication);
         license = licenseService.createLicense(license, sw360User);
         HalResource<License> halResource = createHalLicense(license);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -33,38 +33,26 @@ public class Sw360LicenseService {
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;
 
-    public List<License> getLicenses() {
-        try {
-            LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
-            return sw360LicenseClient.getLicenseSummary();
-        } catch (TException e) {
-            throw new RuntimeException(e);
-        }
+    public List<License> getLicenses() throws TException {
+        LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
+        return sw360LicenseClient.getLicenseSummary();
     }
 
-    public License getLicenseById(String licenseId) {
-        try {
-            LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
-            // TODO Kai Tödter 2017-01-26
-            // What is the semantics of the second parameter (organization)?
-            return sw360LicenseClient.getByID(licenseId, "?");
-        } catch (TException e) {
-            throw new RuntimeException(e);
-        }
+    public License getLicenseById(String licenseId) throws TException {
+        LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
+        // TODO Kai Tödter 2017-01-26
+        // What is the semantics of the second parameter (organization)?
+        return sw360LicenseClient.getByID(licenseId, "?");
     }
 
-    public License createLicense(License license, User sw360User) {
-        try {
-            LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
-            license.setId(license.getShortname());
-            List<License> licenses = sw360LicenseClient.addLicenses(Collections.singletonList(license), sw360User);
-            for(License newlicense: licenses) {
-                if(license.getFullname().equals(newlicense.getFullname())) {
-                    return  newlicense;
-                }
+    public License createLicense(License license, User sw360User) throws TException {
+        LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
+        license.setId(license.getShortname());
+        List<License> licenses = sw360LicenseClient.addLicenses(Collections.singletonList(license), sw360User);
+        for (License newLicense : licenses) {
+            if (license.getFullname().equals(newLicense.getFullname())) {
+                return newLicense;
             }
-        } catch (TException e) {
-            throw new RuntimeException(e);
         }
         return null;
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017.
+ * Copyright Siemens AG, 2017-2018.
  * Copyright Bosch Software Innovations GmbH, 2017.
  * Part of the SW360 Portal Project.
  *
@@ -23,6 +23,7 @@ import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -32,6 +33,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -40,84 +43,67 @@ public class Sw360ProjectService {
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;
 
-    public List<Project> getProjectsForUser(User sw360User) {
-        try {
-            ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-            return sw360ProjectClient.getAccessibleProjectsSummary(sw360User);
-        } catch (TException e) {
-            throw new RuntimeException(e);
-        }
+    public List<Project> getProjectsForUser(User sw360User) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        return sw360ProjectClient.getAccessibleProjectsSummary(sw360User);
     }
 
-    public Project getProjectForUserById(String projectId, User sw360User) {
-        try {
-            ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-            return sw360ProjectClient.getProjectById(projectId, sw360User);
-        } catch (TException e) {
-            throw new RuntimeException(e);
-        }
+    public Project getProjectForUserById(String projectId, User sw360User) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        return sw360ProjectClient.getProjectById(projectId, sw360User);
     }
 
-    public Project createProject(Project project, User sw360User) {
-        try {
-            ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-            AddDocumentRequestSummary documentRequestSummary = sw360ProjectClient.addProject(project, sw360User);
-            if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.SUCCESS) {
-                project.setId(documentRequestSummary.getId());
-                return project;
-            } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE) {
-                throw new DataIntegrityViolationException("sw360 project with name '" + project.getName() + "' already exists.");
-            }
-        } catch (TException e) {
-            throw new RuntimeException(e);
+    public Project createProject(Project project, User sw360User) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        AddDocumentRequestSummary documentRequestSummary = sw360ProjectClient.addProject(project, sw360User);
+        if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.SUCCESS) {
+            project.setId(documentRequestSummary.getId());
+            return project;
+        } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE) {
+            throw new DataIntegrityViolationException("sw360 project with name '" + project.getName() + "' already exists.");
         }
         return null;
     }
 
-    public RequestStatus updateProject(Project project, User sw360User) {
-        try {
-            ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-            RequestStatus requestStatus = sw360ProjectClient.updateProject(project, sw360User);
-            if (requestStatus != RequestStatus.SUCCESS) {
-                throw new RuntimeException("sw360 project with name '" + project.getName() + " cannot be updated.");
-            }
-            return requestStatus;
-        } catch (TException e) {
-            throw new RuntimeException(e);
+    public RequestStatus updateProject(Project project, User sw360User) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        RequestStatus requestStatus = sw360ProjectClient.updateProject(project, sw360User);
+        if (requestStatus != RequestStatus.SUCCESS) {
+            throw new RuntimeException("sw360 project with name '" + project.getName() + " cannot be updated.");
+        }
+        return requestStatus;
+    }
+
+    public RequestStatus deleteProject(Project project, User sw360User) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        RequestStatus requestStatus = sw360ProjectClient.deleteProject(project.getId(), sw360User);
+        if (requestStatus != RequestStatus.SUCCESS) {
+            throw new RuntimeException("sw360 project with name '" + project.getName() + " cannot be deleted.");
+        }
+        return requestStatus;
+    }
+
+    public void deleteAllProjects(User sw360User) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        List<Project> projects = sw360ProjectClient.getAccessibleProjectsSummary(sw360User);
+        for (Project project : projects) {
+            sw360ProjectClient.deleteProject(project.getId(), sw360User);
         }
     }
 
-    public RequestStatus deleteProject(Project project, User sw360User) {
-        try {
-            ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-            RequestStatus requestStatus = sw360ProjectClient.deleteProject(project.getId(), sw360User);
-            if (requestStatus != RequestStatus.SUCCESS) {
-                throw new RuntimeException("sw360 project with name '" + project.getName() + " cannot be deleted.");
-            }
-            return requestStatus;
-        } catch (TException e) {
-            throw new RuntimeException(e);
-        }
+    public List<Project> searchProjectByName(String name, User sw360User) throws TException {
+        final ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        return sw360ProjectClient.searchByName(name, sw360User);
     }
 
-    public void deleteAllProjects(User sw360User) {
-        try {
-            ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-            List<Project> projects = sw360ProjectClient.getAccessibleProjectsSummary(sw360User);
-            for(Project project: projects) {
-                sw360ProjectClient.deleteProject(project.getId(), sw360User);
-            }
-        } catch (TException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public List<Project> searchProjectByName(String name, User sw360User) {
-        try {
-            final ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-            return sw360ProjectClient.searchByName(name, sw360User);
-        } catch (final TException e) {
-            throw new RuntimeException(e);
+    public Set<String> getReleaseIds(String projectId, User sw360User, String transitive) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        if (Boolean.parseBoolean(transitive)) {
+            List<ReleaseClearingStatusData> releaseClearingStatusData = sw360ProjectClient.getReleaseClearingStatuses(projectId, sw360User);
+            return releaseClearingStatusData.stream().map(r -> r.release.getId()).collect(Collectors.toSet());
+        } else {
+            final Project project = getProjectForUserById(projectId, sw360User);
+            return project.getReleaseIdToUsage().keySet();
         }
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017.
+ * Copyright Siemens AG, 2017-2018.
  * Copyright Bosch Software Innovations GmbH, 2017.
  * Part of the SW360 Portal Project.
  *
@@ -10,6 +10,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
+
 package org.eclipse.sw360.rest.resourceserver.release;
 
 import lombok.RequiredArgsConstructor;
@@ -39,36 +40,24 @@ public class Sw360ReleaseService {
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;
 
-    public List<Release> getReleasesForUser(User sw360User) {
-        try {
-            ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-            return sw360ComponentClient.getReleaseSummary(sw360User);
-        } catch (TException e) {
-            throw new RuntimeException(e);
-        }
+    public List<Release> getReleasesForUser(User sw360User) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        return sw360ComponentClient.getReleaseSummary(sw360User);
     }
 
-    public Release getReleaseForUserById(String releaseId, User sw360User) {
-        try {
-            ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-            return sw360ComponentClient.getReleaseById(releaseId, sw360User);
-        } catch (TException e) {
-            throw new RuntimeException(e);
-        }
+    public Release getReleaseForUserById(String releaseId, User sw360User) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        return sw360ComponentClient.getReleaseById(releaseId, sw360User);
     }
 
-    public Release createRelease(Release release, User sw360User) {
-        try {
-            ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-            AddDocumentRequestSummary documentRequestSummary = sw360ComponentClient.addRelease(release, sw360User);
-            if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.SUCCESS) {
-                release.setId(documentRequestSummary.getId());
-                return release;
-            } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE) {
-                throw new DataIntegrityViolationException("sw360 release with name '" + release.getName() + "' already exists.");
-            }
-        } catch (TException e) {
-            throw new RuntimeException(e);
+    public Release createRelease(Release release, User sw360User) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        AddDocumentRequestSummary documentRequestSummary = sw360ComponentClient.addRelease(release, sw360User);
+        if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.SUCCESS) {
+            release.setId(documentRequestSummary.getId());
+            return release;
+        } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE) {
+            throw new DataIntegrityViolationException("sw360 release with name '" + release.getName() + "' already exists.");
         }
         return null;
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,6 +9,7 @@
 
 package org.eclipse.sw360.rest.resourceserver.integration;
 
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
@@ -21,7 +22,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.*;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
@@ -45,7 +45,7 @@ public class ComponentTest extends TestIntegrationBase {
     private Sw360ComponentService componentServiceMock;
 
     @Before
-    public void before() {
+    public void before() throws TException {
         List<Component> componentList = new ArrayList<>();
         Component component = new Component();
         component.setName("Component name");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,6 +9,7 @@
 
 package org.eclipse.sw360.rest.resourceserver.integration;
 
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
@@ -21,7 +22,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.*;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
@@ -45,7 +45,7 @@ public class ProjectTest extends TestIntegrationBase {
     private Sw360ProjectService projectServiceMock;
 
     @Before
-    public void before() {
+    public void before() throws TException {
         List<Project> projectList = new ArrayList<>();
         Project project = new Project();
         project.setName("Project name");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/TestIntegrationBase.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/TestIntegrationBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,14 +12,11 @@ package org.eclipse.sw360.rest.resourceserver.integration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer;
-import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/UserTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/UserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.*;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,6 +9,7 @@
 
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
 import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
@@ -61,7 +62,7 @@ public class AttachmentSpecTest extends TestRestDocsSpecBase {
     private Attachment attachment;
 
     @Before
-    public void before() {
+    public void before() throws TException {
         List<Attachment> attachmentList = new ArrayList<>();
         attachment = new Attachment();
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,6 +9,7 @@
 
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
@@ -54,7 +55,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
     private Sw360ComponentService componentServiceMock;
 
     @Before
-    public void before() {
+    public void before() throws TException {
         List<Component> componentList = new ArrayList<>();
         Component angularComponent = new Component();
         angularComponent.setId("17653524");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,6 +9,7 @@
 
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
@@ -48,7 +49,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
     private License license;
 
     @Before
-    public void before() {
+    public void before() throws TException {
         license = new License();
         license.setId("apache20");
         license.setFullname("Apache License 2.0");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,6 +9,7 @@
 
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectType;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -54,7 +55,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
     private Project project;
 
     @Before
-    public void before() {
+    public void before() throws TException {
         List<Project> projectList = new ArrayList<>();
         project = new Project();
         project.setId("376576");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,6 +9,7 @@
 
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
@@ -56,7 +57,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
     private Release release;
 
     @Before
-    public void before() {
+    public void before() throws TException {
         Component component = new Component();
         component.setId("17653524");
         component.setName("Angular");


### PR DESCRIPTION
New optional request parameter for project controller (transitive)


e.g. 
```
without request parameter / or false:
/resource/api/projects/123456/releases
/resource/api/projects/123456/releases/ecc
/resource/api/projects/123456/releases?transitive=false
/resource/api/projects/123456/releases?transitive=false/ecc
```
```
with request parameter: transitive
/resource/api/projects/123456/releases?transitive=true
/resource/api/projects/123456/releases?transitive=true/ecc
```

closes sw360/sw360portal#733