### PR TITLE
chore(rest): harmonize rest fields and documentation

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/components.adoc
+++ b/rest/resource-server/src/docs/asciidoc/components.adoc
@@ -37,7 +37,8 @@ include::{snippets}/should_document_get_components/links.adoc[]
 [[resources-components-list-by-name]]
 ==== Listing by name
 
-A `GET` request will list all of the service's components by component name.
+A `GET` request will list all of the service's components by component name. +
+Please set the request parameter `&name=<NAME>`.
 
 ===== Response structure
 

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -37,7 +37,8 @@ include::{snippets}/should_document_get_projects/links.adoc[]
 [[resources-projects-list-by-name]]
 ==== Listing by name
 
-A `GET` request will list all of the service's projects by project name.
+A `GET` request will list all of the service's projects by project name. +
+Please set the request parameter `&name=<NAME>`.
 
 ===== Response structure
 
@@ -103,7 +104,7 @@ include::{snippets}/should_document_get_project/links.adoc[]
 ==== Listing releases
 
 A `GET` request will get releases of a single project. +
-Only linked releases without any releases of sub-projects (&transitive=false).
+Only linked releases without any releases of sub-projects `&transitive=false`.
 
 ===== Response structure
 
@@ -125,7 +126,7 @@ include::{snippets}/should_document_get_project_releases/links.adoc[]
 ==== Listing releases (transitive)
 
 A `GET` request will get all releases of a single project (transitive). +
-Please set the request parameter (&transitive=true).
+Please set the request parameter `&transitive=true`.
 
 ===== Response structure
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -10,7 +10,6 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.eclipse.sw360.rest.resourceserver.component;
 
 import lombok.NonNull;
@@ -79,13 +78,8 @@ public class ComponentController implements ResourceProcessor<RepositoryLinksRes
         sw360Components.stream()
                 .filter(component -> componentType == null || componentType.equals(component.componentType.name()))
                 .forEach(c -> {
-                    c.setDescription(null);
-                    c.setType(null);
-                    c.setCreatedOn(null);
-                    c.setVendorNames(null);
-                    c.setReleaseIds(null);
-                    c.setComponentOwner(null);
-                    componentResources.add(new Resource<>(c));
+                    Component embeddedComponent = restControllerHelper.convertToEmbeddedComponent(c);
+                    componentResources.add(new Resource<>(embeddedComponent));
                 });
 
         Resources<Resource<Component>> resources = new Resources<>(componentResources);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/HalResource.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/HalResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -8,11 +8,18 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.eclipse.sw360.rest.resourceserver.core;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
+import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.Resource;
 
