### PR TITLE
feat(ui): improve handling of country fields

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2018. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
  * SPDX-License-Identifier: EPL-1.0
@@ -34,6 +34,7 @@ public class PortalConstants {
     public static final String OPERATING_SYSTEMS;
     public static final Set<String> SET_CLEARING_TEAMS_STRING;
     public static final String LICENSE_IDENTIFIERS;
+    public static final String PREFERRED_COUNTRY_CODES;
 
     //! Role names
     public static final String ROLENAME_ADMIN = "Administrator";
@@ -374,6 +375,7 @@ public class PortalConstants {
         RELEASE_ROLES = props.getProperty("custommap.release.roles", "Committer,Contributor,Expert");
         RELEASE_EXTERNAL_IDS = props.getProperty("custommap.release.externalIds", "[]");
         PROJECTIMPORT_HOSTS = props.getProperty("projectimport.hosts", "");
+        PREFERRED_COUNTRY_CODES = props.getProperty("preferred.country.codes", "DE,AT,CH,US");
     }
 
     private PortalConstants() {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayCountryCodeName.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayCountryCodeName.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Siemens AG, 2018. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.portal.tags;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+import java.io.IOException;
+import java.util.Locale;
+
+public class DisplayCountryCodeName extends SimpleTagSupport {
+
+    private String value;
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public void doTag() throws JspException, IOException {
+        String output = "";
+
+        Locale locale = new Locale("", value);
+        if (locale != null) {
+            output = locale.getDisplayCountry();
+        }
+
+        getJspContext().getOut().print(output);
+    }
+}

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayCountryCodeSelection.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayCountryCodeSelection.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Siemens AG, 2018. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.portal.tags;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+import java.io.IOException;
+import java.util.*;
+
+public class DisplayCountryCodeSelection extends SimpleTagSupport {
+
+    private String selected;
+    private String preferredCountryCodes;
+    private Map<String, Locale> countryCodeMap;
+
+    public void setSelected(String selected) {
+        this.selected = selected;
+    }
+
+    public void setPreferredCountryCodes(String preferredCountryCodes) {
+        this.preferredCountryCodes = preferredCountryCodes;
+    }
+
+    public void doTag() throws JspException, IOException {
+        populateCountryCodeMap();
+        writeOptions(selected, preferredCountryCodes);
+    }
+
+    private void writeOptions(String selected, String preferredCountryCodes) throws IOException {
+        JspWriter jspWriter = getJspContext().getOut();
+
+        if (selected == null || selected.isEmpty()) {
+            jspWriter.write("<option value=\"\">Select a country</option>");
+        }
+
+        List<String> validCountryCodeList = applyCountryCodes(preferredCountryCodes);
+        if (!validCountryCodeList.isEmpty()) {
+            for (String countryCode : validCountryCodeList) {
+                writeOption(jspWriter, countryCodeMap.get(countryCode));
+            }
+            jspWriter.write("<option disabled>───────────────</option>");
+        }
+
+        for (Locale locale : countryCodeMap.values()) {
+            if (!validCountryCodeList.contains(locale.getCountry())) {
+                writeOption(jspWriter, locale);
+            }
+        }
+    }
+
+    private void writeOption(JspWriter jspWriter, Locale locale) throws IOException {
+        boolean selected = locale.getCountry().equalsIgnoreCase(this.selected);
+        jspWriter.write(String.format(
+                "<option value=\"%s\" class=\"textlabel stackedLabel\" " +
+                        (selected ? "selected=\"selected\" " : "") + ">%s</option>",
+                locale.getCountry(), locale.getDisplayCountry()));
+    }
+
+    private List<String> applyCountryCodes(String countryCodes) {
+        List<String> result = new ArrayList<>();
+        if (countryCodes != null && !countryCodes.isEmpty()) {
+            for (String countryCode : countryCodes.split(",")) {
+                if (countryCodeMap.get(countryCode) != null) {
+                    result.add(countryCode);
+                }
+            }
+        }
+        return result;
+    }
+
+    private void populateCountryCodeMap() {
+        String[] countryCodes = Locale.getISOCountries();
+        List<Locale> locales = new ArrayList<>();
+        countryCodeMap = new LinkedHashMap<>();
+        for (String countryCode : countryCodes) {
+            locales.add(new Locale("", countryCode));
+        }
+        locales.sort(Comparator.comparing(Locale::getDisplayCountry));
+        for (Locale locale : locales) {
+            countryCodeMap.put(locale.getCountry(), locale);
+        }
+    }
+}

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2018. Part of the SW360 Portal Project.
   ~ With contributions by Bosch Software Innovations GmbH, 2016.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
@@ -1121,6 +1121,34 @@
         </attribute>
         <attribute>
             <name>defaultText</name>
+            <required>true</required>
+            <type>java.lang.String</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+    </tag>
+    <tag>
+        <name>DisplayCountryCodeSelection</name>
+        <tag-class>org.eclipse.sw360.portal.tags.DisplayCountryCodeSelection</tag-class>
+        <body-content>empty</body-content>
+        <attribute>
+            <name>selected</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>preferredCountryCodes</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+    </tag>
+    <tag>
+        <name>DisplayCountryCodeName</name>
+        <tag-class>org.eclipse.sw360.portal.tags.DisplayCountryCodeName</tag-class>
+        <body-content>empty</body-content>
+        <attribute>
+            <name>value</name>
             <required>true</required>
             <type>java.lang.String</type>
             <rtexprvalue>true</rtexprvalue>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/editBasicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/editBasicInfo.jspf
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2018. Part of the SW360 Portal Project.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
   ~
@@ -11,6 +11,8 @@
 
 <%@ page import="org.eclipse.sw360.datahandler.thrift.components.ComponentType" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.components.Component" %>
+<core_rt:set var="preferredCountryCodes" value='<%=PortalConstants.PREFERRED_COUNTRY_CODES%>'/>
+
 <table class="table info_table" id="ComponentGeneralInfo">
     <thead>
     <tr>
@@ -102,8 +104,10 @@
     <tr>
         <td width="33%">
             <label class="textlabel stackedLabel" for="ownerCountry">Owner Country</label>
-            <input class="toplabelledInput" id="ownerCountry" name="<portlet:namespace/><%=Component._Fields.OWNER_COUNTRY%>" type="text"
-                   placeholder="Enter Owner Country" value="<sw360:out value="${component.ownerCountry}"/>"/>
+            <select class="toplabelledInput, formatSelect" id="ownerCountry"
+                    name="<portlet:namespace/><%=Component._Fields.OWNER_COUNTRY%>">
+                    <sw360:DisplayCountryCodeSelection selected='${component.ownerCountry}' preferredCountryCodes='${preferredCountryCodes}'/>
+            </select>
         </td>
         <td width="33%">
             <sw360:DisplayUserEdit emails="${component.moderators}" id="<%=Component._Fields.MODERATORS.toString()%>"

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/summary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/summary.jspf
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2018. Part of the SW360 Portal Project.
   ~ With contributions by Bosch Software Innovations GmbH, 2016.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
@@ -107,7 +107,7 @@
     </tr>
     <tr>
         <td>Owner country:</td>
-        <td><sw360:out value="${component.ownerCountry}"/></td>
+        <td><sw360:DisplayCountryCodeName value="${component.ownerCountry}"/></td>
     </tr>
     <tr>
         <td>Moderators:</td>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/basicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/basicInfo.jspf
@@ -17,6 +17,7 @@
 <%@ page import="static org.eclipse.sw360.datahandler.thrift.projects.projectsConstants.CLEARING_TEAM_UNKNOWN" %>
 
 <core_rt:set var="clearingTeamsStringSet" value='<%=PortalConstants.SET_CLEARING_TEAMS_STRING%>'/>
+<core_rt:set var="preferredCountryCodes" value='<%=PortalConstants.PREFERRED_COUNTRY_CODES%>'/>
 
 <table class="table info_table" id="ProjectBasicInfo">
     <thead>
@@ -151,9 +152,10 @@
         </td>
         <td width="33%">
             <label class="textlabel stackedLabel" for="proj_owner_country">Owner country</label>
-            <input class="toplabelledInput" id="proj_owner_country" name="<portlet:namespace/><%=Project._Fields.OWNER_COUNTRY%>"
-                   type="text"
-                   value="<sw360:out value="${project.ownerCountry}"/>" placeholder="Enter owner's country"/>
+            <select class="toplabelledInput, formatSelect" id="proj_owner_country"
+                    name="<portlet:namespace/><%=Project._Fields.OWNER_COUNTRY%>">
+                <sw360:DisplayCountryCodeSelection selected='${project.ownerCountry}' preferredCountryCodes='${preferredCountryCodes}'/>
+            </select>
         </td>
     </tr>
     <tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/summary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/summary.jspf
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2018. Part of the SW360 Portal Project.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
   ~
@@ -86,7 +86,7 @@
     </tr>
     <tr>
         <td>Owner country:</td>
-        <td><sw360:out value="${project.ownerCountry}"/></td>
+        <td><sw360:DisplayCountryCodeName value="${project.ownerCountry}"/></td>
     </tr>
     <tr>
         <td>Lead architect:</td>


### PR DESCRIPTION
- added two new tags (display name, display options)
- ISO-3166-1 / Alpha 2 Codes
- configurable preferred country code list in sw360.properties
(preferred.country.codes: DE,AT,CH,US)

closes sw360/sw360portal#750