### PR TITLE
chore(ui): remove bracket at the end of a component name

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/components/detailRelease.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/detailRelease.jsp
@@ -59,7 +59,7 @@
     <script type="text/javascript" src="<%=request.getContextPath()%>/js/releaseTools.js"></script>
 
     <div id="header"></div>
-    <p class="pageHeader"><label id="releaseHeaderLabel"> <span class="pageHeaderBigSpan"> Component: <sw360:out value="${component.name}"/>}</span>
+    <p class="pageHeader"><label id="releaseHeaderLabel"><span class="pageHeaderBigSpan">Component: <sw360:out value="${component.name}"/></span>
         <select id="releaseSelect" onchange="this.options[this.selectedIndex].value
         && (window.location = createDetailURLfromReleaseId (this.options[this.selectedIndex].value) );">
             <core_rt:forEach var="releaseItr" items="${component.releases}">


### PR DESCRIPTION
- remove the bracket at the end of a component name (release summary)

closes sw360/sw360portal#752