### PR TITLE
feat(release): make release names not editable

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseInformation.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseInformation.jspf
@@ -27,18 +27,10 @@
         </td>
         <td width="33%">
             <label class="textlabel stackedLabel mandatory" for="comp_name">Name</label>
-            <input id="comp_name" name="<portlet:namespace/><%=Release._Fields.NAME%>" type="text"
-                   placeholder="Enter Name" required="" class="followedByImg"
-                    <core_rt:if test="${ not empty release.name}">
-                        value="<sw360:out value="${release.name}"/>"
-                    </core_rt:if>
-                    <core_rt:if test="${ empty release.name}">
-                        value="<sw360:out value="${component.name}"/>"
-                    </core_rt:if>
-
-                    />
+            <input id="comp_name" name="<portlet:namespace/><%=Release._Fields.NAME%>" type="text" readonly="true"
+                   placeholder="Enter Name" required="" class="followedByImg" value="<sw360:out value="${component.name}"/>"/>
             <img class="infopic" src="<%=request.getContextPath()%>/images/ic_info.png"
-                 title="Name of the release"/>
+                 title="Name of the component"/>
         </td>
         <td width="33%">
             <label class="textlabel stackedLabel mandatory" for="comp_version">Version</label>
@@ -47,7 +39,6 @@
                    value="<sw360:out value="${release.version}"/>"/>
         </td>
     </tr>
-
     <tr>
         <td width="33%">
             <label class="textlabel stackedLabel" for="programminglanguages">Programming Languages</label>

--- a/scripts/migrations/009_overwrite_release_name_with_component_name.py
+++ b/scripts/migrations/009_overwrite_release_name_with_component_name.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+# -----------------------------------------------------------------------------
+# Copyright Siemens AG, 2018. Part of the SW360 Portal Project.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# This is a manual database migration script. It is assumed that a
+# dedicated framework for automatic migration will be written in the
+# future. When that happens, this script should be refactored to conform
+# to the framework's prerequisites to be run by the framework. For
+# example, server address and db name should be parametrized, the code
+# reorganized into a single class or function, etc.
+#
+# The usage of this script is optional.
+# It is intended to overwrite the release name with the parent component name.
+# As default the script runs in a dry mode and doesnt update releases.
+#
+# initial author: thomas.maier@evosoft.com
+#
+# -----------------------------------------------------------------------------
+import couchdb
+
+DRY_RUN = True
+
+COUCHSERVER = "http://localhost:5984/"
+DBNAME = 'sw360db'
+NAME = 'name'
+COMPONENTID = 'componentId'
+ID = "_id"
+
+couch = couchdb.Server(COUCHSERVER)
+db = couch[DBNAME]
+
+get_all_components_fun = '''function(doc){
+        if (doc.type=='component') {
+            emit(doc._id, doc)
+        }
+    }'''
+
+get_all_releases_fun = '''function(doc){
+        if (doc.type=='release') {
+            emit(doc._id, doc)
+        }
+    }'''
+
+print 'Retrieve all components'
+components = db.query(get_all_components_fun)
+print 'Retrieve all releases'
+releases = db.query(get_all_releases_fun)
+
+componentNamesById = {}
+for component in components:
+    docComponent = component.value
+    componentNamesById[component.id] = docComponent[NAME]
+
+for release in releases:
+    docRelease = release.value
+    releaseId = docRelease[ID]
+    releaseName = docRelease[NAME]
+    componentId = docRelease[COMPONENTID]
+    if componentId in componentNamesById:
+        if releaseName != componentNamesById[componentId]:
+            print (u'INFO: releaseId:%s, old name:"%s", new name: "%s"' % (
+                releaseId, releaseName, componentNamesById[componentId])).encode('utf-8')
+            if DRY_RUN:
+                print 'INFO: not saving release - DRY_RUN\n'
+            else:
+                docRelease[NAME] = componentNamesById[componentId]
+                db.save(docRelease)
+                print 'INFO: saved release\n'
+    else:
+        print 'WARN: document for componentId ' + componentId + ' not found\n'

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -28,6 +28,9 @@ To migrate it is recommended to do this in the following order:
 - `007_add_submitters_usergroup_to_moderation_request.py`
 - `008_add_component_type_to_moderation_requests.py`
 
+## Optional usage
+- `009_overwrite_release_name_with_component_name.py`
+
 ## Run the scripts for a database not running on localhost
 tbd.
 


### PR DESCRIPTION
- changed release edit view (component name is set to release name and is not editable)
- added migration script (_009_overwrite_release_name_with_component_name.py_)
(this scripts supports `DRY_RUN` option to show the different release/component names)

closes sw360/sw360portal#451