### PR TITLE
chore(datahandler): remove assertion for couchdb test (lib-datahandler)

### DIFF
--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentDownloaderTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentDownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2018. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -88,8 +88,6 @@ public class AttachmentContentDownloaderTest {
                 } catch (ExecutionException e) {
                     Throwable futureException = e.getCause();
                     assertThat(futureException, is(notNullValue()));
-                    assertThat(futureException.getMessage(),
-                            anyOf(containsString("timed out"), containsString("Das Netzwerk ist nicht erreichbar")));
                 }
             } catch (TimeoutException e) {
                 fail("downloader got stuck on a black hole");


### PR DESCRIPTION
- unfortunately this test fails because the blackhole ip (_192.0.2.0_) is not reachable in the network.
- this can happen in automated ci environments

```
FAILURE!
java.lang.AssertionError: 
Expected: (a string containing "timed out" or a string containing "Das Netzwerk ist nicht erreichbar")
     but: was "No route to host (Host unreachable)"
```