### PR TITLE
feat(rest): add search parameter name, type and transitive to documentation

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/api-guide.adoc
+++ b/rest/resource-server/src/docs/asciidoc/api-guide.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+// Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
 //
 // All rights reserved. This configuration file is provided to you under the
 // terms and conditions of the Eclipse Distribution License v1.0 which
@@ -181,7 +181,7 @@ Token response elements
 |===
 
 [[token-jwt]]
-=== JSON Web Tokens (JWT.IO)
+=== JSON Web Tokens
 
 http://jwt.io[JWT.IO] allows you to decode and verify your sw360 authorization token.
 
@@ -265,4 +265,4 @@ include::releases.adoc[]
 include::attachments.adoc[]
 include::vendors.adoc[]
 include::licenses.adoc[]
-include::vulnerabilites.adoc[]
+include::vulnerabilities.adoc[]

--- a/rest/resource-server/src/docs/asciidoc/components.adoc
+++ b/rest/resource-server/src/docs/asciidoc/components.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+// Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
 //
 // All rights reserved. This configuration file is provided to you under the
 // terms and conditions of the Eclipse Distribution License v1.0 which
@@ -33,6 +33,49 @@ include::{snippets}/should_document_get_components/http-response.adoc[]
 ===== Links
 
 include::{snippets}/should_document_get_components/links.adoc[]
+
+[[resources-components-list-by-name]]
+==== Listing by name
+
+A `GET` request will list all of the service's components by component name.
+
+===== Response structure
+
+include::{snippets}/should_document_get_components_by_name/response-fields.adoc[]
+
+===== Example request
+
+include::{snippets}/should_document_get_components_by_name/curl-request.adoc[]
+
+===== Example response
+
+include::{snippets}/should_document_get_components_by_name/http-response.adoc[]
+
+===== Links
+
+include::{snippets}/should_document_get_components_by_name/links.adoc[]
+
+[[resources-components-list-by-type]]
+==== Listing by type
+
+A `GET` request will list all of the service's components by component type. +
+Component types = `{INTERNAL, OSS, COTS, FREESOFTWARE, INNER_SOURCE, SERVICE}`
+
+===== Response structure
+
+include::{snippets}/should_document_get_components_by_type/response-fields.adoc[]
+
+===== Example request
+
+include::{snippets}/should_document_get_components_by_type/curl-request.adoc[]
+
+===== Example response
+
+include::{snippets}/should_document_get_components_by_type/http-response.adoc[]
+
+===== Links
+
+include::{snippets}/should_document_get_components_by_type/links.adoc[]
 
 [[resources-component-get]]
 ==== Get a single component

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+// Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
 //
 // All rights reserved. This configuration file is provided to you under the
 // terms and conditions of the Eclipse Distribution License v1.0 which
@@ -34,6 +34,50 @@ include::{snippets}/should_document_get_projects/http-response.adoc[]
 
 include::{snippets}/should_document_get_projects/links.adoc[]
 
+[[resources-projects-list-by-name]]
+==== Listing by name
+
+A `GET` request will list all of the service's projects by project name.
+
+===== Response structure
+
+include::{snippets}/should_document_get_projects_by_name/response-fields.adoc[]
+
+===== Example request
+
+include::{snippets}/should_document_get_projects_by_name/curl-request.adoc[]
+
+===== Example response
+
+include::{snippets}/should_document_get_projects_by_name/http-response.adoc[]
+
+===== Links
+
+include::{snippets}/should_document_get_projects_by_name/links.adoc[]
+
+[[resources-projects-list-by-type]]
+==== Listing by type
+
+A `GET` request will list all of the service's projects by project type. +
+Project types = `{CUSTOMER, INTERNAL, PRODUCT, SERVICE, INNER_SOURCE}`
+
+===== Response structure
+
+include::{snippets}/should_document_get_projects_by_type/response-fields.adoc[]
+
+===== Example request
+
+include::{snippets}/should_document_get_projects_by_type/curl-request.adoc[]
+
+===== Example response
+
+include::{snippets}/should_document_get_projects_by_type/http-response.adoc[]
+
+===== Links
+
+include::{snippets}/should_document_get_projects_by_type/links.adoc[]
+
+
 [[resources-project-get]]
 ==== Get a single project
 