@@ -28,6 +35,23 @@ public class HalResource<T> extends Resource<T> {
 
     public HalResource(T content, Link... links) {
         super(content, links);
+        if (content instanceof Project) {
+            ((Project) content).setType(null);
+        } else if (content instanceof Component) {
+            ((Component) content).setType(null);
+        } else if (content instanceof Release) {
+            ((Release) content).setType(null);
+        } else if (content instanceof User) {
+            ((User) content).setType(null);
+        } else if (content instanceof License) {
+            ((License) content).setType(null);
+        } else if (content instanceof Vendor) {
+            ((Vendor) content).setType(null);
+        } else if (content instanceof Vulnerability) {
+            ((Vulnerability) content).setType(null);
+        } else if (content instanceof VulnerabilityDTO) {
+            ((VulnerabilityDTO) content).setType(null);
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -39,17 +63,15 @@ public class HalResource<T> extends Resource<T> {
         Object embeddedResources = embeddedMap.get(relation);
         boolean isPluralRelation = relation.endsWith("s");
 
-
-
         // if a relation is plural, the content will always be rendered as an array
-        if(isPluralRelation) {
+        if (isPluralRelation) {
             if (embeddedResources == null) {
                 embeddedResources = new ArrayList<>();
             }
             ((List<Object>) embeddedResources).add(embeddedResource);
 
-        // if a relation is singular, it would be a single object if there is only one object available
-        // Otherwise it would be rendered as array
+            // if a relation is singular, it would be a single object if there is only one object available
+            // Otherwise it would be rendered as array
         } else {
             if (embeddedResources == null) {
                 embeddedResources = embeddedResource;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -298,8 +298,6 @@ class JacksonCustomizations {
                 "createdBy",
                 "moderators",
                 "clearingInformation",
-                "mainlineState",
-                "downloadurl",
                 "setAttachments",
                 "setCreatedOn",
                 "setRepository",
@@ -370,7 +368,6 @@ class JacksonCustomizations {
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonIgnoreProperties({
                 "attachmentContentId",
-                "createdBy",
                 "setAttachmentContentId",
                 "setAttachmentType",
                 "setCreatedComment",
@@ -614,15 +611,11 @@ class JacksonCustomizations {
 
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
         @JsonIgnoreProperties({
-                "AL",
-                "ECCN",
                 "assessorContactPerson",
                 "assessorDepartment",
                 "eccComment",
                 "materialIndexNumber",
                 "assessmentDate",
-                "al",
-                "eccn",
                 "setEccComment",
                 "setECCN",
                 "setEccStatus",

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -10,7 +10,6 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.eclipse.sw360.rest.resourceserver.license;
 
 import lombok.NonNull;
@@ -58,21 +57,16 @@ public class LicenseController implements ResourceProcessor<RepositoryLinksResou
 
     @RequestMapping(value = LICENSES_URL, method = RequestMethod.GET)
     public ResponseEntity<Resources<Resource<License>>> getLicenses(OAuth2Authentication oAuth2Authentication) throws TException {
-        List<License> licenses = licenseService.getLicenses();
+        List<License> sw360Licenses = licenseService.getLicenses();
 
         List<Resource<License>> licenseResources = new ArrayList<>();
-        for (License license : licenses) {
-            // TODO Kai Tödter 2017-01-04
-            // Find better way to decrease details in list resources,
-            // e.g. apply projections or Jackson Mixins
-            license.setText(null);
-            license.setType(null);
-            license.setShortname(null);
-            Resource<License> licenseResource = new Resource<>(license);
+        for (License sw360License : sw360Licenses) {
+            License embeddedLicense = restControllerHelper.convertToEmbeddedLicense(sw360License);
+            Resource<License> licenseResource = new Resource<>(embeddedLicense);
             licenseResources.add(licenseResource);
         }
-        Resources<Resource<License>> resources = new Resources<>(licenseResources);
 
+        Resources<Resource<License>> resources = new Resources<>(licenseResources);
         return new ResponseEntity<>(resources, HttpStatus.OK);
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -22,7 +22,6 @@ import org.apache.thrift.transport.THttpClient;
 import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
-import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
@@ -6,7 +6,6 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
@@ -26,7 +25,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.hateoas.MediaTypes;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.ArrayList;
@@ -85,7 +83,6 @@ public class AttachmentSpecTest extends TestRestDocsSpecBase {
         release.setId("874687");
         release.setName("Spring Core 4.3.4");
         release.setCpeid("cpe:/a:pivotal:spring-core:4.3.4:");
-        release.setType("release");
         release.setReleaseDate("2016-12-07");
         release.setVersion("4.3.4");
         release.setCreatedOn("2016-12-18");
@@ -126,6 +123,7 @@ public class AttachmentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("createdTeam").description("The team who created this attachment"),
                                 fieldWithPath("createdComment").description("Comment of the creating team"),
                                 fieldWithPath("createdOn").description("The date the attachment was created"),
+                                fieldWithPath("createdBy").description("The creator of the attachment"),
                                 fieldWithPath("checkedTeam").description("The team who checked this attachment"),
                                 fieldWithPath("checkedComment").description("Comment of the checking team"),
                                 fieldWithPath("checkedOn").description("The date the attachment was checked"),

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -6,7 +6,6 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
@@ -58,6 +57,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
     @Before
     public void before() throws TException {
         List<Component> componentList = new ArrayList<>();
+        List<Component> componentListByName = new ArrayList<>();
 
         angularComponent = new Component();
         angularComponent.setId("17653524");
@@ -73,6 +73,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         angularComponent.setOwnerCountry("DE");
         angularComponent.setOwnerGroup("AA BB 123 GHV2-DE");
         componentList.add(angularComponent);
+        componentListByName.add(angularComponent);
 
         Component springComponent = new Component();
         springComponent.setId("678dstzd8");
@@ -99,7 +100,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
 
         given(this.componentServiceMock.getComponentsForUser(anyObject())).willReturn(componentList);
         given(this.componentServiceMock.getComponentForUserById(eq("17653524"), anyObject())).willReturn(angularComponent);
-        given(this.componentServiceMock.searchComponentByName(eq(angularComponent.getName()))).willReturn(componentList);
+        given(this.componentServiceMock.searchComponentByName(eq(angularComponent.getName()))).willReturn(componentListByName);
 
         User user = new User();
         user.setId("admin@sw360.org");
@@ -114,7 +115,6 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         release.setId("3765276512");
         release.setName("Angular 2.3.0");
         release.setCpeid("cpe:/a:Google:Angular:2.3.0:");
-        release.setType("release");
         release.setReleaseDate("2016-12-07");
         release.setVersion("2.3.0");
         release.setCreatedOn("2016-12-18");
@@ -127,7 +127,6 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         release2.setId("3765276512");
         release2.setName("Angular 2.3.1");
         release2.setCpeid("cpe:/a:Google:Angular:2.3.1:");
-        release2.setType("release");
         release2.setReleaseDate("2016-12-15");
         release2.setVersion("2.3.1");
         release2.setCreatedOn("2016-12-18");
@@ -153,9 +152,6 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                         responseFields(
                                 fieldWithPath("_embedded.sw360:components[]name").description("The name of the component"),
                                 fieldWithPath("_embedded.sw360:components[]componentType").description("The component type, possible values are: " + Arrays.asList(ComponentType.values())),
-                                fieldWithPath("_embedded.sw360:components[]ownerAccountingUnit").description("The owner accounting unit of the component"),
-                                fieldWithPath("_embedded.sw360:components[]ownerGroup").description("The owner group of the component"),
-                                fieldWithPath("_embedded.sw360:components[]ownerCountry").description("The owner country of the component"),
                                 fieldWithPath("_embedded.sw360:components").description("An array of <<resources-components, Components resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
@@ -177,7 +173,6 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("componentType").description("The component type, possible values are: " + Arrays.asList(ComponentType.values())),
                                 fieldWithPath("description").description("The component description"),
                                 fieldWithPath("createdOn").description("The date the component was created"),
-                                fieldWithPath("type").description("is always 'component'"),
                                 fieldWithPath("componentOwner").description("The owner name of the component"),
                                 fieldWithPath("ownerAccountingUnit").description("The owner accounting unit of the component"),
                                 fieldWithPath("ownerGroup").description("The owner group of the component"),
@@ -219,7 +214,6 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("componentOwner").description("The owner name of the component"),
                                 fieldWithPath("description").description("The component description"),
                                 fieldWithPath("createdOn").description("The date the component was created"),
-                                fieldWithPath("type").description("is always 'component'"),
                                 fieldWithPath("ownerAccountingUnit").description("The owner accounting unit of the component"),
                                 fieldWithPath("ownerGroup").description("The owner group of the component"),
                                 fieldWithPath("ownerCountry").description("The owner country of the component"),
@@ -242,9 +236,6 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                         responseFields(
                                 fieldWithPath("_embedded.sw360:components[]name").description("The name of the component"),
                                 fieldWithPath("_embedded.sw360:components[]componentType").description("The component type, possible values are: " + Arrays.asList(ComponentType.values())),
-                                fieldWithPath("_embedded.sw360:components[]ownerAccountingUnit").description("The owner accounting unit of the component"),
-                                fieldWithPath("_embedded.sw360:components[]ownerGroup").description("The owner group of the component"),
-                                fieldWithPath("_embedded.sw360:components[]ownerCountry").description("The owner country of the component"),
                                 fieldWithPath("_embedded.sw360:components").description("An array of <<resources-components, Components resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
@@ -264,9 +255,6 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                         responseFields(
                                 fieldWithPath("_embedded.sw360:components[]name").description("The name of the component"),
                                 fieldWithPath("_embedded.sw360:components[]componentType").description("The component type, possible values are: " + Arrays.asList(ComponentType.values())),
-                                fieldWithPath("_embedded.sw360:components[]ownerAccountingUnit").description("The owner accounting unit of the component"),
-                                fieldWithPath("_embedded.sw360:components[]ownerGroup").description("The owner group of the component"),
-                                fieldWithPath("_embedded.sw360:components[]ownerCountry").description("The owner country of the component"),
                                 fieldWithPath("_embedded.sw360:components").description("An array of <<resources-components, Components resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -6,7 +6,6 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
@@ -102,7 +101,6 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("fullName").description("The full name of the license"),
                                 fieldWithPath("shortName").description("The short name of the license, optional"),
                                 fieldWithPath("text").description("The license's original text"),
-                                fieldWithPath("type").description("is always 'license'"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -6,7 +6,6 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
@@ -73,10 +72,10 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         ProjectReleaseRelationship projectReleaseRelationship = new ProjectReleaseRelationship(CONTAINED, MAINLINE);
 
         List<Project> projectList = new ArrayList<>();
+        List<Project> projectListByName = new ArrayList<>();
         project = new Project();
         project.setId("376576");
         project.setName("Emerald Web");
-        project.setType("project");
         project.setProjectType(ProjectType.PRODUCT);
         project.setVersion("1.0.2");
         project.setDescription("Emerald Web provides a suite of components for Critical Infrastructures.");
@@ -93,12 +92,12 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         linkedProjects.put("376576", ProjectRelationship.CONTAINED);
         project.setLinkedProjects(linkedProjects);
         projectList.add(project);
+        projectListByName.add(project);
 
         Project project2 = new Project();
         project2.setId("376570");
         project2.setName("Orange Web");
         project2.setVersion("2.0.1");
-        project2.setType("project");
         project2.setProjectType(ProjectType.PRODUCT);
         project2.setDescription("Orange Web provides a suite of components for documentation.");
         project2.setCreatedOn("2016-12-17");
@@ -118,7 +117,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
 
         given(this.projectServiceMock.getProjectsForUser(anyObject())).willReturn(projectList);
         given(this.projectServiceMock.getProjectForUserById(eq(project.getId()), anyObject())).willReturn(project);
-        given(this.projectServiceMock.searchProjectByName(eq(project.getName()), anyObject())).willReturn(projectList);
+        given(this.projectServiceMock.searchProjectByName(eq(project.getName()), anyObject())).willReturn(projectListByName);
         given(this.projectServiceMock.getReleaseIds(eq(project.getId()), anyObject(), eq("false"))).willReturn(releaseIds);
         given(this.projectServiceMock.getReleaseIds(eq(project.getId()), anyObject(), eq("true"))).willReturn(releaseIdsTransitive);
 
@@ -126,7 +125,6 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         release.setId("3765276512");
         release.setName("Angular 2.3.0");
         release.setCpeid("cpe:/a:Google:Angular:2.3.0:");
-        release.setType("release");
         release.setReleaseDate("2016-12-07");
         release.setVersion("2.3.0");
         release.setCreatedOn("2016-12-18");
@@ -139,7 +137,23 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         release.setClearingState(ClearingState.APPROVED);
         release.setExternalIds(Collections.singletonMap("mainline-id-component", "1432"));
 
+        Release release2 = new Release();
+        release2.setId("5578999");
+        release2.setName("Spring 1.4.0");
+        release2.setCpeid("cpe:/a:Spring:1.4.0:");
+        release2.setReleaseDate("2017-05-06");
+        release2.setVersion("1.4.0");
+        release2.setCreatedOn("2017-11-19");
+        eccInformation.setEccStatus(ECCStatus.APPROVED);
+        release2.setEccInformation(eccInformation);
+        release2.setCreatedBy("admin@sw360.org");
+        release2.setModerators(new HashSet<>(Arrays.asList("admin@sw360.org", "jane@sw360.org")));
+        release2.setComponentId("12356115");
+        release2.setClearingState(ClearingState.APPROVED);
+        release2.setExternalIds(Collections.singletonMap("mainline-id-component", "1771"));
+
         given(this.releaseServiceMock.getReleaseForUserById(eq(release.getId()), anyObject())).willReturn(release);
+        given(this.releaseServiceMock.getReleaseForUserById(eq(release2.getId()), anyObject())).willReturn(release2);
 
         User user = new User();
         user.setId("admin@sw360.org");
@@ -165,9 +179,6 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("_embedded.sw360:projects[]name").description("The name of the project"),
                                 fieldWithPath("_embedded.sw360:projects[]version").description("The project version"),
                                 fieldWithPath("_embedded.sw360:projects[]projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
-                                fieldWithPath("_embedded.sw360:projects[]ownerAccountingUnit").description("The owner accounting unit of the project"),
-                                fieldWithPath("_embedded.sw360:projects[]ownerGroup").description("The owner group of the project"),
-                                fieldWithPath("_embedded.sw360:projects[]ownerCountry").description("The owner country of the project"),
                                 fieldWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
@@ -189,7 +200,6 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("version").description("The project version"),
                                 fieldWithPath("createdOn").description("The date the project was created"),
                                 fieldWithPath("description").description("The project description"),
-                                fieldWithPath("type").description("is always 'project'"),
                                 fieldWithPath("projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
                                 fieldWithPath("businessUnit").description("The business unit this project belongs to"),
                                 fieldWithPath("externalIds").description("When projects are imported from other tools, the external ids can be stored here"),
@@ -199,9 +209,9 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("linkedProjects").description("The relationship between linked projects of the project"),
                                 fieldWithPath("linkedReleases").description("The relationship between linked releases of the project"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
+                                fieldWithPath("_embedded.createdBy").description("The user who created this project"),
                                 fieldWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
                                 fieldWithPath("_embedded.sw360:releases").description("An array of <<resources-releases, Releases resources>>"),
-                                fieldWithPath("_embedded.createdBy").description("The user who created this project"),
                                 fieldWithPath("_embedded.sw360:moderators").description("An array of all project moderators with email and link to their <<resources-user-get,User resource>>")
                         )));
     }
@@ -221,9 +231,6 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("_embedded.sw360:projects[]name").description("The name of the project"),
                                 fieldWithPath("_embedded.sw360:projects[]version").description("The project version"),
                                 fieldWithPath("_embedded.sw360:projects[]projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
-                                fieldWithPath("_embedded.sw360:projects[]ownerAccountingUnit").description("The owner accounting unit of the project"),
-                                fieldWithPath("_embedded.sw360:projects[]ownerGroup").description("The owner group of the project"),
-                                fieldWithPath("_embedded.sw360:projects[]ownerCountry").description("The owner country of the project"),
                                 fieldWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
@@ -244,9 +251,6 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("_embedded.sw360:projects[]name").description("The name of the project"),
                                 fieldWithPath("_embedded.sw360:projects[]version").description("The project version"),
                                 fieldWithPath("_embedded.sw360:projects[]projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
-                                fieldWithPath("_embedded.sw360:projects[]ownerAccountingUnit").description("The owner accounting unit of the project"),
-                                fieldWithPath("_embedded.sw360:projects[]ownerGroup").description("The owner group of the project"),
-                                fieldWithPath("_embedded.sw360:projects[]ownerCountry").description("The owner country of the project"),
                                 fieldWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -6,10 +6,10 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.MainlineState;
 import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
@@ -70,31 +70,33 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         List<Release> releaseList = new ArrayList<>();
         release = new Release();
         release.setId("3765276512");
-        release.setName("Angular 2.3.0");
+        release.setName("Angular");
         release.setCpeid("cpe:/a:Google:Angular:2.3.0:");
-        release.setType("release");
         release.setReleaseDate("2016-12-07");
         release.setVersion("2.3.0");
         release.setCreatedOn("2016-12-18");
         release.setCreatedBy("admin@sw360.org");
+        release.setDownloadurl("http://www.google.com");
         release.setModerators(new HashSet<>(Arrays.asList("admin@sw360.org", "jane@sw360.org")));
         release.setComponentId(component.getId());
         release.setClearingState(ClearingState.APPROVED);
+        release.setMainlineState(MainlineState.OPEN);
         release.setExternalIds(Collections.singletonMap("mainline-id-component", "1432"));
         releaseList.add(release);
 
         Release release2 = new Release();
         release2.setId("3765276512");
-        release2.setName("Angular 2.3.1");
+        release2.setName("Angular");
         release2.setCpeid("cpe:/a:Google:Angular:2.3.1:");
-        release2.setType("release");
         release2.setReleaseDate("2016-12-15");
         release2.setVersion("2.3.1");
         release2.setCreatedOn("2016-12-18");
         release2.setCreatedBy("admin@sw360.org");
+        release2.setDownloadurl("http://www.google.com");
         release2.setModerators(new HashSet<>(Arrays.asList("admin@sw360.org", "jane@sw360.org")));
         release2.setComponentId(component.getId());
         release2.setClearingState(ClearingState.APPROVED);
+        release2.setMainlineState(MainlineState.MAINLINE);
         release2.setExternalIds(Collections.singletonMap("mainline-id-component", "4876"));
         releaseList.add(release2);
 
@@ -110,7 +112,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
     }
 
     @Test
-    public void should_document_get_releases()  throws Exception {
+    public void should_document_get_releases() throws Exception {
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
         mockMvc.perform(get("/api/releases")
                 .header("Authorization", "Bearer " + accessToken)
@@ -123,7 +125,6 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                         responseFields(
                                 fieldWithPath("_embedded.sw360:releases[]name").description("The name of the release, optional"),
                                 fieldWithPath("_embedded.sw360:releases[]version").description("The version of the release"),
-                                fieldWithPath("_embedded.sw360:releases[]clearingState").description("The clearing of the release, possible values are " + Arrays.asList(ClearingState.values())),
                                 fieldWithPath("_embedded.sw360:releases").description("An array of <<resources-releases, Releases resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
@@ -150,7 +151,8 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("cpeId").description("The CPE id"),
                                 fieldWithPath("releaseDate").description("The date of this release"),
                                 fieldWithPath("createdOn").description("The creation date of the internal sw360 release"),
-                                fieldWithPath("type").description("is always 'release'"),
+                                fieldWithPath("mainlineState").description("the mainline state of the release, possible values are: " + Arrays.asList(MainlineState.values())),
+                                fieldWithPath("downloadurl").description("the download url of the release"),
                                 fieldWithPath("externalIds").description("When releases are imported from other tools, the external ids can be stored here"),
                                 fieldWithPath("_embedded.sw360:moderators").description("An array of all release moderators with email and link to their <<resources-user-get,User resource>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/UserSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/UserSpecTest.java
@@ -6,7 +6,6 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -56,7 +55,6 @@ public class UserSpecTest extends TestRestDocsSpecBase {
         user = new User();
         user.setEmail("admin@sw360.org");
         user.setId(Base64.getEncoder().encodeToString(user.getEmail().getBytes("utf-8")));
-        user.setType("user");
         user.setUserGroup(UserGroup.ADMIN);
         user.setFullname("John Doe");
         user.setGivenname("John");
@@ -70,7 +68,6 @@ public class UserSpecTest extends TestRestDocsSpecBase {
         User user2 = new User();
         user2.setEmail("jane@sw360.org");
         user2.setId(Base64.getEncoder().encodeToString(user.getEmail().getBytes("utf-8")));
-        user2.setType("user");
         user2.setUserGroup(UserGroup.USER);
         user2.setFullname("Jane Doe");
         user2.setGivenname("Jane");
@@ -95,7 +92,6 @@ public class UserSpecTest extends TestRestDocsSpecBase {
                         ),
                         responseFields(
                                 fieldWithPath("_embedded.sw360:users[]email").description("The user's email"),
-                                fieldWithPath("_embedded.sw360:users[]userGroup").description("The user group, possible values are: " + Arrays.asList(UserGroup.values())),
                                 fieldWithPath("_embedded.sw360:users").description("An array of <<resources-users, User resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
@@ -113,7 +109,6 @@ public class UserSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("self").description("The <<resources-users,User resource>>")
                         ),
                         responseFields(
-                                fieldWithPath("type").description("always 'user'"),
                                 fieldWithPath("email").description("The user's email"),
                                 fieldWithPath("userGroup").description("The user group, possible values are: " + Arrays.asList(UserGroup.values())),
                                 fieldWithPath("fullName").description("The users's full name"),

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VendorSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VendorSpecTest.java
@@ -1,12 +1,11 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
@@ -101,7 +100,6 @@ public class VendorSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("fullName").description("The full name of the vendor"),
                                 fieldWithPath("shortName").description("The short name of the vendor, optional"),
                                 fieldWithPath("url").description("The vendor's home page URL"),
-                                fieldWithPath("type").description("is always 'vendor'"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }


### PR DESCRIPTION
- bug fix in tests for search by name (**projects**, **components**)
- bug fix show licenses for project (e.g. _/projects/123456/licenses_)
- harmonize fields for resource objects (name, version, type)
- add fields `mainlineState`, `downloadUrl` (**release**)
- add field `createdBy` (**attachments**)
- add fields `al`, `eccn` (**eccInformation**)

closes sw360/sw360portal#760
closes sw360/sw360portal#766