@@ -55,6 +99,71 @@ include::{snippets}/should_document_get_project/http-response.adoc[]
 
 include::{snippets}/should_document_get_project/links.adoc[]
 
+[[resources-project-get-project-releases]]
+==== Listing releases
+
+A `GET` request will get releases of a single project. +
+Only linked releases without any releases of sub-projects (&transitive=false).
+
+===== Response structure
+
+include::{snippets}/should_document_get_project_releases/response-fields.adoc[]
+
+===== Example request
+
+include::{snippets}/should_document_get_project_releases/curl-request.adoc[]
+
+===== Example response
+
+include::{snippets}/should_document_get_project_releases/http-response.adoc[]
+
+===== Links
+
+include::{snippets}/should_document_get_project_releases/links.adoc[]
+
+[[resources-project-get-project-releases-transitive]]
+==== Listing releases (transitive)
+
+A `GET` request will get all releases of a single project (transitive). +
+Please set the request parameter (&transitive=true).
+
+===== Response structure
+
+include::{snippets}/should_document_get_project_releases_transitive/response-fields.adoc[]
+
+===== Example request
+
+include::{snippets}/should_document_get_project_releases_transitive/curl-request.adoc[]
+
+===== Example response
+
+include::{snippets}/should_document_get_project_releases_transitive/http-response.adoc[]
+
+===== Links
+
+include::{snippets}/should_document_get_project_releases_transitive/links.adoc[]
+
+[[resources-project-get-project-releases-ecc-information]]
+==== Listing releases with ECC
+
+A `GET` request will get all releases with ECC information of a single project.
+This works also with the transitive request parameter (&transitive=true)
+
+===== Response structure
+
+include::{snippets}/should_document_get_project_releases_ecc_information/response-fields.adoc[]
+
+===== Example request
+
+include::{snippets}/should_document_get_project_releases_ecc_information/curl-request.adoc[]
+
+===== Example response
+
+include::{snippets}/should_document_get_project_releases_ecc_information/http-response.adoc[]
+
+===== Links
+
+include::{snippets}/should_document_get_project_releases_ecc_information/links.adoc[]
 
 ////
 [[resources-projects-create]]
@@ -74,4 +183,3 @@ include::{snippets}/should_document_create_project/curl-request.adoc[]
 
 include::{snippets}/should_document_create_project/http-response.adoc[]
 ////
-

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -84,6 +84,7 @@ public class ComponentController implements ResourceProcessor<RepositoryLinksRes
                     c.setCreatedOn(null);
                     c.setVendorNames(null);
                     c.setReleaseIds(null);
+                    c.setComponentOwner(null);
                     componentResources.add(new Resource<>(c));
                 });
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -79,6 +79,9 @@ public class ReleaseController implements ResourceProcessor<RepositoryLinksResou
             release.setReleaseDate(null);
             release.setVendor(null);
             release.setMainLicenseIds(null);
+            release.setExternalIds(null);
+            release.setCreatedOn(null);
+            release.setCpeid(null);
             Resource<Release> releaseResource = new Resource<>(release);
             releaseResources.add(releaseResource);
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Bosch Software Innovations GmbH, 2017.
+ * With modifications by Siemens AG, 2018.
  * Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
@@ -11,24 +12,13 @@
  */
 package org.eclipse.sw360.rest.resourceserver.vulnerability;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.eclipse.sw360.datahandler.common.SW360Constants;
-import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
-import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
-import org.eclipse.sw360.datahandler.thrift.components.Component;
-import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.eclipse.sw360.rest.resourceserver.project.ProjectController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -41,9 +31,10 @@ import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
 @BasePathAwareController
 @Slf4j
@@ -64,6 +55,9 @@ public class VulnerabilityController implements ResourceProcessor<RepositoryLink
 
         List<Resource<Vulnerability>> vulnerabilityResources = new ArrayList<>();
         for (Vulnerability vulnerability : vulnerabilities) {
+            vulnerability.setCwe(null);
+            vulnerability.setId(null);
+            vulnerability.setExternalId(null);
             Resource<Vulnerability> vulnerabilityResource = new Resource<>(vulnerability);
             vulnerabilityResources.add(vulnerabilityResource);
         }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -10,11 +10,18 @@
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
+import org.eclipse.sw360.datahandler.thrift.components.ECCStatus;
+import org.eclipse.sw360.datahandler.thrift.components.EccInformation;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectType;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
+import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,11 +29,12 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.hateoas.MediaTypes;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.*;
 
+import static org.eclipse.sw360.datahandler.thrift.MainlineState.MAINLINE;
+import static org.eclipse.sw360.datahandler.thrift.ReleaseRelationship.CONTAINED;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
@@ -52,10 +60,18 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
     @MockBean
     private Sw360ProjectService projectServiceMock;
 
+    @MockBean
+    private Sw360ReleaseService releaseServiceMock;
+
     private Project project;
 
     @Before
     public void before() throws TException {
+
+        Map<String, ProjectReleaseRelationship> linkedReleases = new HashMap<>();
+        Map<String, ProjectRelationship> linkedProjects = new HashMap<>();
+        ProjectReleaseRelationship projectReleaseRelationship = new ProjectReleaseRelationship(CONTAINED, MAINLINE);
+
         List<Project> projectList = new ArrayList<>();
         project = new Project();
         project.setId("376576");
@@ -72,10 +88,14 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         project.setOwnerAccountingUnit("4822");
         project.setOwnerCountry("DE");
         project.setOwnerGroup("AA BB 123 GHV2-DE");
+        linkedReleases.put("3765276512", projectReleaseRelationship);
+        project.setReleaseIdToUsage(linkedReleases);
+        linkedProjects.put("376576", ProjectRelationship.CONTAINED);
+        project.setLinkedProjects(linkedProjects);
         projectList.add(project);
 
         Project project2 = new Project();
-        project2.setId("376576");
+        project2.setId("376570");
         project2.setName("Orange Web");
         project2.setVersion("2.0.1");
         project2.setType("project");
@@ -88,21 +108,50 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         project2.setOwnerCountry("FR");
         project2.setOwnerGroup("SIM-KA12");
         project2.setExternalIds(Collections.singletonMap("mainline-id-project", "7657"));
+        linkedReleases = new HashMap<>();
+        linkedReleases.put("5578999", projectReleaseRelationship);
+        project2.setReleaseIdToUsage(linkedReleases);
         projectList.add(project2);
+
+        Set<String> releaseIds = new HashSet<>(Arrays.asList("3765276512"));
+        Set<String> releaseIdsTransitive = new HashSet<>(Arrays.asList("3765276512", "5578999"));
 
         given(this.projectServiceMock.getProjectsForUser(anyObject())).willReturn(projectList);
         given(this.projectServiceMock.getProjectForUserById(eq(project.getId()), anyObject())).willReturn(project);
+        given(this.projectServiceMock.searchProjectByName(eq(project.getName()), anyObject())).willReturn(projectList);
+        given(this.projectServiceMock.getReleaseIds(eq(project.getId()), anyObject(), eq("false"))).willReturn(releaseIds);
+        given(this.projectServiceMock.getReleaseIds(eq(project.getId()), anyObject(), eq("true"))).willReturn(releaseIdsTransitive);
+
+        Release release = new Release();
+        release.setId("3765276512");
+        release.setName("Angular 2.3.0");
+        release.setCpeid("cpe:/a:Google:Angular:2.3.0:");
+        release.setType("release");
+        release.setReleaseDate("2016-12-07");
+        release.setVersion("2.3.0");
+        release.setCreatedOn("2016-12-18");
+        EccInformation eccInformation = new EccInformation();
+        eccInformation.setEccStatus(ECCStatus.APPROVED);
+        release.setEccInformation(eccInformation);
+        release.setCreatedBy("admin@sw360.org");
+        release.setModerators(new HashSet<>(Arrays.asList("admin@sw360.org", "jane@sw360.org")));
+        release.setComponentId("12356115");
+        release.setClearingState(ClearingState.APPROVED);
+        release.setExternalIds(Collections.singletonMap("mainline-id-component", "1432"));
+
+        given(this.releaseServiceMock.getReleaseForUserById(eq(release.getId()), anyObject())).willReturn(release);
 
         User user = new User();
         user.setId("admin@sw360.org");
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
+        user.setDepartment("sw360");
 
         given(this.userServiceMock.getUserByEmail("admin@sw360.org")).willReturn(user);
     }
 
     @Test
-    public void should_document_get_projects()  throws Exception {
+    public void should_document_get_projects() throws Exception {
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
         mockMvc.perform(get("/api/projects")
                 .header("Authorization", "Bearer " + accessToken)
@@ -113,6 +162,12 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("curies").description("Curies are used for online documentation")
                         ),
                         responseFields(
+                                fieldWithPath("_embedded.sw360:projects[]name").description("The name of the project"),
+                                fieldWithPath("_embedded.sw360:projects[]version").description("The project version"),
+                                fieldWithPath("_embedded.sw360:projects[]projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
+                                fieldWithPath("_embedded.sw360:projects[]ownerAccountingUnit").description("The owner accounting unit of the project"),
+                                fieldWithPath("_embedded.sw360:projects[]ownerGroup").description("The owner group of the project"),
+                                fieldWithPath("_embedded.sw360:projects[]ownerCountry").description("The owner country of the project"),
                                 fieldWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
@@ -141,9 +196,111 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("ownerAccountingUnit").description("The owner accounting unit of the project"),
                                 fieldWithPath("ownerGroup").description("The owner group of the project"),
                                 fieldWithPath("ownerCountry").description("The owner country of the project"),
+                                fieldWithPath("linkedProjects").description("The relationship between linked projects of the project"),
+                                fieldWithPath("linkedReleases").description("The relationship between linked releases of the project"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
+                                fieldWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
+                                fieldWithPath("_embedded.sw360:releases").description("An array of <<resources-releases, Releases resources>>"),
                                 fieldWithPath("_embedded.createdBy").description("The user who created this project"),
                                 fieldWithPath("_embedded.sw360:moderators").description("An array of all project moderators with email and link to their <<resources-user-get,User resource>>")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_projects_by_type() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/projects?type=" + project.getProjectType())
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        links(
+                                linkWithRel("curies").description("Curies are used for online documentation")
+                        ),
+                        responseFields(
+                                fieldWithPath("_embedded.sw360:projects[]name").description("The name of the project"),
+                                fieldWithPath("_embedded.sw360:projects[]version").description("The project version"),
+                                fieldWithPath("_embedded.sw360:projects[]projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
+                                fieldWithPath("_embedded.sw360:projects[]ownerAccountingUnit").description("The owner accounting unit of the project"),
+                                fieldWithPath("_embedded.sw360:projects[]ownerGroup").description("The owner group of the project"),
+                                fieldWithPath("_embedded.sw360:projects[]ownerCountry").description("The owner country of the project"),
+                                fieldWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
+                                fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_projects_by_name() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/projects?name=" + project.getName())
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        links(
+                                linkWithRel("curies").description("Curies are used for online documentation")
+                        ),
+                        responseFields(
+                                fieldWithPath("_embedded.sw360:projects[]name").description("The name of the project"),
+                                fieldWithPath("_embedded.sw360:projects[]version").description("The project version"),
+                                fieldWithPath("_embedded.sw360:projects[]projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
+                                fieldWithPath("_embedded.sw360:projects[]ownerAccountingUnit").description("The owner accounting unit of the project"),
+                                fieldWithPath("_embedded.sw360:projects[]ownerGroup").description("The owner group of the project"),
+                                fieldWithPath("_embedded.sw360:projects[]ownerCountry").description("The owner country of the project"),
+                                fieldWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
+                                fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_project_releases() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/projects/" + project.getId() + "/releases?transitive=false")
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        links(
+                                linkWithRel("curies").description("Curies are used for online documentation")
+                        ),
+                        responseFields(
+                                fieldWithPath("_embedded.sw360:releases").description("An array of <<resources-releases, Releases resources>>"),
+                                fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_project_releases_transitive() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/projects/" + project.getId() + "/releases?transitive=true")
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        links(
+                                linkWithRel("curies").description("Curies are used for online documentation")
+                        ),
+                        responseFields(
+                                fieldWithPath("_embedded.sw360:releases").description("An array of <<resources-releases, Releases resources>>"),
+                                fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_project_releases_ecc_information() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/projects/" + project.getId() + "/releases/ecc?transitive=false")
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        links(
+                                linkWithRel("curies").description("Curies are used for online documentation")
+                        ),
+                        responseFields(
+                                fieldWithPath("_embedded.sw360:releases").description("An array of <<resources-releases, Releases resources>>"),
+                                fieldWithPath("_embedded.sw360:releases[].eccInformation.eccStatus").description("The ECC information status value"),
+                                fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -24,7 +24,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.hateoas.MediaTypes;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.*;
@@ -122,6 +121,9 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("curies").description("Curies are used for online documentation")
                         ),
                         responseFields(
+                                fieldWithPath("_embedded.sw360:releases[]name").description("The name of the release, optional"),
+                                fieldWithPath("_embedded.sw360:releases[]version").description("The version of the release"),
+                                fieldWithPath("_embedded.sw360:releases[]clearingState").description("The clearing of the release, possible values are " + Arrays.asList(ClearingState.values())),
                                 fieldWithPath("_embedded.sw360:releases").description("An array of <<resources-releases, Releases resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
@@ -141,8 +143,8 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("curies").description("The curies for documentation")
                         ),
                         responseFields(
-                                fieldWithPath("version").description("The version of the release"),
                                 fieldWithPath("name").description("The name of the release, optional"),
+                                fieldWithPath("version").description("The version of the release"),
                                 fieldWithPath("cpeId").description("CpeId of the release"),
                                 fieldWithPath("clearingState").description("The clearing of the release, possible values are " + Arrays.asList(ClearingState.values())),
                                 fieldWithPath("cpeId").description("The CPE id"),

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/UserSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/UserSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -94,6 +94,8 @@ public class UserSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("curies").description("Curies are used for online documentation")
                         ),
                         responseFields(
+                                fieldWithPath("_embedded.sw360:users[]email").description("The user's email"),
+                                fieldWithPath("_embedded.sw360:users[]userGroup").description("The user group, possible values are: " + Arrays.asList(UserGroup.values())),
                                 fieldWithPath("_embedded.sw360:users").description("An array of <<resources-users, User resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VendorSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VendorSpecTest.java
@@ -80,6 +80,7 @@ public class VendorSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("curies").description("Curies are used for online documentation")
                         ),
                         responseFields(
+                                fieldWithPath("_embedded.sw360:vendors[]fullName").description("The full name of the vendor"),
                                 fieldWithPath("_embedded.sw360:vendors").description("An array of <<resources-vendors, Vendors resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VulnerabilitySpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VulnerabilitySpecTest.java
@@ -59,7 +59,7 @@ public class VulnerabilitySpecTest extends TestRestDocsSpecBase {
         vulnerability = new Vulnerability();
         vulnerability.setId("12345");
         vulnerability.setAction("new");
-        vulnerability.setCwe("cwe");
+        vulnerability.setCwe("common weakness enumeration");
         vulnerability.setDescription("Description of vulnerability");
         vulnerability.setExternalId("123");
         vulnerability.setPriority("high");
@@ -73,7 +73,7 @@ public class VulnerabilitySpecTest extends TestRestDocsSpecBase {
         Vulnerability vulnerability2 = new Vulnerability();
         vulnerability2.setId("7854");
         vulnerability2.setAction("remove");
-        vulnerability2.setCwe("cwe");
+        vulnerability2.setCwe("common weakness enumeration");
         vulnerability2.setDescription("Description of vulnerability");
         vulnerability2.setExternalId("7543");
         vulnerability2.setPriority("low");
@@ -108,6 +108,8 @@ public class VulnerabilitySpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("curies").description("Curies are used for online documentation")
                         ),
                         responseFields(
+                                fieldWithPath("_embedded.sw360:vulnerabilities[]title").description("The title of the vulnerability"),
+                                fieldWithPath("_embedded.sw360:vulnerabilities[]description").description("The vulnerability description"),
                                 fieldWithPath("_embedded.sw360:vulnerabilities").description("An array of <<resources-vulnerabilities, Vulnerabilities resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
@@ -129,7 +131,7 @@ public class VulnerabilitySpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("title").description("The title of the vulnerability"),
                                 fieldWithPath("description").description("The vulnerability description"),
                                 fieldWithPath("externalId").description("The external Id"),
-                                fieldWithPath("cwe").description("The CWE value"),
+                                fieldWithPath("cwe").description("The CWE (Common Weakness Enumeration) value"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }


### PR DESCRIPTION
Added the following chapters

Projects Chapter:
- Listing projects by name
- Listing projects by type
- Listing releases of a single projects
- Listing releases with ecc information

Components Chapter:
- Listing components by name
- Listing components by type

... and some fixes (typo, add fields, field descriptions...)